### PR TITLE
Improve process-running detection

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -145,7 +145,7 @@ def check_sh_is_running(pidfile):
     """
     
     pid = read_pidfile(pidfile)
-    return psutil.pid_exists(pid) if pid > 0 else False
+    return psutil.pid_exists(pid) if pid > 0 and pid != os.getpid() else False
 
 
 def kill(pidfile, waittime=15):

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -167,7 +167,8 @@ def check_sh_is_running(pidfile):
                 # pidfile is locked, so sh is running
                 isRunning = True
             else:
-                print("Error while testing lock in pidfile: %d (%s)" % (e.errno, e.strerror) , file=sys.stderr)
+                print("Error while testing lock in pidfile %s: %d (%s)" % (pidfile, e.errno, e.strerror) , file=sys.stderr)
+                sys.exit(1)
         finally:
             if fd:
                 os.close(fd)


### PR DESCRIPTION
As suggested in the discussion for PR #252, this patch uses file locking for the pidfile to improve check_sh_is_running().
A lock is set by the daemon process and then check_sh_is_running tests if it can acquire the lock in the second process. If not, there is no other daemon process running, even if the pidfile exists.

Issue with this code:
The daemon thread needs to wait for the pidfile to exist before the lock can be placed.
We could also write the pidfile from the daemon process itself or use a separate lockfile instead.
  