### PR TITLE
Update Travis-CI build

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,101 @@
+#######################################################################
+# Travis-CI script
+#
+# This script will checkout all required reqository to run the
+# suite.
+#
+# The following configuration settings are available:
+# * Environment settings:
+#   - REPOSITORY_ORIGIN: defines the current repos origin (e.g.
+#     "smarthome" or "plugins")
+# * Script settings:
+#   - REPOSITORIES: List of repositories to checkout from smarthomeNG
+#     organization (e.g. "https://github.com/smarthomeNG/<repo-name>")
+#   - LINKS: Contains a list of links to create before running the
+#     suite (e.g. "<target-repo>/<target-dir>/<source-repo>")
+# * Script variables:
+#   - REPOSITORY: The name of the current repository
+#   - REPOSITORY_ORIGIN: The origin repository from environment setting
+#   - REPOSITORY_BRANCH: The branch to use for checkouts
+
+echo -e "travis_fold:start:Environment\nEnvironment dump"
+set
+export
+echo "travis_fold:end:Environment"
+
+#######################################################################
+# Declare some common variables
+
+REPOSITORIES="smarthome plugins"
+LINKS="smarthome/plugins/plugins"
+
+# Get the current repository which is processed
+REPOSITORY="$(basename $TRAVIS_REPO_SLUG)"
+REPOSITORY_ORIGIN="$REPOSITORY_ORIGIN"
+
+# Find out on which branch to work
+if [ "$TRAVIS_BRANCH" = "master" ] ; then
+  REPOSITORY_BRANCH="master"
+else
+  REPOSITORY_BRANCH="develop"
+fi
+
+
+#######################################################################
+# 1. Checkout all repositories
+
+echo -e "travis_fold:start:Checkout\nChecking out repositories with $REPOSITORY_BRANCH branch"
+
+# Change to root directory since script is started in checkout
+cd $TRAVIS_BUILD_DIR/..
+
+# Check out other repositories with develop version
+for REPO in $REPOSITORIES ; do
+  if [ "$REPO" != "$REPOSITORY_ORIGIN" ] ; then
+    echo "Checking out $REPO ..."
+    git clone https://github.com/smarthomeNG/$REPO.git $REPO
+    cd $REPO
+    git checkout $REPOSITORY_BRANCH
+    cd ..
+  else
+    echo "Moving checkout $TRAVIS_REPO_SLUG to $REPO ..."
+    mv ../$TRAVIS_REPO_SLUG $REPO
+  fi
+done
+
+echo "travis_fold:end:Checkout"
+
+
+#######################################################################
+# 2. Create symlinks in repositories
+
+echo -e "travis_fold:start:Links\nCreating symlinks"
+
+# Create symlinks in core repository
+for LINK in $LINKS ; do
+  TARGET=$(dirname "$LINK")
+  TARGET_REPO=$(dirname "$TARGET")
+  TARGET_DIR=$(basename "$TARGET")
+  SOURCE_REPO=$(basename "$LINK")
+
+  echo "Create link from $SOURCE_REPO to $TARGET_REPO/$TARGET_DIR ..."
+  cd $TARGET_REPO
+  rm -rf $TARGET_DIR
+  ln -s ../$SOURCE_REPO $TARGET_DIR
+  cd ..
+done
+
+echo "travis_fold:end:Links"
+
+
+#######################################################################
+# 3. Run
+
+echo -e "travis_fold:start:Suite\nRunning suite"
+
+cd smarthome
+tox
+cd ..
+
+echo "travis_fold:end:Suite"
+

--- a/.travis.sh
+++ b/.travis.sh
@@ -99,3 +99,14 @@ cd ..
 
 echo "travis_fold:end:Suite"
 
+
+#######################################################################
+# 4. Docs
+
+echo -e "travis_fold:start:Docs\nBuilding documentation"
+
+cd smarthome/doc
+yes | bash build_doc.sh
+cd ../..
+
+echo "travis_fold:end:Docs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 sudo: false
 language: python
 python:
-#    - "3.2"
     - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"
 
-before_install:
-    - git submodule update --init --remote --recursive
+env:
+    - REPOSITORY_ORIGIN=smarthome
 
 install:
     - pip install tox-travis "virtualenv<14.0.0"
 
 script:
-    - tox
+    - sh .travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 
 install:
     - pip install tox-travis "virtualenv<14.0.0"
+    - pip install sphinx sphinx_rtd_theme recommonmark ruamel.yaml
 
 script:
     - sh .travis.sh

--- a/doc/build_doc.sh
+++ b/doc/build_doc.sh
@@ -155,8 +155,8 @@ if [ "${DOC,,}" == "developer" ] || [ "${DOC,,}" == "all" ]; then
   echo
   echo Bau der Entwickler-Dokumentation:
   cd $DEVELOPDOC
-  make clean
-  make html
+  make clean || exit
+  make html || exit
   echo
   echo Bau der Entwickler-Dokumentation ist abgeschlossen!
 fi
@@ -168,8 +168,8 @@ if [ "${DOC,,}" == "user" ] || [ "${DOC,,}" == "all" ]; then
   echo
   echo Bau der Anwender-Dokumentation:
   cd $USERDOC
-  make clean
-  make html
+  make clean || exit
+  make html || exit
   echo
   echo Bau der Anwender-Dokumentation ist abgeschlossen!
 fi


### PR DESCRIPTION
This is an update for the Travis-CI build:
* updated `tox.ini` and `.travis.yml`
* introduced new `.travis.sh` script which is used to run the suite

It will enable execution of tests when committing to the `core` repository. An example run can be reviewed [here](https://travis-ci.org/ohinckel/smarthomeNG-core/jobs/328408455). The [documentation](https://github.com/smarthomeNG/smarthome/wiki/Tests) will also be updated after merge.

The execute will be unified with this PR so that the `plugins` and `core` repositories uses the same script and configuration and run the suite as follows:
* commits to `master` will run the tests using both repositories' `master` branch
* commits to `develop` will run the tests using both repositories' `develop` branch

(see also https://github.com/smarthomeNG/smarthome/issues/240)