### PR TITLE
Backend Plugin: Timeout for PyPI access check configurable

### DIFF
--- a/plugins/backend/README.md
+++ b/plugins/backend/README.md
@@ -58,6 +58,7 @@ To support visualization, the visu_websocket plugin has to be used. It has to be
 	#password = very_secure_password
 	#language = en
 	#developer_mode = on
+	#pypi_timeout = 5
 </pre>
 
 ### ip
@@ -87,3 +88,6 @@ You can specify a language to use for the plugin. Besides the standard language 
 
 ### developer_mode (optional)
 You may specify develper_mode = on, if you are developiing within the backend plugin. At the moment, the only thing that changes is an additional button **``relaod translation``** on the services page
+
+### pypi_timeout (optional)
+Timeout for PyPI accessibility check (seconds). PyPI is queried on page "Systeminfo" to compare installed python module versions with current versions if accessible. If you receive the message "PyPI inaccessible" on systems with internet access you may increase the value. On systems where PyPI can not be reached (no/restricted internet access) you may set the timeout to 0 which disables the PyPI queries.

--- a/plugins/backend/__init__.py
+++ b/plugins/backend/__init__.py
@@ -57,7 +57,7 @@ class BackendServer(SmartPlugin):
         s.connect(("10.10.10.10", 80))
         return s.getsockname()[0]
 
-    def __init__(self, sh, port=None, threads=8, ip='', updates_allowed='True', user="admin", password="", language="", developer_mode="no"):
+    def __init__(self, sh, port=None, threads=8, ip='', updates_allowed='True', user="admin", password="", language="", developer_mode="no", pypi_timeout=5):
         self.logger = logging.getLogger(__name__)
         self._user = user
         self._password = password
@@ -96,6 +96,13 @@ class BackendServer(SmartPlugin):
 
         self.updates_allowed = self.my_to_bool(updates_allowed, 'updates_allowed', True)
 
+        if self.is_int(pypi_timeout):
+            self.pypi_timeout = int(pypi_timeout)
+        else:
+            self.pypi_timeout = 5
+            if pypi_timeout is not None:
+                self.logger.error("BackendServer: Invalid value '" + str(pypi_timeout) + "' configured for attribute 'pypi_timeout' in plugin.conf, using '" + str(self.pypi_timeout) + "' instead")
+
         current_dir = os.path.dirname(os.path.abspath(__file__))
         self.logger.debug("BackendServer running from '{}'".format(current_dir))
 
@@ -123,7 +130,7 @@ class BackendServer(SmartPlugin):
         }
         self._cherrypy = cherrypy
         self._cherrypy.config.update(config)
-        self._cherrypy.tree.mount(Backend(self, self.updates_allowed, language, self.developer_mode), '/', config = config)
+        self._cherrypy.tree.mount(Backend(self, self.updates_allowed, language, self.developer_mode, self.pypi_timeout), '/', config = config)
 
     def run(self):
         self.logger.debug("BackendServer: rest run")
@@ -236,13 +243,14 @@ class Backend:
     env.globals['is_userlogic'] = is_userlogic
     env.globals['_'] = translate
     
-    def __init__(self, backendserver=None, updates_allowed=True, language='', developer_mode=False):
+    def __init__(self, backendserver=None, updates_allowed=True, language='', developer_mode=False, pypi_timeout = 5):
         self.logger = logging.getLogger(__name__)
         self._bs = backendserver
         self._sh = backendserver._sh
         self.language = language
         self.updates_allowed = updates_allowed
         self.developer_mode = developer_mode
+        self.pypi_timeout = pypi_timeout
 
         self._sh_dir = self._sh.base_dir
         self.visu_plugin = None
@@ -357,15 +365,20 @@ class Backend:
         self.find_visu_plugin()
         
         # check if pypi service is reachable
-        pypi_available = True
-        try:
-            import socket
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(5)
-            sock.connect(('pypi.python.org',443))
-            sock.close()
-        except:
+        if self.pypi_timeout <= 0:
             pypi_available = False
+            pypi_unavailable_message = translate('PyPI Prüfung deaktiviert')
+        else:
+            pypi_available = True
+            try:
+                import socket
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(self.pypi_timeout)
+                sock.connect(('pypi.python.org',443))
+                sock.close()
+            except:
+                pypi_available = False
+                pypi_unavailable_message = translate('PyPI nicht erreichbar')
         
         import pip
         import xmlrpc
@@ -386,7 +399,7 @@ class Backend:
                 except:
                     package['version_available'] = [translate('Keine Antwort von PyPI')]
             else:
-                package['version_available'] = translate('PyPI nicht erreichbar')
+                package['version_available'] = pypi_unavailable_message
             packages.append(package)
 
         sorted_packages = sorted([(i['key'], i['version_installed'], i['version_available']) for i in packages])

--- a/plugins/backend/locale/de.json
+++ b/plugins/backend/locale/de.json
@@ -58,6 +58,7 @@
 	"Neuste Version": "Neuste Version",
 	"Keine Antwort von PyPI": "Keine Antwort von PyPI",
 	"PyPI nicht erreichbar": "PyPI nicht erreichbar",
+	"PyPI Prüfung deaktiviert": "PyPI Prüfung deaktiviert",
 	"Dienst": "Dienst",
 	"Status": "Status",
 	"Aktion": "Aktion",

--- a/plugins/backend/locale/en.json
+++ b/plugins/backend/locale/en.json
@@ -58,6 +58,7 @@
 	"Neuste Version": "Newest Version",
 	"Keine Antwort von PyPI": "No answer from PyPI",
 	"PyPI nicht erreichbar": "PyPI inaccessible",
+	"PyPI Prüfung deaktiviert": "PyPI check disabled",
 	"Dienst": "Service",
 	"Status": "Status",
 	"Aktion": "Action",

--- a/plugins/backend/locale/fr.json
+++ b/plugins/backend/locale/fr.json
@@ -60,6 +60,7 @@
 	"Neuste Version": "Dernière version",
 	"Keine Antwort von PyPI": "Pas de réponse de PyPI",
 	"PyPI nicht erreichbar": "PyPI non accessible",
+	"PyPI Prüfung deaktiviert": "Check PyPI désactivé",
 	"Dienst": "Service",
 	"Status": "Etat",
 	"Aktion": "Action",


### PR DESCRIPTION
As discussed in #99:
The timeout for checking if a connection to PyPI can be established is now configurable in the plugin configuration via parameter "pypi_timeout".
Default value is 5 seconds. If the value is set to 0, the PyPI check will be disabled.

Documentation has been adapted accordingly