### PR TITLE
Common mock objecsts for tests

### DIFF
--- a/lib/model/smartplugin.py
+++ b/lib/model/smartplugin.py
@@ -71,27 +71,34 @@ class SmartPlugin(SmartObject, Utils):
         else:
            return "%s@%s"%(attr, self.__instance)
 
+    def __get_iattr_conf(self, conf, attr):
+        """
+            returns item attribute name including instance if required and found
+            in conf
+
+            :rtype: str
+        """
+        __attr = self.__get_iattr(attr)
+        if __attr in conf:
+            return __attr
+        elif "%s@*"%attr in conf:
+            return "%s@*"%attr
+        return None
+
     def has_iattr(self, conf, attr):
         """
             checks item conf for an attribute
             :rtype: Boolean 
         """
-        if self.__get_iattr(attr) in conf or "%s@*"%attr in conf:
-            return True
-        return False
+        __attr = self.__get_iattr_conf(conf, attr)
+        return __attr is not None
     
     def get_iattr_value(self, conf, attr):
         """
             returns value for an attribute from item config
         """
-        __value = None
-        __attr = self.__get_iattr(attr)
-        if __attr in conf:
-            __value = conf[__attr] 
-        elif "%s@*"%attr in conf:
-            __value = conf["%s@*"%attr]
-        return __value
-
+        __attr = self.__get_iattr_conf(conf, attr)
+        return None if __attr is None else conf[__attr]
     
     def __new__(cls, *args, **kargs):
         if not hasattr(cls,'PLUGIN_VERSION'):

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,4 +9,3 @@ pydocstyle>=1.0.0
 virtualenv<14.0.0;python_version=='3.2'
 coverage<4.0.0;python_version=='3.2'
 beautifulsoup4>=4.1.0
-pyserial>=3.0.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,3 +9,4 @@ pydocstyle>=1.0.0
 virtualenv<14.0.0;python_version=='3.2'
 coverage<4.0.0;python_version=='3.2'
 beautifulsoup4>=4.1.0
+pyserial>=3.0.1

--- a/tests/mock/core.py
+++ b/tests/mock/core.py
@@ -1,6 +1,7 @@
 
 import datetime
 
+import lib.plugin
 import lib.connection
 
 from lib.model.smartplugin import SmartPlugin

--- a/tests/mock/core.py
+++ b/tests/mock/core.py
@@ -1,0 +1,83 @@
+
+import datetime
+
+import lib.connection
+
+from lib.model.smartplugin import SmartPlugin
+
+class MockScheduler():
+
+    def add(self, name, obj, prio=3, cron=None, cycle=None, value=None, offset=None, next=None):
+        print(name)
+        if isinstance(obj.__self__, SmartPlugin):
+            name = name +'_'+ obj.__self__.get_instance_name()
+        print(name)
+        print( obj)
+        print(obj.__self__.get_instance_name())
+
+
+class MockSmartHome():
+
+    def __init__(self):
+        self.__logs = {}
+        self.__item_dict = {}
+        self.__items = []
+        self.children = []
+        self._plugins = []
+        self.scheduler = MockScheduler()
+        self.connections = lib.connection.Connections()
+
+    def with_plugins_from(self, conf):
+        lib.plugin.Plugins._plugins = []
+        lib.plugin.Plugins._threads = []
+        self._plugins = lib.plugin.Plugins(self, conf)
+        return self._plugins
+
+    def with_items_from(self, conf):
+        item_conf = lib.config.parse(conf, None)
+        for attr, value in item_conf.items():
+            if isinstance(value, dict):
+                child_path = attr
+                try:
+                    child = lib.item.Item(self, self, child_path, value)
+                except Exception as e:
+                    print("Item {}: problem creating: ()".format(child_path, e))
+                else:
+                    vars(self)[attr] = child
+                    self.add_item(child_path, child)
+                    self.children.append(child)
+        return item_conf
+
+    def add_log(self, name, log):
+        self.__logs[name] = log
+
+    def now(self):
+        return datetime.datetime.now()
+
+    def add_item(self, path, item):
+        if path not in self.__items:
+            self.__items.append(path)
+        self.__item_dict[path] = item
+
+    def return_item(self, string):
+        if string in self.__items:
+            return self.__item_dict[string]
+
+    def return_items(self):
+        for item in self.__items:
+            yield self.__item_dict[item]
+
+    def return_plugins(self):
+        for plugin in self._plugins:
+            yield plugin
+
+    def string2bool(self, string):
+        if isinstance(string, bool):
+            return string
+        if string.lower() in ['0', 'false', 'n', 'no', 'off']:
+            return False
+        if string.lower() in ['1', 'true', 'y', 'yes', 'on']:
+            return True
+        else:
+            return None
+

