### PR TITLE
module http: fix hostname resolving

### DIFF
--- a/modules/http/__init__.py
+++ b/modules/http/__init__.py
@@ -235,7 +235,16 @@ class Http():
         :rtype: str
         """
         import socket
-        return socket.gethostbyaddr(self.get_local_ip_address())[0]
+        try:
+            return socket.gethostbyaddr(self.get_local_ip_address())[0] # can fail with default /etc/hosts
+        except socket.herror:
+            try:
+                return socket.gethostbyaddr("127.0.1.1")[0]	# in debian based systems hostname is assigned to "127.0.1.1" by default
+            except socket.herror:
+                try:
+                    return socket.gethostbyaddr("127.0.0.1")[0]	# 'localhost' in most cases
+                except socket.herror:
+                    return "localhost"	# should not happen
 
  
     def get_local_port(self):


### PR DESCRIPTION
Just switched to newest develop and find out this issue with http module: 


`2017-09-18 19:12:14 ERROR    module       Main         Module http exception: [Errno 1]  Unknown host -- module.py:__init__:81
Traceback (most recent call last):
  File "/home/smarthome/smarthome/lib/module.py", line 79, in __init__
    self._load_module(module, classname, classpath, args)
  File "/home/smarthome/smarthome/lib/module.py", line 224, in _load_module
    exec("self.loadedmodule.__init__(self._sh{0}{1})".format("," if len(arglist) else "", argstring))
  File "<string>", line 1, in <module>
  File "/home/smarthome/smarthome/modules/http/__init__.py", line 86, in __init__
    self.logger.info("Module 'http': ip address = {}, hostname = '{}'".format(self.get_local_ip_address(), self.get_local_hostname()))
  File "/home/smarthome/smarthome/modules/http/__init__.py", line 238, in get_local_hostname
    return socket.gethostbyaddr(self.get_local_ip_address())[0]
socket.herror: [Errno 1]  Unknown host`


Reason is lack of hostname assigned to my local ip in /etc/hosts (which is default) and `socket.gethostbyaddr()` error. This commit handles socket.herror and fall back to localhost if needed