### PR TITLE
systemair: use modbus serial port with threading.Lock()

### DIFF
--- a/plugins/systemair/__init__.py
+++ b/plugins/systemair/__init__.py
@@ -43,6 +43,7 @@ class Systemair():
         self.mod_write_repeat = 20  # if port is already open, e.g on auto-update,
                                     # repeat mod_write attempt x times a 1 seconds
         self._lockmb = threading.Lock()    # modbus serial port lock
+        self.init_serial_connection(self.serialport, self.slave_address)
 
     def init_serial_connection(self, serialport, slave_address):
         try:
@@ -60,7 +61,6 @@ class Systemair():
             # check for working /dev/ttyXXX
             if not self.init_serial_connection(self.serialport, self.slave_address):
                 return
-
             # read all fan registers
             # System air documentation: FAN values starts with 101, but thats incorrect: register starts with 100
 

--- a/plugins/systemair/__init__.py
+++ b/plugins/systemair/__init__.py
@@ -23,6 +23,7 @@ from time import sleep
 import minimalmodbus
 from serial import SerialException
 import serial
+import threading
 
 logger = logging.getLogger('Systemair')
 
@@ -41,6 +42,7 @@ class Systemair():
         self.my_reg_items = []
         self.mod_write_repeat = 20  # if port is already open, e.g on auto-update,
                                     # repeat mod_write attempt x times a 1 seconds
+        self._lockmb = threading.Lock()    # modbus serial port lock
 
     def init_serial_connection(self, serialport, slave_address):
         try:
@@ -53,6 +55,7 @@ class Systemair():
             return False
 
     def _read_modbus(self):
+        self._lockmb.acquire()
         try:
             # check for working /dev/ttyXXX
             if not self.init_serial_connection(self.serialport, self.slave_address):
@@ -241,6 +244,8 @@ class Systemair():
         except Exception as err:
             logger.error(err)
             self.instrument = None
+        finally:
+            self._lockmb.release()
 
     def run(self):
         self.alive = True
@@ -272,7 +277,7 @@ class Systemair():
                     self._update[modbus_regaddr]['items'].append(item)
             # we need a small list here to make it easier to find our items if update_item is triggered
             self.my_reg_items.append(item) 
-            
+
         if 'systemair_coiladdr' in item.conf:
             modbus_coiladdr = int(item.conf['systemair_coiladdr'])
             logger.debug("systemair_value_from_bus: {0} connected to coil register {1:#04x}".format(item, modbus_coiladdr))
@@ -292,7 +297,8 @@ class Systemair():
             # BUG in Systemair docu, register starts with 100, not 101
             reg_addr = int(item.conf['systemair_regaddr']) - 1
             val = int(item())
-            self.instrument.write_register(reg_addr, value=val)
+            with self._lockmb:
+                self.instrument.write_register(reg_addr, value=val)
         except serial.serialutil.SerialException as err:
             if err.args[0].lower() == 'port is already open.':
                 if self.mod_write_repeat < repeat_count:


### PR DESCRIPTION
Hi,
I'm using systemair plugin with VTR200/B and it works well, but I think that using serial port without any protection isn't very elegant, even with resends handled. To solve this, I added threading.Lock() to this plugin. In my case this change eliminates resend warnings and "Port is already open." errors.
Since this is my first contribution, I hope for feedback, especially from @pfischi :)

4d4mu