--- a/tests/mock/core.py
+++ b/tests/mock/core.py
@@ -1,7 +1,9 @@
 
 import datetime
 
+import lib.item
 import lib.plugin
+import lib.config
 import lib.connection
 
 from lib.model.smartplugin import SmartPlugin

--- a/tests/mock/core.py
+++ b/tests/mock/core.py
@@ -44,7 +44,7 @@ class MockSmartHome():
                 try:
                     child = lib.item.Item(self, self, child_path, value)
                 except Exception as e:
-                    print("Item {}: problem creating: ()".format(child_path, e))
+                    print("Item {}: problem creating: {}".format(child_path, e))
                 else:
                     vars(self)[attr] = child
                     self.add_item(child_path, child)

--- a/tests/resources/plugin.conf
+++ b/tests/resources/plugin.conf
@@ -1,20 +1,40 @@
-#[cli]
-#    class_name = CLI
-#    class_path = plugins.cli
-#    ip = 0.0.0.0
-#    update = True 
+[cli]
+    class_name = CLI
+    class_path = plugins.cli
+    ip = 0.0.0.0
+    update = True
+    hashed_password = 1245a9633edf47b7091f37c4d294b5be5a9936c81c5359b16d1c4833729965663f1943ef240959c53803fedef7ac19bd59c66ad7e7092d7dbf155ce45884607d
+
 [memlog]
    class_name = MemLog
    class_path = plugins.memlog
    name = alert
 
+[sml0]
+   class_name = Sml
+   class_path = plugins.sml
+   serialport = /dev/ttyUSB0
+
+[sml1]
+   class_name = Sml
+   class_path = plugins.sml
+   serialport = /dev/ttyUSB1
+
 [wol]
    class_name = WakeOnLan
    class_path = plugins.wol
+
 [wol_ww]
    instance = bind
    class_name = WakeOnLan
    class_path = plugins.wol
+
+[knx]
+  class_name = KNX
+  class_path = plugins.knx
+  host = hostname
+  instance = default
+
 #[rest]
 #    class_name = RestServer
 #    class_path = plugins.rest

--- a/tests/resources/plugin.yaml
+++ b/tests/resources/plugin.yaml
@@ -4,10 +4,27 @@ comment: '[cli]
     ip = 0.0.0.0
     update = True'
 
+cli:
+    class_name: CLI
+    class_path: plugins.cli
+    ip: 0.0.0.0
+    update: True
+    hashed_password: 1245a9633edf47b7091f37c4d294b5be5a9936c81c5359b16d1c4833729965663f1943ef240959c53803fedef7ac19bd59c66ad7e7092d7dbf155ce45884607d
+
 memlog:
     class_name: MemLog
     class_path: plugins.memlog
     name: alert
+
+sml0:
+   class_name: Sml
+   class_path: plugins.sml
+   serialport: /dev/ttyUSB0
+
+sml1:
+   class_name: Sml
+   class_path: plugins.sml
+   serialport: /dev/ttyUSB1
 
 wol:
     class_name: WakeOnLan
@@ -29,3 +46,9 @@ wol_ww:
         ip = 0.0.0.0
         port = 8001
         update = True'
