### PR TITLE
systemair: fix bug with unsigned temperatures

### DIFF
--- a/plugins/systemair/README.md
+++ b/plugins/systemair/README.md
@@ -119,37 +119,31 @@ is a writeable register.
         # read
         type = num
         systemair_regaddr = 208
-        eval = value / 10 #to get Celsius
         
     [[Temperatursensor_1]]
         # read
         type = num
         systemair_regaddr = 214
-        eval = value / 10 #to get Celsius
 
     [[Temperatursensor_2]]
         # read
         type = num
         systemair_regaddr = 215
-        eval = value / 10 #to get Celsius
 
     [[Temperatursensor_3]]
         # read
         type = num
         systemair_regaddr = 216
-        eval = value / 10 #to get Celsius
 
     [[Temperatursensor_4]]
         # read
         type = num
         systemair_regaddr = 217
-        eval = value / 10 #to get Celsius
 
     [[Temperatursensor_5]]
         # read
         type = num
         systemair_regaddr = 218
-        eval = value / 10 #to get Celsius
 
     [[Wochenprogramm_Aktiv]]
         # read

--- a/plugins/systemair/__init__.py
+++ b/plugins/systemair/__init__.py
@@ -27,14 +27,13 @@ import threading
 from ctypes import c_short
 from lib.model.smartplugin import SmartPlugin
 
-logger = logging.getLogger('Systemair')
-
 class Systemair(SmartPlugin):
     PLUGIN_VERSION = "1.3.0.1"
     ALLOW_MULTIINSTANCE = False
 
     def __init__(self, smarthome, serialport, slave_address="1", update_cycle="30"):
         self._sh = smarthome
+        self.logger = logging.getLogger(__name__)
         self.instrument = None
         self.slave_address = int(slave_address)
         self._update_coil = {}
@@ -71,7 +70,7 @@ class Systemair(SmartPlugin):
             return True
         except:
             self.instrument = None
-            logger.error("Failed to initialize modbus on {serialport}".format(serialport=serialport))
+            self.logger.error("Failed to initialize modbus on {serialport}".format(serialport=serialport))
             return False
 
     def _read_modbus(self):
@@ -97,7 +96,7 @@ class Systemair(SmartPlugin):
                             try:
                                 item(read_regs[reg], 'systemair_value_from_bus', "Reg {}".format(reg))
                             except Exception as e:
-                                logger.error("Modbus: Exception when updating {} {}".format(item, e))
+                                self.logger.error("Modbus: Exception when updating {} {}".format(item, e))
 
             # get coils
             for coil_addr in self._update_coil:
@@ -107,7 +106,7 @@ class Systemair(SmartPlugin):
                         item(value, 'systemair_value_from_bus', "Coil {}".format(coil_addr))
 
         except Exception as err:
-            logger.error(err)
+            self.logger.error(err)
             self.instrument = None
         finally:
             self._lockmb.release()
@@ -120,7 +119,7 @@ class Systemair(SmartPlugin):
         self.alive = False
 
     def connect(self):
-        logger.debug("systemair_value_from_bus: connect")
+        self.logger.debug("systemair_value_from_bus: connect")
 
     def update_item(self, item, caller=None, source=None, dest=None):
         # ignore values from bus
@@ -134,7 +133,7 @@ class Systemair(SmartPlugin):
     def parse_item(self, item):
         if self.has_iattr(item.conf, 'systemair_regaddr'):
             modbus_regaddr = int(self.get_iattr_value(item.conf, 'systemair_regaddr'))
-            logger.debug("systemair_value_from_bus: {0} connected to register {1:#04x}".format(item, modbus_regaddr))
+            self.logger.debug("systemair_value_from_bus: {0} connected to register {1:#04x}".format(item, modbus_regaddr))
             self.my_reg_items.append(item)
             for reg_set in self._reg_sets:
                 if modbus_regaddr in reg_set['range']:
@@ -149,13 +148,13 @@ class Systemair(SmartPlugin):
                         reg_set['range_used'] = range(min(reg_set['range_used'].start, modbus_regaddr), max(reg_set['range_used'].stop, modbus_regaddr + 1))
                     else:
                         reg_set['range_used'] = range(modbus_regaddr, modbus_regaddr + 1)
-                    logger.debug("systemair: adding reg {} to reg_set {} {}".format(modbus_regaddr, reg_set['name'], reg_set['range_used']))
-                    logger.debug("systemair: regs used: {}".format(reg_set['regs_used']))
+                    self.logger.debug("systemair: adding reg {} to reg_set {} {}".format(modbus_regaddr, reg_set['name'], reg_set['range_used']))
+                    self.logger.debug("systemair: regs used: {}".format(reg_set['regs_used']))
                     break
 
         if self.has_iattr(item.conf, 'systemair_coiladdr'):
             modbus_coiladdr = int(self.get_iattr_value(item.conf, 'systemair_coiladdr'))
-            logger.debug("systemair_value_from_bus: {0} connected to coil register {1:#04x}".format(item, modbus_coiladdr))
+            self.logger.debug("systemair_value_from_bus: {0} connected to coil register {1:#04x}".format(item, modbus_coiladdr))
             if not modbus_coiladdr in self._update_coil:
                 self._update_coil[modbus_coiladdr] = set()
 
@@ -165,9 +164,9 @@ class Systemair(SmartPlugin):
 
     def _write_register_value(self, item, repeat_count=0):
         try:
-            logger.debug('writing register value')
+            self.logger.debug('writing register value')
             if not self.has_iattr(item.conf, 'systemair_regaddr'):
-                logger.error('Could not write to modbus. Register address missing!')
+                self.logger.error('Could not write to modbus. Register address missing!')
                 return
             # BUG in Systemair docu, register starts with 100, not 101
             reg_addr = int(self.get_iattr_value(item.conf, 'systemair_regaddr')) - 1
@@ -177,14 +176,14 @@ class Systemair(SmartPlugin):
         except serial.serialutil.SerialException as err:
             if err.args[0].lower() == 'port is already open.':
                 if self.mod_write_repeat < repeat_count:
-                    logger.error("Could not write register value to systemair modbus. Maximal retries reached.")
+                    self.logger.error("Could not write register value to systemair modbus. Maximal retries reached.")
                     return
                 repeat_count += 1
-                logger.warning('Could not write register value to systemair modbus. Port is already open.')
-                logger.warning('Repeat {rep} of {max}.'.format(rep=repeat_count, max=self.mod_write_repeat))
+                self.logger.warning('Could not write register value to systemair modbus. Port is already open.')
+                self.logger.warning('Repeat {rep} of {max}.'.format(rep=repeat_count, max=self.mod_write_repeat))
                 sleep(1)
                 self._write_register_value(item, repeat_count)
             pass
         except Exception as err:
-            logger.error('Could not write register value to modbus. Error: {err}!'.format(err=err))
+            self.logger.error('Could not write register value to modbus. Error: {err}!'.format(err=err))
             self.instrument = None

--- a/plugins/systemair/__init__.py
+++ b/plugins/systemair/__init__.py
@@ -45,7 +45,7 @@ class Systemair():
                                     # repeat mod_write attempt x times a 1 seconds
         self._lockmb = threading.Lock()    # modbus serial port lock
         self.init_serial_connection(self.serialport, self.slave_address)
-        self._temperature_scaled_regs = range(209, 218+1)
+        self._temperature_scaled_regs = range(208, 218+1)
 
     def init_serial_connection(self, serialport, slave_address):
         try:

--- a/plugins/systemair/__init__.py
+++ b/plugins/systemair/__init__.py
@@ -24,6 +24,7 @@ import minimalmodbus
 from serial import SerialException
 import serial
 import threading
+from ctypes import c_short
 
 logger = logging.getLogger('Systemair')
 
@@ -84,7 +85,7 @@ class Systemair():
                 if start_register_heater in self._update:
                     for item in self._update[start_register_heater]['items']:
                         try:
-                            item(register, 'systemair_value_from_bus', "Reg {}".format(start_register_heater))
+                            item(c_short(register).value, 'systemair_value_from_bus', "Reg {}".format(start_register_heater))
                         except Exception as e:
                             logger.error("Modbus: Exception when updating {} {}".format(item, e))
                 start_register_heater += 1

--- a/plugins/systemair/systemair.conf
+++ b/plugins/systemair/systemair.conf
@@ -294,67 +294,56 @@
         # read
         type = num
         systemair_regaddr = 208
-        eval = value / 10 #to get Celsius
 
     [[Temperaturlevel1_Heizregister]]
         # read
         type = num
         systemair_regaddr = 209
-        eval = value / 10 #to get Celsius
 
     [[Temperaturlevel2_Heizregister]]
         # read
         type = num
         systemair_regaddr = 210
-        eval = value / 10 #to get Celsius
 
     [[Temperaturlevel3_Heizregister]]
         # read
         type = num
         systemair_regaddr = 211
-        eval = value / 10 #to get Celsius
 
     [[Temperaturlevel4_Heizregister]]
         # read
         type = num
         systemair_regaddr = 212
-        eval = value / 10 #to get Celsius
 
     [[Temperaturlevel5_Heizregister]]
         # read
         type = num
         systemair_regaddr = 213
-        eval = value / 10 #to get Celsius
 
     [[Temperatursensor_1]]
         # read
         type = num
         systemair_regaddr = 214
-        eval = value / 10 #to get Celsius
 
     [[Temperatursensor_2]]
         # read
         type = num
         systemair_regaddr = 215
-        eval = value / 10 #to get Celsius
 
     [[Temperatursensor_3]]
         # read
         type = num
         systemair_regaddr = 216
-        eval = value / 10 #to get Celsius
 
     [[Temperatursensor_4]]
         # read
         type = num
         systemair_regaddr = 217
-        eval = value / 10 #to get Celsius
 
     [[Temperatursensor_5]]
         # read
         type = num
         systemair_regaddr = 218
-        eval = value / 10 #to get Celsius
 
     [[Status_Temperatursensor_Input1]]
         # read

--- a/requirements/plugins.systemair.txt
+++ b/requirements/plugins.systemair.txt
@@ -1,0 +1,2 @@
+minimalmodbus>=0.7
+pyserial>=3.0.1


### PR DESCRIPTION
Hi,
My vent told me, that last night temperature was over +6500*C!
There's a bug in systemair plugin - all values are parsed as unsigned. Minimalmodbus has optional argument for signed/unsigned, but only for reading one reg, not group. Since group read is faster, i decided to convert temperatures with ctypes. According to systemair modbus manual, only heater regs contain temperatures and rest of heater regs doesn't exceed value 32767, so I applied fix to all heater regs (for simplicity).