### PR TITLE
changed detection of path to os.path.normpath

### DIFF
--- a/bin/smarthome.py
+++ b/bin/smarthome.py
@@ -50,7 +50,7 @@ import traceback
 #####################################################################
 # Base
 #####################################################################
-BASE = '/'.join(os.path.realpath(__file__).split('/')[:-2])
+BASE = '/'.join(os.path.normpath(__file__).split('/')[:-2])
 sys.path.insert(0, BASE)
 sys.path.insert(1, BASE + '/lib/3rd')
 


### PR DESCRIPTION
instead of os.path.realpath.

os.path.realpath eliminates any symbolic links - and therefore you can't work with symbolic links for redirecting log files.

I am using the following file structure to eliminate the need to store my items, logs & so on in the application directory. The application directory (as checked out from github) should be replaceable - without even thinking about to backup this or that. config should be in completely seperate directories.

lrwxrwxrwx 1 root      root        18 Feb 18 13:19 bin -> ../smarthomeNG/bin
lrwxrwxrwx 1 root      root        18 Feb 18 13:20 dev -> ../smarthomeNG/dev
lrwxrwxrwx 1 root      root        18 Feb 18 13:20 doc -> ../smarthomeNG/doc
lrwxrwxrwx 1 root      root        22 Feb 18 13:19 etc -> /var/lib/smarthome/etc
lrwxrwxrwx 1 root      root        24 Feb 18 13:19 items -> /var/lib/smarthome/items
lrwxrwxrwx 1 root      root        18 Feb 18 13:19 lib -> ../smarthomeNG/lib
lrwxrwxrwx 1 root      root        25 Feb 18 13:19 logics -> /var/lib/smarthome/logics
lrwxrwxrwx 1 root      root        22 Feb 18 13:40 plugins -> ../smarthomeNG_plugins
lrwxrwxrwx 1 root      root        20 Feb 18 13:20 tests -> ../smarthomeNG/tests
lrwxrwxrwx 1 root      root        20 Feb 18 13:20 tools -> ../smarthomeNG/tools

drwxr-xr-x 2 smarthome smarthome 4096 Feb 18 13:25 var
lrwxrwxrwx 1 root      root        20 Feb 18 13:22 cache -> /var/cache/smarthome
lrwxrwxrwx 1 root      root        21 Feb 18 13:23 db -> /var/lib/smarthome/db
lrwxrwxrwx 1 root      root        18 Feb 18 13:23 log -> /var/log/smarthome
lrwxrwxrwx 1 root      root        22 Feb 18 13:25 rrd -> /var/lib/smarthome/rrd
lrwxrwxrwx 1 root      root        18 Feb 18 13:24 run -> /var/run/smarthome

my start-script starts /opt/smarthome/bin/smarthome.py. when using os.path.realpath it switches to /opt/smarthomeNG - that's not what I want - and probably others too. With normpath everything works like a charm - the smarthomeNG directory is absolutely replaceable.