+
+knx:
+  class_name: KNX
+  class_path: plugins.knx
+  host: hostname
+  instance: default

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -86,7 +86,7 @@ class TestConfig(unittest.TestCase):
 		self.assertEqual(wolplug.plugin.get_iattr_value(config_mock, "key3"), "value3")
 		config_mock = {'key3@bind' : 'value2'}
 		self.assertIsNone(wolplug.plugin.get_iattr_value(config_mock, "key3"))
-		config_mock = {'key3@bind2', 'value4'}
+		config_mock = {'key3@bind2' : 'value4'}
 		self.assertIsNone(wolplug.plugin.get_iattr_value(config_mock, "key3"))
 
 	def test_plugin_instance_set_get_iattr_value(self):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -39,12 +39,6 @@ class TestConfig(unittest.TestCase):
 		cliplug = self.plugins.get_plugin("cli")
 		self.assertEqual(cliplug.plugin.get_instance_name(),"")
 
-	def test_plugin_instance_not_set_uses_plugin_name(self):
-		sml0plug = self.plugins.get_plugin("sml0")
-		self.assertEqual(sml0plug.plugin.get_instance_name(),"sml0")
-		sml1plug = self.plugins.get_plugin("sml1")
-		self.assertEqual(sml1plug.plugin.get_instance_name(),"sml1")
-
 	def test_plugin_instance_set(self):
 		cliplug = self.plugins.get_plugin("wol_ww")
 		self.assertEqual(cliplug.plugin.get_instance_name(),"bind")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,184 +1,136 @@
 
 import common
 import unittest
-import lib.plugin
-import lib.item
+
 from lib.model.smartplugin import SmartPlugin
-import threading
+
+from tests.mock.core import MockSmartHome
 
 class TestConfig(unittest.TestCase):
-    def props(self,cls):   
-        return [i for i in cls.__dict__.keys() if i[:1] != '_']
-    def test_plugins(self):
-        plugins = lib.plugin.Plugins(MockSmartHome(), common.BASE + "/tests/resources/plugin")
-        self.assertIsNone(plugins.get_plugin("wol1") )
-        self.assertIsNotNone(plugins._plugins )
-        if 0:
-            for p in plugins._threads: 
-                print(p.name)
-                print(p.plugin)
-                print(self.props(p.plugin))
-                print(dir(p.plugin))
-                import inspect
-                print(inspect.getmembers(p.plugin, lambda a:not(inspect.isroutine(a))))
 
-        wolplug= plugins.get_plugin("wol_ww") 
+	def setUp(self):
+		self.sh = MockSmartHome()
+		self.plugins = self.sh.with_plugins_from(common.BASE + "/tests/resources/plugin.conf")
+		self.item_conf = self.sh.with_items_from(common.BASE + "/tests/resources/plugin_items.conf")
 
-        self.assertIsNotNone(wolplug )
-        self.assertEqual(wolplug.name,"wol_ww" )
-        self.assertIsNone(wolplug.ident )
-        plugins.start()
-        self.assertEqual(wolplug.ident,wolplug.get_ident())
-        self.assertEqual(wolplug.plugin, wolplug.get_implementation())
-        self.assertIsNotNone(wolplug.get_ident() )
-        
-        plugins.stop()
-#        print(plugins.get_plugin("wol").get_ident() )
-        
-    def test_plugininstance(self):
-        sh=MockSmartHome()
-        # load pluginsA
-        plugins = lib.plugin.Plugins(sh, common.BASE + "/tests/resources/plugin")
-        sh._plugins=plugins
-        wolplug= plugins.get_plugin("wol")
-        self.assertEqual(wolplug.plugin.get_instance_name(),"")
+	def test_plugin_is_registered(self):
+		self.assertIsNotNone(self.plugins.get_plugin("wol"))
 
-        config_mock = {'key3', 'value3'}
-        self.assertTrue(wolplug.plugin.has_iattr(config_mock,"key3"))
-        config_mock = {'key3@*', 'value3'}
-        self.assertTrue(wolplug.plugin.has_iattr(config_mock, "key3"))
-        config_mock = {'key3@false*', 'value3'}
-        self.assertFalse(wolplug.plugin.has_iattr(config_mock, "key3"))
+	def test_plugin_not_registered(self):
+		self.assertIsNone(self.plugins.get_plugin("wol1"))
 
