### PR TITLE
Don't detect own process as other running instance

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -146,7 +146,7 @@ def check_sh_is_running(pidfile):
     """
     
     pid = read_pidfile(pidfile)
-    return psutil.pid_exists(pid) if pid > 0 else False
+    return psutil.pid_exists(pid) if pid > 0 and pid != os.getpid() else False
 
 
 def kill(pidfile, waittime=15):


### PR DESCRIPTION
This checks if the pid is the currently running process and ignores the pidfile, if so.

Scenario:
When running inside a docker container, sometimes during termination of the container, the pid file is not removed.
In a docker container, the pid is usually 1 and will be the same on subsequent launches.
When restarting the container, smarthome-ng now detects another instance is already running (which is in fact itself).