### PR TITLE
Fix issue #82 - lock buffer while running dump/maintain

### DIFF
--- a/plugins/sqlite/__init__.py
+++ b/plugins/sqlite/__init__.py
@@ -166,7 +166,11 @@ class SQL(SmartPlugin):
             self._fdb_lock.release()
             
     def _dump(self):
-        for item in self._buffer:
+        if not self._fdb_lock.acquire(timeout=2):
+            return
+        items = list(self._buffer.keys())
+        self._fdb_lock.release()
+        for item in items:
             self._buffer_lock.acquire()
             tuples = self._buffer[item]
             self._buffer[item] = []

--- a/plugins/sqlite_visu2_8/__init__.py
+++ b/plugins/sqlite_visu2_8/__init__.py
@@ -282,7 +282,11 @@ class SQL(SmartPlugin):
             self._fdb_lock.release()
 
     def _maintain(self):
-        for item in self._buffer:
+        if not self._fdb_lock.acquire(timeout=2):
+            return
+        items = list(self._buffer.keys())
+        self._fdb_lock.release()
+        for item in items:
             if self._buffer[item] != []:
                 self._insert(item)
         self._pack()


### PR DESCRIPTION
Due to a missing lock in the `dump()` and `maintain()` method it could happen that the internal item buffer changes while running the dump or maintenance and stops with error:
`RuntimeError: dictionary changed size during iteration`.

This fix will add the lock and avoid this error - still untested but should be working since it is a minimal patch. Please test!