-        wolplug = plugins.get_plugin("wol_ww")
-        #wolplug.plugin.ALLOW_MULTIINSTANCE= False
-        #wolplug.plugin.set_instance_name("")
-        self.assertTrue(isinstance(wolplug.plugin, SmartPlugin))
-        self.assertTrue(wolplug.plugin.is_multi_instance_capable())
-        self.assertEqual(wolplug.plugin.get_instance_name(),"bind")
+	def test_plugin_name(self):
+		wolplug = self.plugins.get_plugin("wol_ww")
+		self.assertEqual(wolplug.name, "wol_ww")
 
-        config_mock = {'key3@bind', 'value3'}
-        self.assertTrue(wolplug.plugin.has_iattr(config_mock, "key3"))
-        config_mock = {'key3@*', 'value3'}
-        self.assertTrue(wolplug.plugin.has_iattr(config_mock, "key3"))
-        config_mock = {'key3@false', 'value3'}
-        self.assertFalse(wolplug.plugin.has_iattr(config_mock, "key3"))
+	def test_plugin_implementation(self):
+		wolplug = self.plugins.get_plugin("wol_ww")
+		self.assertEqual(wolplug.plugin, wolplug.get_implementation())
 
-        config_mock = {}
-        config_mock["key3@*"] = "value3"
-        self.assertEqual(wolplug.plugin.get_iattr_value(config_mock, "key3"), "value3")
-        config_mock = {}
-        config_mock["key3@bind"] = "value2"
-        self.assertEqual(wolplug.plugin.get_iattr_value(config_mock, "key3"), "value2")
-        config_mock = {}
-        config_mock["key3@bind2"] = "value4"
-        self.assertIsNone(wolplug.plugin.get_iattr_value(config_mock, "key3"))
-        
-        if 0:
-            print(sh._plugins)        
-            for plug in sh.return_plugins():
-                print(plug)
-        #load items
-        item_conf = None
-        item_conf = lib.config.parse(common.BASE + "/tests/resources/plugin_items.conf", item_conf)
-#        print(item_conf.items())
-        for attr, value in item_conf.items():
-            if isinstance(value, dict):
-                child_path = attr
-                try:
-                    child = lib.item.Item(sh, sh, child_path, value)
-                except Exception as e:
-                    self.logger.error("Item {}: problem creating: ()".format(child_path, e))
-                else:
-                    #vars(sh)[attr] = child
-                    sh.add_item(child_path, child)
-                    sh.children.append(child)
-#        for item in sh.return_items():
-#            item._init_prerun()
-#        for item in sh.return_items():
-#            item._init_run()
-#       
-        if 0: self.dump_items(sh)
+	def test_plugin_ident(self):
+		wolplug = self.plugins.get_plugin("wol_ww")
+		self.assertIsNone(wolplug.ident)
+		self.plugins.start()
+		self.assertEqual(wolplug.ident, wolplug.get_ident())
+		self.assertIsNotNone(wolplug.get_ident())
+		self.plugins.stop()
 
-        it = sh.return_item("item3.item3b.item3b1.item3b1a")
-        self.assertIsNotNone(it)
-        self.assertEqual(len(it.get_method_triggers()),2)
-        it = sh.return_item("item3.item3b.item3b1")
-        self.assertIsNotNone(it)
-        self.assertEqual(len(it.get_method_triggers()),1)
-        it = sh.return_item("item3.item3b")
-        self.assertIsNotNone(it)
-        self.assertEqual(len(it.get_method_triggers()),0)
-        sh.scheduler.add(wolplug.name, wolplug.plugin.update_item, prio=5, cycle=300, offset=2)
-        wolplug.plugin.testprint()
-        wolplug.plugin.wake_on_lan("11:22:33:44:55:66")
+	def test_plugin_instance_not_set(self):
+		cliplug = self.plugins.get_plugin("cli")
+		self.assertEqual(cliplug.plugin.get_instance_name(),"")
 
