### PR TITLE
Ignore keywords in configuration files

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -22,6 +22,7 @@
 
 import logging
 import collections
+import keyword
 import os
 import lib.shyaml as shyaml
 from lib.constants import (YAML_FILE, CONF_FILE)
@@ -138,6 +139,15 @@ def remove_reserved(ydata):
     remove_keys(ydata, lambda k: k in reserved)
 
 
+def remove_keyword(ydata):
+    '''
+    Removes reserved Python keywords from a dict or OrderedDict structure
+
+    :param ydata: configuration (sub)tree to work on
+    '''
+    remove_keys(ydata, lambda k: keyword.iskeyword(k))
+
+
 def remove_invalid(ydata):
     '''
     Removes invalid chars in item from a dict or OrderedDict structure
@@ -197,6 +207,7 @@ def parse_yaml(filename, config=None):
     remove_comments(items)
     remove_digits(items)
     remove_reserved(items)
+    remove_keyword(items)
     remove_invalid(items)
     
     config = merge(items, config)
@@ -293,6 +304,9 @@ def parse_conf(filename, config=None):
                     return config
                 elif name in reserved:
                     logger.error("Problem parsing '{}': item using reserved word set/get in line {}: {}".format(filename, linenu, line))
+                    return config
+                elif keyword.iskeyword(name):
+                    logger.error("Problem parsing '{}': item using reserved Python keyword {} in line {}: {}".format(filename, name, linenu, line))
                     return config
                     
                 if level == 1:

--- a/tests/resources/config_keyword.conf
+++ b/tests/resources/config_keyword.conf
@@ -1,0 +1,5 @@
+[keyword]
+  [[global]]
+    type = num
+  [[and]]
+    type = num

--- a/tests/resources/config_keyword.yaml
+++ b/tests/resources/config_keyword.yaml
@@ -1,0 +1,5 @@
+keyword:
+  global:
+    type = num
+  and:
+    type = num

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,10 @@ class ConfigBaseTests:
         conf = self.config('reserved')
         self.assertEquals(0, len(conf['reserved']))
 
+    def test_read_ignores_keyword(self):
+        conf = self.config('keyword')
+        self.assertEquals(0, len(conf['keyword']))
+
     def test_read_ignores_invalidchars(self):
         conf = self.config('invalidchars')
         self.assertEquals(0, len(conf['invalidchars']))


### PR DESCRIPTION
Using keywords in configuration can lead to problem. Especially
when the configuration is referenced in some Python expressions
like eval attribute in items.conf.

Fixes #180 Items with same root item spread over multiple config files.
