### PR TITLE
Add get_plugins() and get_logics() method to SmartHome

### DIFF
--- a/bin/smarthome.py
+++ b/bin/smarthome.py
@@ -447,6 +447,10 @@ class SmartHome():
     #################################################################
     # Plugin Methods
     #################################################################
+    def get_plugins(self):
+        return self._plugins
+
+    # deprecated: use get_plugins()
     def return_plugins(self):
         for plugin in self._plugins:
             yield plugin
@@ -454,13 +458,19 @@ class SmartHome():
     #################################################################
     # Logic Methods
     #################################################################
+    def get_logics(self):
+        return self._logics
+
+    # deprecated: use get_logics().get_logic(name).generate_bytecode()
     def reload_logics(self, signum=None, frame=None):
         for logic in self._logics:
             self._logics[logic].generate_bytecode()
 
+    # deprecated: use get_logics().get_logic(name)
     def return_logic(self, name):
         return self._logics[name]
 
+    # deprecated: use get_logics()
     def return_logics(self):
         for logic in self._logics:
             yield logic


### PR DESCRIPTION
To be able to minimize dependency between plugin and logic handling this PR introduces two new methods:
* `get_plugins` - returns the instance to `lib.Plugins`
* `get_logics` - returns the instance to `lib.Logics`

These methods should be used as entry point for plugin and logics operations. The existing other plugins/logics methods are marked as deprecated and should be removed in a later release.

Plugin migration will be provided in a new PR later.
