### PR TITLE
Add foreground mode to SmartHomeNG startup options

### DIFF
--- a/bin/smarthome.py
+++ b/bin/smarthome.py
@@ -1153,6 +1153,7 @@ if __name__ == '__main__':
 
     arggroup.add_argument('-v', '--verbose', help='verbose (info output) logging to the logfile - DEPRECATED use logging-configuration', action='store_true')
     arggroup.add_argument('-d', '--debug', help='stay in the foreground with verbose output - DEPRECATED use logging-configuration', action='store_true')
+    arggroup.add_argument('-f', '--foreground', help='stay in the foreground', action='store_true')
     arggroup.add_argument('-q', '--quiet', help='reduce logging to the logfile - DEPRECATED use logging-configuration', action='store_true')
     args = argparser.parse_args()
 
@@ -1203,6 +1204,9 @@ if __name__ == '__main__':
         pass
     elif args.verbose:
         MODE = 'verbose'
+        pass
+    elif args.foreground:
+        MODE = 'foreground'
         pass
     elif args.create_backup:
         fn = lib.backup.create_backup(extern_conf_dir)


### PR DESCRIPTION
Currently SHNG only supports starting in foreground with DEBUG logging enabled. This will introduce a new option which will start SHNG in foreground without additional logging (just use default log settings).

This could be useful in case SHNG is started by some other program (e.g. docker, supervisor, etc.).
