### PR TITLE
Backend Plugin: Consider PyPI may be inaccessible

### DIFF
--- a/plugins/backend/locale/de.json
+++ b/plugins/backend/locale/de.json
@@ -57,6 +57,7 @@
 	"installierte Version": "installierte Version",
 	"Neuste Version": "Neuste Version",
 	"Keine Antwort von PyPI": "Keine Antwort von PyPI",
+	"PyPI nicht erreichbar": "PyPI nicht erreichbar",
 	"Dienst": "Dienst",
 	"Status": "Status",
 	"Aktion": "Aktion",

--- a/plugins/backend/locale/en.json
+++ b/plugins/backend/locale/en.json
@@ -57,6 +57,7 @@
 	"installierte Version": "installed Version",
 	"Neuste Version": "Newest Version",
 	"Keine Antwort von PyPI": "No answer from PyPI",
+	"PyPI nicht erreichbar": "PyPI inaccessible",
 	"Dienst": "Service",
 	"Status": "Status",
 	"Aktion": "Action",

--- a/plugins/backend/locale/fr.json
+++ b/plugins/backend/locale/fr.json
@@ -59,6 +59,7 @@
 	"installierte Version": "Version installée",
 	"Neuste Version": "Dernière version",
 	"Keine Antwort von PyPI": "Pas de réponse de PyPI",
+	"PyPI nicht erreichbar": "Impossible à obtenir PyPI",
 	"Dienst": "Service",
 	"Status": "Etat",
 	"Aktion": "Action",


### PR DESCRIPTION
Productive Systems may not have internet access. (At least mine doesn't) In this case checking for
current versions of python packages takes a very long time. In my case every
checked package fails after two minutes. So page "System Info" seems to be inaccessible because it has tremendous load times.

This change checks accessibility of PyPI by trying to enable a socket connection
with a 5 second timeout. If no connection can be made within this time, reading
current versions of python packages will not happen. Instead a message is being shown that PyPI is inaccessible.

Someone may have a look on the french translation of the message. I do not speak french, so I had Google translate the message ...