### PR TITLE
Make it possible to match on item attribute and it's value

### DIFF
--- a/bin/smarthome.py
+++ b/bin/smarthome.py
@@ -416,7 +416,7 @@ class SmartHome():
         attr, __, val = attr.partition('[')
         val = val.rstrip(']')
         if attr != '' and val != '':
-            return [self.__item_dict[item] for item in self.__items if regex.match(item) and attr in self.__item_dict[item].conf and val == self.__item_dict[item].conf[attr]]
+            return [self.__item_dict[item] for item in self.__items if regex.match(item) and attr in self.__item_dict[item].conf and ((type(self.__item_dict[item].conf[attr]) in [list,dict] and val in self.__item_dict[item].conf[attr]) or (val == self.__item_dict[item].conf[attr]))]
         elif attr != '':
             return [self.__item_dict[item] for item in self.__items if regex.match(item) and attr in self.__item_dict[item].conf]
         else:

--- a/bin/smarthome.py
+++ b/bin/smarthome.py
@@ -413,7 +413,11 @@ class SmartHome():
         regex, __, attr = regex.partition(':')
         regex = regex.replace('.', '\.').replace('*', '.*') + '$'
         regex = re.compile(regex)
-        if attr != '':
+        attr, __, val = attr.partition('[')
+        val = val.rstrip(']')
+        if attr != '' and val != '':
+            return [self.__item_dict[item] for item in self.__items if regex.match(item) and attr in self.__item_dict[item].conf and val == self.__item_dict[item].conf[attr]]
+        elif attr != '':
             return [self.__item_dict[item] for item in self.__items if regex.match(item) and attr in self.__item_dict[item].conf]
         else:
             return [self.__item_dict[item] for item in self.__items if regex.match(item)]


### PR DESCRIPTION
(copied from https://github.com/mknx/smarthome/pull/175)

The `sh.match_items()` method is already able to mach items by a given attribute names and return a list of items having the given attribute.

Usually you're using this to identify item having some characteristics. But sometimes you have the same attribute with different values configured and want to handle them differently, for example when connecting them to some logics using `watch_item` setting.

You can now do
* `sh.match_items("some.items.*:attr")` which returns items with the attribute `attr` (already working)
* `sh.match_items("some.items.*:attr[value]")` which returns items with the attribute `attr` set to value `value` (new)

The value checking supports
* simple types (e.g. str, int, ...) by checking equality (e.g. `attr = somevalue`)
* lists by checking against the list's values (e.g. `attr = first | second | third`)
* dictionary by checking against the dict's keys (e.g. `attr = { first : val1 | second : val2 }` (only works with https://github.com/mknx/smarthome/pull/88, of if attributes are set in some code directly)

Something like this is now possible
```
[somelogic]
  filename = logic.py
  watch_item = *:item_class[light]

[otherlogic]
  filename = logic.py
  watch_item = *:item_class[dimmer]
```

Further I was also thinking about tree traversal and make it possible to match items using the pattern `some.path:attr[value].children.*`. But this seems to be more complex and could need a rewrite of the matching logic. And I don't know if this is really a good idea to introduce such a complexity. On the other hand, this feature would be nice, since it makes the configuration more flexible.
