### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: python
+python:
+    - "3.4"
+install: pip install tox-travis
+script: tox

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 
 
-# README.md
-
+# SmartHomeNG
+[![Build Status on TravisCI](https://travis-ci.org/ohinckel/smarthome.svg?branch=travis-ci)](https://travis-ci.org/ohinckel/smarthome)
 [![Join the chat at https://gitter.im/smarthomeNG/smarthome](https://badges.gitter.im/smarthomeNG/smarthome.svg)](https://gitter.im/smarthomeNG/smarthome?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 This file contains basic information about the basic directories of smarthomeNG
 
 | directory | description|


### PR DESCRIPTION
With writing more and more tests (and also changing existing code) it could be helpful to have a CI environment setup to test the codebase on changes.

I just created a configuration file and linked the status image in the README file just to let you see how this can be used.

View [README.md](https://github.com/ohinckel/smarthome/blob/travis-ci/README.md) or [Travis CI](https://travis-ci.org/ohinckel/smarthome).

Maybe we should also discuss which branches we want to test by Travis CI and which we want to integrate into the README file.
