### PR TITLE
Drexel und Weiss Plugin updated, made smart, added examples

### DIFF
--- a/plugins/drexelundweiss/DrexelWeiss.conf
+++ b/plugins/drexelundweiss/DrexelWeiss.conf
@@ -1,0 +1,447 @@
+[WP]
+    type = foo
+	[[Status]]
+		type = foo
+		[[[Kuehlung]]]
+			visu_acl = r
+			type = bool
+			cache = true
+			DuW_WP_register = 1142
+
+
+		[[[Heizung]]]
+			visu_acl = r
+			type = bool
+			cache = true
+			DuW_WP_register = 1328
+
+
+		[[[Warmwasser]]]
+			visu_acl = r
+			type = bool
+			cache = true
+			DuW_WP_register = 1036
+
+
+		[[[Aktiv]]]
+			visu_acl = r
+			type = bool
+			cache = true
+			DuW_WP_register = 1044
+
+			
+		[[[Modus]]]
+			visu_acl = r
+			type = num
+			cache = true
+			DuW_WP_register = 1314
+
+		
+		[[[Temperatur]]]
+			type = foo
+			[[[[Aussen]]]]
+				name = Temperatur aussen
+				visu_acl = r
+				type = num
+	
+				DuW_WP_register = 202
+
+			[[[[Raum]]]]
+				name = Temperatur innen
+				visu_acl = r
+				type = num
+	
+				DuW_WP_register = 200
+				
+			[[[[Boiler]]]]
+				name = Temperatur Boiler
+				visu_acl = r
+				type = num
+	
+				DuW_WP_register = 214
+
+			[[[[Boileroben]]]]
+				visu_acl = r
+				type = num
+				name = Temperatur Boiler oben
+	
+				DuW_WP_register = 212
+
+	[[Einstellung]]
+		type = foo
+		[[[Raumsoll]]]
+			name = Temperatur Soll
+			visu_acl = rw
+			type = num
+			cache = true
+
+			DuW_WP_register = 5016
+
+		[[[Kuehlung_Schwellwert]]]
+			visu_acl = rw
+			type = num
+			cache = true
+			DuW_WP_register = 5186
+
+		[[[Heizungplus]]]
+			visu_acl = rw
+			type = bool
+			cache = true
+			DuW_WP_register = 5492
+
+    [[Energieverbrauch]]
+        type = foo
+        [[[Heizung]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 4502
+
+
+        [[[Warmwasser]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 4504
+
+
+        [[[Kompressor]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 4500
+
+
+        [[[Lufterwaermung]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 4506
+
+
+    [[Leistung]]
+        type = foo
+        [[[Heizung]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 4002
+
+
+        [[[Warmwasser]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 4004
+
+
+        [[[Kompressor]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 4000
+
+
+        [[[Lufterwaermung]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 4006
+
+
+    [[Betriebsstunden]]
+        type = foo
+        [[[Gesamt]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 924
+
+
+        [[[Boiler]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 948
+
+
+        [[[Heizung]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 950
+
+
+		[[[Heizstufe1]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 912
+
+
+        [[[Heizstufe2]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 914
+
+
+        [[[Kuehlung]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 952
+
+
+        [[[Kompressor]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_WP_register = 910
+
+
+
+    [[Stoerung]]
+        type = foo
+        [[[Boilerfuehler]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_WP_register = 830
+
+        [[[Boilertemperatur]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_WP_register = 810
+
+        [[[Heizkreis_Durchfluss]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_WP_register = 848
+
+        [[[Heizkreis_Temperatur]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_WP_register = 850
+
+        [[[Solekreis_Durchfluss]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_WP_register = 846
+
+        [[[Solekreis_Temperatur]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_WP_register = 812
+
+        [[[WP_Hochdruck]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_WP_register = 818
+
+        [[[WP_Niederdruck]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_WP_register = 820
+
+
+[LU]
+type = foo
+    [[Betriebsart]]
+        name = Betriebsart
+        visu_acl = rw
+        type = num
+        cache = true
+        database@nas = yes
+        DuW_LU_register = 5002
+
+    [[Einstellung]]
+        type = foo				
+
+		 [[[CO2_Stufe0]]]
+			name = CO2 0
+			visu_acl = rw
+			type = num
+			DuW_LU_register = 5274
+
+		 [[[CO2_Stufe1]]]
+			name = CO2 1
+			visu_acl = rw
+			type = num
+			DuW_LU_register = 5276
+
+		 [[[CO2_Stufe2]]]
+			name = CO2 2
+			visu_acl = rw
+			type = num
+			DuW_LU_register = 5278
+
+		 [[[CO2_Stufe3]]]
+			name = CO2 3
+			visu_acl = rw
+			type = num
+			DuW_LU_register = 5280
+
+     [[Status]]
+        type = foo
+          [[[Feinstaubfilter]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_LU_register = 7004
+            database@nas = yes
+
+          [[[Grobstaubfilter]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_LU_register = 7002
+            database@nas = yes
+
+		 [[[CO2_Wert]]]
+			visu_acl = r
+			type = num
+			DuW_LU_register = 230
+
+			
+		[[[Luefterstufe]]]
+			name = Stufe
+			visu_acl = r
+			type = num
+			DuW_LU_register = 1066
+
+
+			
+    [[Betriebsstunden]]
+        type = foo
+          [[[Abluftventilator]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_LU_register = 902
+
+
+          [[[Feinstaubfilter]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_LU_register = 928
+
+
+          [[[Grobstaubfilter]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_LU_register = 926
+
+
+          [[[Luefterstufe0]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_LU_register = 962
+
+
+          [[[Luefterstufe1]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_LU_register = 904
+
+
+          [[[Luefterstufe2]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_LU_register = 906
+
+
+          [[[Luefterstufe3]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_LU_register = 908
+
+
+          [[[Zuluftventilator]]]
+            visu_acl = r
+            type = num
+            cache = true
+            DuW_LU_register = 900
+
+
+    [[Stoerung]]
+        type = foo
+        [[[Abluftventilator]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 826
+
+        [[[CO2]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 832
+
+        [[[Heizkreisdurchfluss]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 848
+
+        [[[Druckverlust_Abluft]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 854
+
+        [[[Druckverlust_Zuluft]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 852
+
+        [[[Temp_aussen]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 806
+
+        [[[Temp_Vorlauf]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 850
+
+        [[[Temp_Raum]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 804
+
+        [[[Temp_Sole]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 812
+
+        [[[Temp_Sole_aussen]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 7504
+
+        [[[Zuluftventilator]]]
+            visu_acl = r
+            type = bool
+            cache = true
+            DuW_LU_register = 824
+

--- a/plugins/drexelundweiss/README.md
+++ b/plugins/drexelundweiss/README.md
@@ -2,26 +2,39 @@
 
 This plugin uses the D&W USB service interface for connection, so you don't need the additional modbusadapter. Be careful not to configure wrong parameters, otherwise the function of your device may be damaged. The D&W warranty is not including this case of damage!
 
+Changelog
+============
+
+1.3.0:
+* Ignore wrong device info and use backup device id (set correct number for your DuW device from list below)
+* Retry reading lines to prevent wrong data (set value in conf file)
+* Catch division by zero errors
+* expanded config file for x2 plus. See http://filter.drexel-weiss.at/HP/Upload/Dateien/900.6667_00_TI_Modbus_Parameter_V4.01_DE.pdf for further parameters
+* Plugin is smart so you can use seperate logging level in logging.yaml
+* Fixed some code
+* Added example config file in plugins folder
+
+
 Supported Devices
 ============
 
 The plugin detects the connected device type automatically:
 
-   * aerosilent bianco
-   * aerosilent business
-   * aerosilent centro
-   * aerosilent micro
-   * aerosilent primus
-   * aerosilent stratos
-   * aerosilent topo
-   * aerosmart l
-   * aerosmart m
-   * aerosmart s
-   * aerosmart mono
-   * aerosmart xls
-   * termosmart sc
-   * X²
-   * X² Plus
+   * aerosilent bianco: 13
+   * aerosilent business: 15
+   * aerosilent centro: 8
+   * aerosilent micro: 3
+   * aerosilent primus: 1
+   * aerosilent stratos: 17
+   * aerosilent topo: 2
+   * aerosmart l: 6
+   * aerosmart m: 5
+   * aerosmart s: 4
+   * aerosmart mono: 11
+   * aerosmart xls: 7
+   * termosmart sc: 9
+   * XÂ²: 10
+   * XÂ² Plus: 14
 
 
 Configuration
@@ -37,6 +50,8 @@ plugin.conf
 #   Busmonitor = 1
 #   LU_ID = 130
 #   WP_ID = 140
+#   device = 14 # x2 plus as standard device
+#   retrylimit = 100 # number of retries to get answer right
 </pre>
 
 You have to adapt the tty to your local environment and change LU_ID and WP_ID if not D&W default is used.
@@ -64,6 +79,7 @@ Values are calculated automatically regarding the register depending divisor and
         sv_widget = {{ basic.slider('item', 'item', 0, 5, 1) }}
 </pre>
 
+Find a full conf file example in plugin folder
 
 Functions
 =========

--- a/plugins/drexelundweiss/x2_plus.txt
+++ b/plugins/drexelundweiss/x2_plus.txt
@@ -173,7 +173,7 @@
 5168;Pelletofen vorhanden?;0;1;1;0;R;LU
 5282;Pelletofen: Anlaufverzoegerung;1;60;1;0;R;LU
 5284;Pelletofen: Mindestlaufzeit;1;60;1;0;R;LU
-200;Raum;-28000;100000;100;1;R/W;LU
+200;Raumtemperatur;-28000;100000;100;1;R/W;LU
 5016;Raum-Soll;14000;26000;100;1;R/W;LU
 5338;Raumtemperatur: Beschattung;20000;26000;100;1;R/W;LU
 252;Relaiskontakt: EXT;0;1;1;0;R;LU
@@ -400,7 +400,7 @@
 5178;Solaranlage: Einschaltschwelle Solarpumpe;6000;12000;1000;0;R/W;WP
 5176;Solaranlage: Maximale Ladetemperatur;50000;80000;1000;0;R/W;WP
 5306;Solare Raumheizung vorhanden?;0;1;1;0;R;WP
-216;Sole;-28000;100000;100;1;R;WP
+216;Temperatur Sole;-28000;100000;100;1;R;WP
 5496;Sollwert-Erhoehung Funktion HEIZUNG+;300;2000;100;1;R/W;WP
 1314;Status Waermepumpe;0;12;1;0;R;WP
 1316;Status Waermepumpe Restzeit;0;3600;1;0;R;WP
@@ -437,3 +437,15 @@
 1044;Waermepumpe;0;1;1;0;R;WP
 5494;Zeitspanne Funktion HEIZUNG+;180;14400;60;0;R/W;WP
 5436;Zentralgeraet Adresse;100;999999;1;0;R;WP
+4500;Energieverbrauch: Kompressor;0;2000000000;10;2;R;WP
+4502;Energieverbrauch: Heizung;0;2000000000;10;2;R;WP
+4504;Energieverbrauch: Warmwasser;0;2000000000;10;2;R;WP
+4506;Energieverbrauch: Luft;0;2000000000;10;2;R;WP
+4000;Leistung: Kompressor;0;2000000000;100;1;R;WP
+4002;Leistung: Heizung;0;2000000000;100;1;R;WP
+4004;Leistung: Warmwasser;0;2000000000;100;1;R;WP
+4006;Leistung: Luft;0;2000000000;100;1;R;WP
+1184;Drehzahl Zuluft;0;3500;1;0;R;LU
+1186;Drehzahl Abluft;0;3500;1;0;R;LU
+1082;Soll-Volumen Zuluft;0;350;1;0;R;LU
+1084;Soll-Volumen Abluft;0;350;1;0;R;LU


### PR DESCRIPTION
Changed some additional code to make plugin smart (really this time) and added some more help and an example conf.
Complete changelog compared to original plugin from Bernator:
* Ignore wrong device info and use backup device id (set correct number for your DuW device from list below)
* Retry reading lines to prevent wrong data (set value in conf file)
* Catch division by zero errors
* expanded config file for x2 plus. See http://filter.drexel-weiss.at/HP/Upload/Dateien/900.6667_00_TI_Modbus_Parameter_V4.01_DE.pdf for further parameters
* Plugin is smart so you can use seperate logging level in logging.yaml
* Fixed some code
* Added example config file in plugins folder
