### PR TITLE
Make additional module pathes configurable

### DIFF
--- a/bin/smarthome.py
+++ b/bin/smarthome.py
@@ -183,6 +183,9 @@ class SmartHome():
                     vars(self)['_' + attr] = config[attr]
             del(config)  # clean up
 
+        if hasattr(self, '_module_pathes'):
+            sys.path.extend(self._module_pathes if type(self._module_pathes) is list else [self._module_pathes])
+
         #############################################################
         # Database APIs
         #############################################################


### PR DESCRIPTION
Allow to configure additional module pathes in SmartHome configuration by using the `module_pathes` setting. It can be used to specify a single path or a list of pathes which will be added to the Python module search path.

This could be useful if users want to use other 3rd party modules which are not part of the SmartHome project.
