### PR TITLE
persistent variables are prefixed with logics

### DIFF
--- a/doc/user/source/logiken/persistente_variablen.rst
+++ b/doc/user/source/logiken/persistente_variablen.rst
@@ -40,10 +40,10 @@ muss die Variable folgendermaßen definert werden:
 .. code-block:: python
    :caption: persistent
    
-   logic.myvar = 'my Value'
+   logics.myvar = 'my Value'
 
 
-Die Variable **logic.myvar** übersteht die Zeit bis zum nächsten Lauf der Logik und sie steht
+Die Variable **logics.myvar** übersteht die Zeit bis zum nächsten Lauf der Logik und sie steht
 nur in der Logik zur Verfügung, die sie auch definiert hat.
 
 
@@ -54,20 +54,20 @@ Wenn auf eine Variable zugegriffen wird bevor sie definiert wird, führt das zu 
 und der Rest der Logik wird nicht ausgeführt. Beim ersten Lauf einer Logik nach einem Neustart 
 von SmartHomeNG existiert jedoch keine Variable aus vorangegangenen Läufen. Sie muss erstmal
 definiert werden. Das kann zum Beispiel in der folgenden Form erfolgen, in der die Variable
-**logic.myvar** mit dem Wert **None** initialisiert wird, falls sie nicht existiert
+**logics.myvar** mit dem Wert **None** initialisiert wird, falls sie nicht existiert
 
 .. code-block:: python
    :caption: Sicherstellen, dass die Variable existiert
    
    if not hasattr(logic, 'myvar'):
-       logic.myvar = None
+       logics.myvar = None
 
 
 Nutzung selbst definierter Parameter
 ------------------------------------
 
 Es ist möglich eigene Parameter in der Datei **../etc/logic.yaml** zu definieren. Diese Parameter
-stehen in der Logik under **logic.<Parameter>** zur Verfügung. Diese Parameter können als
+stehen in der Logik under **logics.<Parameter>** zur Verfügung. Diese Parameter können als
 eine bereits initialisierte Variable verstanden/genutzt werden. Sie können in der Logiik nicht
 nur gelesen, sondern auch verändert werden. Diese Änderung geht wie beschrieben bei einem
 Neustart von SmartHomeNG verloren.


### PR DESCRIPTION
In the documentation about persistent variables it says it needs to be prefixed with logic instead of logics.