### PR TITLE
New CLI command: dump

### DIFF
--- a/lib/item.py
+++ b/lib/item.py
@@ -399,8 +399,14 @@ class Item():
     def add_logic_trigger(self, logic):
         self.__logics_to_trigger.append(logic)
 
+    def get_logic_triggers(self):
+        return self.__logics_to_trigger
+
     def add_method_trigger(self, method):
         self.__methods_to_trigger.append(method)
+
+    def get_method_triggers(self):
+        return self.__methods_to_trigger
 
     def age(self):
         delta = self._sh.now() - self.__last_change

--- a/plugins/cli/README.md
+++ b/plugins/cli/README.md
@@ -33,6 +33,7 @@ lo: list all logics and next execution time
 lt: list current thread names
 update item = value: update the specified item with the specified value
 up: alias for update
+dump item: dump details about given item
 tr logic: trigger logic
 rl logic: reload logic
 rr logic: reload and run logic

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -142,6 +142,14 @@ class CLIHandler(lib.connection.Stream):
                         for name in item.conf:
                             self.push("    {} = {}\n".format(name, item.conf[name]))
                         self.push("  }\n")
+                    self.push("  logics = [\n")
+                    for trigger in item.get_logic_triggers():
+                        self.push("    {}\n".format(trigger))
+                    self.push("  ]\n")
+                    self.push("  triggers = [\n")
+                    for trigger in item.get_method_triggers():
+                        self.push("    {}\n".format(trigger))
+                    self.push("  ]\n")
                     self.push("}\n")
         else:
             self.push("Nothing found\n")

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -133,9 +133,9 @@ class CLIHandler(lib.connection.Stream):
                     self.push("  value = {}\n".format(item()))
                     self.push("  age = {}\n".format(item.age()))
                     self.push("  last_change = {}\n".format(item.last_change()))
-                    self.push("  changed by = {}\n".format(item.changed_by()))
-                    self.push("  previous value = {}\n".format(item.prev_value()))
-                    self.push("  previous age = {}\n".format(item.prev_age()))
+                    self.push("  changed_by = {}\n".format(item.changed_by()))
+                    self.push("  previous_value = {}\n".format(item.prev_value()))
+                    self.push("  previous_age = {}\n".format(item.prev_age()))
                     self.push("  previous_change = {}\n".format(item.prev_change()))
                     if hasattr(item, 'conf'):
                         self.push("  config = {\n")

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -59,7 +59,7 @@ class CLIHandler(lib.connection.Stream):
         elif cmd.startswith('update ') or cmd.startswith('up '):
             self.update(cmd.lstrip('update').strip())
         elif cmd.startswith('dump'):
-            self.dump(cmd.lstrip('dump ').strip())
+            self.dump(cmd.lstrip('dump').strip())
         elif cmd.startswith('tr'):
             self.tr(cmd.lstrip('tr').strip())
         elif cmd.startswith('rl'):
@@ -119,8 +119,8 @@ class CLIHandler(lib.connection.Stream):
             return
         item(value, 'CLI', self.source)
 
-    def dump(self, data):
-        item = self.sh.return_item(data)
+    def dump(self, path):
+        item = self.sh.return_item(path)
         if item != None:
             self.push("Item {} ".format(item.id()))
             self.push("{\n")
@@ -209,7 +209,7 @@ class CLIHandler(lib.connection.Stream):
 
 class CLI(lib.connection.Server):
 
-    def __init__(self, smarthome, update='False', ip='127.0.0.1', port=2323):
+    def __init__(self, smarthome, update='False', ip='127.0.0.1', port=2525):
         lib.connection.Server.__init__(self, ip, port)
         self.sh = smarthome
         self.updates_allowed = smarthome.string2bool(update)

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -58,6 +58,8 @@ class CLIHandler(lib.connection.Stream):
             self.cl()
         elif cmd.startswith('update ') or cmd.startswith('up '):
             self.update(cmd.lstrip('update').strip())
+        elif cmd.startswith('dump'):
+            self.dump(cmd.lstrip('dump ').strip())
         elif cmd.startswith('tr'):
             self.tr(cmd.lstrip('tr').strip())
         elif cmd.startswith('rl'):
@@ -117,6 +119,27 @@ class CLIHandler(lib.connection.Stream):
             return
         item(value, 'CLI', self.source)
 
+    def dump(self, data):
+        item = self.sh.return_item(data)
+        if item != None:
+            self.push("Item {} ".format(item.id()))
+            self.push("{\n")
+            self.push("  type = {}\n".format(item.type()))
+            self.push("  value = {}\n".format(item()))
+            self.push("  age = {}\n".format(item.age()))
+            self.push("  last_change = {}\n".format(item.last_change()))
+            self.push("  changed by = {}\n".format(item.changed_by()))
+            self.push("  previous value = {}\n".format(item.prev_value()))
+            self.push("  previous age = {}\n".format(item.prev_age()))
+            self.push("  previous_change = {}\n".format(item.prev_change()))
+            self.push("  config = {\n")
+            for name in item.conf:
+                self.push("    {} = {}\n".format(name, item.conf[name]))
+            self.push("  }\n")
+            self.push("}\n")
+        else:
+            self.push("Nothing found\n")
+
     def tr(self, logic):
         if not self.updates_allowed:
             self.push("Logic triggering is not allowed.\n")
@@ -175,6 +198,7 @@ class CLIHandler(lib.connection.Stream):
         self.push('lt: list current thread names\n')
         self.push('update item = value: update the specified item with the specified value\n')
         self.push('up: alias for update\n')
+        self.push('dump item: dump details about given item\n')
         self.push('tr logic: trigger logic\n')
         self.push('rl logic: reload logic\n')
         self.push('rr logic: reload and run logic\n')

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -209,7 +209,7 @@ class CLIHandler(lib.connection.Stream):
 
 class CLI(lib.connection.Server):
 
-    def __init__(self, smarthome, update='False', ip='127.0.0.1', port=2525):
+    def __init__(self, smarthome, update='False', ip='127.0.0.1', port=2323):
         lib.connection.Server.__init__(self, ip, port)
         self.sh = smarthome
         self.updates_allowed = smarthome.string2bool(update)


### PR DESCRIPTION
(copied from https://github.com/mknx/smarthome/pull/138)

This will add a new CLI command named `dump` which display additional information for a given item. It could really be handy when trying to debug something (e.g. logics) to know the items current state and all information related to an item (e.g. previous value, last change, method and logic triggers,  ...).

Example output:

```
> dump env.core.memory
Item env.core.memory {
  type = num
  value = 14188544
  age = 56.113745
  last_change = 2014-11-18 21:34:38.136741+01:00
  changed by = Logic:None
  previous value = 0
  previous age = 14.555422
  previous_change = 2014-11-18 21:34:23.581319+01:00
  config = {
    sqlite = init
  }
}
>  dump light.l1
Item light.l1 {
  type = bool
  value = False
  age = 155.85737
  last_change = 2015-11-29 21:44:46.320419+01:00
  changed_by = Init:None
  previous_value = False
  previous_age = -0.002529
  previous_change = 2015-11-29 21:44:46.322948+01:00
  config = {
    visu_acl = rw
    count_light = yes
    nw = yes
  }
  logics = [
    count_status_lights
  ]
  triggers = [
    <bound method WebSocket.update_item of <plugins.visu.WebSocket object at 0x7a94f0>>
  ]
}
> 
```