-    def _update_dummy(self):
-        print("update dummy")
-    def dump_items(self, sh ):
-        for item in sh.return_items():
-            print(item)
-            for meth in item.get_method_triggers():
-                print('   ' + meth.__self__.get_info())
+	def test_plugin_instance_not_set_uses_plugin_name(self):
+		sml0plug = self.plugins.get_plugin("sml0")
+		self.assertEqual(sml0plug.plugin.get_instance_name(),"sml0")
+		sml1plug = self.plugins.get_plugin("sml1")
+		self.assertEqual(sml1plug.plugin.get_instance_name(),"sml1")
 
-    def _test_configsave(self):
-        import configparser
-        plugins = lib.plugin.Plugins(MockSmartHome(), common.BASE + "/tests/resources/plugin")
-        item_conf = None
-        item_conf = lib.config.parse(common.BASE + "/tests/resources/plugin_items.conf", item_conf)
-        print(item_conf)
-        for attr, value in item_conf.items():
-            if isinstance(value, dict):
-                child_path = attr
-                try:
-                    child = lib.item.Item(self, self, child_path, value)
-                except Exception as e:
-                    print("Item {}: problem creating: ()".format(child_path, e))
-                else:
-                    vars(self)[attr] = child
-                    sh.add_item(child_path, child)
-                    sh.children.append(child)
-        config = configparser.RawConfigParser( )
-        #config.read(common.BASE + '/tests/resources/plugin_items.conf')
-        config.read_dict(item_conf)
-        print(config)
-        with open('example.cfg', 'w') as configfile:
-            config.write(configfile)
+	def test_plugin_instance_set(self):
+		cliplug = self.plugins.get_plugin("wol_ww")
+		self.assertEqual(cliplug.plugin.get_instance_name(),"bind")
 
-class MockSmartHome():
-    
-    class MockScheduler():
-        def add(self, name, obj, prio=3, cron=None, cycle=None, value=None, offset=None, next=None): 
-            print(name) 
-            if isinstance(obj.__self__, SmartPlugin):
-                name = name +'_'+ obj.__self__.get_instance_name()
-            print(name)  
-            print( obj) 
-            print(obj.__self__.get_instance_name())
-    __logs = {}
-    __item_dict = {}
-    __items = []
-    children = []
-    _plugins = []
-    scheduler = MockScheduler()
-    def add_log(self, name, log):
-        self.__logs[name] = log
-    def now(self):
-        import datetime
-        return datetime.datetime.now()
-    def add_item(self, path, item):
-        if path not in self.__items:
-            self.__items.append(path)
-        self.__item_dict[path] = item
-    def return_item(self, string):
-        if string in self.__items:
-            return self.__item_dict[string]
-    def return_items(self):
-        for item in self.__items:
-            yield self.__item_dict[item]
-    def return_plugins(self):
-        for plugin in self._plugins:
-            yield plugin   
+	def test_plugin_multi_instance_capable_true(self):
+		wolplug = self.plugins.get_plugin("wol_ww")
+		self.assertTrue(isinstance(wolplug.plugin, SmartPlugin))
+		self.assertTrue(wolplug.plugin.is_multi_instance_capable())
+
+	def test_plugin_multi_instance_capable_false(self):
+		cliplug = self.plugins.get_plugin("cli")
+		self.assertTrue(isinstance(cliplug.plugin, SmartPlugin))
+		self.assertFalse(cliplug.plugin.is_multi_instance_capable())
+
+	def test_plugin_instance_not_set_has_iattr(self):
+		wolplug = self.plugins.get_plugin("wol")
+
+		config_mock = {'key3', 'value3'}
+		self.assertTrue(wolplug.plugin.has_iattr(config_mock,"key3"))
+		config_mock = {'key3@*', 'value3'}
+		self.assertTrue(wolplug.plugin.has_iattr(config_mock, "key3"))
+		config_mock = {'key3@false*', 'value3'}
+		self.assertFalse(wolplug.plugin.has_iattr(config_mock, "key3"))
+
+	def test_plugin_instance_set_has_iattr(self):
+		wolplug = self.plugins.get_plugin("wol_ww")
+
+		config_mock = {'key3@bind', 'value3'}
+		self.assertTrue(wolplug.plugin.has_iattr(config_mock, "key3"))
+		config_mock = {'key3@*', 'value3'}
+		self.assertTrue(wolplug.plugin.has_iattr(config_mock, "key3"))
+		config_mock = {'key3@false', 'value3'}
+		self.assertFalse(wolplug.plugin.has_iattr(config_mock, "key3"))
+
+	def test_plugin_instance_not_set_get_iattr_value(self):
+		wolplug = self.plugins.get_plugin("wol")
+
+		config_mock = {'key3@*' : 'value3'}
+		self.assertEqual(wolplug.plugin.get_iattr_value(config_mock, "key3"), "value3")
+		config_mock = {'key3@bind' : 'value2'}
+		self.assertIsNone(wolplug.plugin.get_iattr_value(config_mock, "key3"))
+		config_mock = {'key3@bind2', 'value4'}
+		self.assertIsNone(wolplug.plugin.get_iattr_value(config_mock, "key3"))
+
+	def test_plugin_instance_set_get_iattr_value(self):
+		wolplug = self.plugins.get_plugin("wol_ww")
+
+		config_mock = {'key3@*' : 'value3'}
+		self.assertEqual(wolplug.plugin.get_iattr_value(config_mock, "key3"), "value3")
+		config_mock = {'key3@bind' : 'value2'}
+		self.assertEqual(wolplug.plugin.get_iattr_value(config_mock, "key3"), "value2")
+		config_mock = {'key3@bind2', 'value4'}
+		self.assertIsNone(wolplug.plugin.get_iattr_value(config_mock, "key3"))
+
+	def test_plugin_instance_not_used_in_item_config(self):
+		it = self.sh.return_item("item3.item3b.item3b1")
+		self.assertIsNotNone(it)
+		self.assertEqual(len(it.get_method_triggers()),1)
+
+	def test_plugin_instance_used_in_item_config(self):
+		it = self.sh.return_item("item3.item3b.item3b1.item3b1a")
+		self.assertIsNotNone(it)
+		self.assertEqual(len(it.get_method_triggers()),2)
+
+	def test_plugin_instance_no_attributes_item_config(self):
+		it = self.sh.return_item("item3.item3b")
+		self.assertIsNotNone(it)
+		self.assertEqual(len(it.get_method_triggers()),0)
+
+	def test_plugin_instance_wol(self):
+		wolplug = self.plugins.get_plugin("wol_ww")
+		self.sh.scheduler.add(wolplug.name, wolplug.plugin.update_item, prio=5, cycle=300, offset=2)
+		wolplug.plugin.testprint()
+		wolplug.plugin.wake_on_lan("11:22:33:44:55:66")
+
+	def _test_configsave(self):
+		import configparser
+		item_conf = self.item_conf
+
+		config = configparser.RawConfigParser( )
+		#config.read(common.BASE + '/tests/resources/plugin_items.conf')
+		config.read_dict(item_conf)
+		print(config)
+		with open('example.cfg', 'w') as configfile:
+			config.write(configfile)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -10,7 +10,7 @@ class TestConfig(unittest.TestCase):
 
 	def setUp(self):
 		self.sh = MockSmartHome()
-		self.plugins = self.sh.with_plugins_from(common.BASE + "/tests/resources/plugin.conf")
+		self.plugins = self.sh.with_plugins_from(common.BASE + "/tests/resources/plugin")
 		self.item_conf = self.sh.with_items_from(common.BASE + "/tests/resources/plugin_items.conf")
 
 	def test_plugin_is_registered(self):


### PR DESCRIPTION
This PR contains:

* start implementing core mock objects for reuse in other tests
* decrease code-duplications in SmartPlugin attribute name calculation
* refactor tests for plugin and create small functions to actually tests units of plugin handling

(previously included in #127)