### PR TITLE
Fix class name

### DIFF
--- a/dev/sample_plugin/__init__.py
+++ b/dev/sample_plugin/__init__.py
@@ -225,7 +225,7 @@ class SamplePlugin(SmartPlugin):
         self.mod_http.register_webif(WebInterface(webif_dir, self),
                                      self.get_shortname(),
                                      config,
-                                     self.get_classname(), self.get_instance_name(),
+                                     self.get_class_name(), self.get_instance_name(),
                                      description='')
 
         return True

--- a/dev/sample_plugin/plugin.yaml
+++ b/dev/sample_plugin/plugin.yaml
@@ -17,7 +17,7 @@ plugin:
 #    sh_maxversion:                 # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: False           # plugin supports multi instance
     restartable: unknown
-    classname: SamplePlugin         # class containing the plugin
+    class_name: SamplePlugin         # class containing the plugin
 
 parameters:
     # Definition of parameters to be configured in etc/plugin.yaml (enter 'parameters: NONE', if section should be empty)

--- a/doc/developer/source/config.rst
+++ b/doc/developer/source/config.rst
@@ -100,7 +100,7 @@ The ``plugins`` directory contains a subdirectory for every available plugin.
 The file ``etc/plugin.yaml`` holds the configuration for every plugin to be used during runtime.
 
 For each plugin at least the plugin object name is needed and the
-attributes where to find the plugin and how to expect the classname to be.
+attributes where to find the plugin and how to expect the class_name to be.
 
 The example below configures a plugin for the KNX bus to send and receive telegrams from and to eibd or knxd (both a software gateway to the KNX hardware bus).
 In this case the object name is ``knx``, the place to look for the module is within subdirectory ``plugins/knx/`` and the class of the plugin is ``KNX``.

--- a/doc/developer/source/development_plugin/plugin_in5minutes.md
+++ b/doc/developer/source/development_plugin/plugin_in5minutes.md
@@ -259,7 +259,7 @@ def bla(self):
 **!! Look at the sample plugin in /dev/sample_plugin for an actual template !!**
 
 First you import certain things you need and get access to the logger. The logger allows you to log output of your plugin into the
-smarthome.log file. Then you start you class. The class name has to match the ``classname`` parameter in the plugin.conf file.
+smarthome.log file. Then you start you class. The class name has to match the ``class_name`` parameter in the plugin.conf file.
 Afterwards you define the required functions.
 
 ```python

--- a/doc/developer/source/metadata/module_global.rst
+++ b/doc/developer/source/metadata/module_global.rst
@@ -8,7 +8,7 @@ The global metadata section ``module:`` has the following keys:
     # Metadata for the module
     module:
         # Global module attributes
-        classname: Http
+        class_name: Http
         version: 1.4.3
         sh_minversion: 1.3a
     #   sh_maxversion:          # maximum shNG version to use this module (leave empty if latest)
@@ -18,7 +18,7 @@ The global metadata section ``module:`` has the following keys:
 
 Description of the keys in the section ``module:``
 
-    - **classname:** Name of the Python class to initialize
+    - **class_name:** Name of the Python class to initialize
     - **version:** Version number of the module. It is checked against the version number defined in the Python source code
     - **sh_minversion:** Minimum SmartHomeNG version this module is compatible with. If *sh_minversion* is left empty, SmartHomeNG assumes that the module is compatible with every version of SmartHomeNG [Test not yet implemented]
     - **sh_maxversion:** Maximum SmartHomeNG version this module is compatible with (or empty, if compatible with the actual version of SmartHomeNG) [Test not yet implemented]

--- a/doc/developer/source/metadata/plugin_global.rst
+++ b/doc/developer/source/metadata/plugin_global.rst
@@ -24,7 +24,7 @@ The global metadata section ``plugin:`` has the following keys:
     #    sh_maxversion:              # maximum shNG version to use this plugin (leave empty if latest)
         multi_instance: true        # plugin supports multi instance (if not specified, False is assumed)
 
-        classname: <plugin_class>   # Name of the class that implements the plugin
+        class_name: <plugin_class>   # Name of the class that implements the plugin
 
 Description of the keys in the section ``plugin:``
 
@@ -42,7 +42,7 @@ Description of the keys in the section ``plugin:``
     - **sh_maxversion:** Maximum SmartHomeNG version this plugin is compatible with (or empty, if compatible with the actual version of SmartHomeNG) [Test not yet implemented]
     - **multi_instance:** Is the plugin multi-instance capable?
     - **restartable:** Is the plugin restartable?  (valid entries are: **True**, ** **False**, **unknown**)
-    - **classname:** Name of the Python class to initialize (the class that implements the plugin)
+    - **class_name:** Name of the Python class to initialize (the class that implements the plugin)
 
     - **classpath:** **Usually not specified.** Only needed, if the plugin resides outside the ``/plugins`` folder
 

--- a/lib/model/smartplugin.py
+++ b/lib/model/smartplugin.py
@@ -46,7 +46,7 @@ class SmartPlugin(SmartObject, Utils):
     _sh = None          #: Variable containing a pointer to the main SmartHomeNG object; is initialized during loading of the plugin; :Warning: Don't change it
     _configname = ''    #: Configname of the plugin; is initialized during loading of the plugin; :Warning: Don't change it
     _shortname = ''     #: Shortname of the plugin; is initialized during loading of the plugin; :Warning: Don't change it
-    _classname = ''     #: Classname of the plugin; is initialized during loading of the plugin; :Warning: Don't change it
+    _class_name = ''     #: Classname of the plugin; is initialized during loading of the plugin; :Warning: Don't change it
     shtime = None       #: Variable containing a pointer to the SmartHomeNG time handling object; is initialized during loading of the plugin; :Warning: Don't change it
 
     _pluginname_prefix = 'plugins.'
@@ -168,19 +168,19 @@ class SmartPlugin(SmartObject, Utils):
             return  self.get_shortname() + '_' + self.get_instance_name()
 
 
-    def get_classname(self):
+    def get_class_name(self):
         """
-        return the classname of the plugin
+        return the class_name of the plugin
 
         :note: Only available in SmartHomeNG versions **beyond** v1.3
 
-        :return: classname of the plugin
+        :return: class_name of the plugin
         :rtype: str
         """
-        return self._classname
+        return self._class_name
 
 
-    def _set_classname(self, classname):
+    def _set_class_name(self, class_name):
         """
         ...
 
@@ -188,10 +188,10 @@ class SmartPlugin(SmartObject, Utils):
 
         :note: Only available in SmartHomeNG versions **beyond** v1.3
 
-        :param classname: name of the plugin's class
-        :type classname: str
+        :param class_name: name of the plugin's class
+        :type class_name: str
         """
-        self._classname = classname
+        self._class_name = class_name
 
 
     def get_version(self, extended=False):

--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -269,7 +269,7 @@ class Plugins():
                 plugin_version = '._pv_' + plugin_version.replace('.','_')
 
         if class_name == '':
-            class_name = self.meta.get_string('class_name')
+            class_name = self.meta.get_string(KEY_CLASS_NAME)
         try:
             classpath = plg_conf[KEY_CLASS_PATH]
         except:

--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -129,20 +129,20 @@ class Plugins():
             if str(_conf[plugin].get('plugin_enabled', None)).lower() == 'false':
                 logger.info("Section {} (plugin_name {}) is disabled - Plugin not loaded".format(plugin, _conf[plugin].get('plugin_name', None)))
             elif self.meta.test_shngcompatibility():
-                classname, classpath = self._get_classname_and_classpath(_conf[plugin], plugin_name)
-                if (classname == '') and (classpath == ''):
+                class_name, classpath = self._get_class_name_and_classpath(_conf[plugin], plugin_name)
+                if (class_name == '') and (classpath == ''):
                     logger.error("Plugins, section {}: plugin_name is not defined".format(plugin))
-                elif classname == '':
+                elif class_name == '':
                     logger.error("Plugins, section {}: class_name is not defined".format(plugin))
                 elif classpath == '':
                     logger.error("Plugins, section {}: class_path is not defined".format(plugin))
                 else:
                     args = self._get_conf_args(_conf[plugin])
-#                    logger.warning("Plugin '{}' from from section '{}': classname = {}, classpath = {}".format( str(classpath).split('.')[1], plugin, classname, classpath ) )
+#                    logger.warning("Plugin '{}' from from section '{}': class_name = {}, classpath = {}".format( str(classpath).split('.')[1], plugin, class_name, classpath ) )
                     instance = self._get_instancename(_conf[plugin]).lower()
-                    dummy = self._test_duplicate_pluginconfiguration(plugin, classname, instance)
+                    dummy = self._test_duplicate_pluginconfiguration(plugin, class_name, instance)
                     try:
-                        plugin_thread = PluginWrapper(smarthome, plugin, classname, classpath, args, instance, self.meta, self._gtrans)
+                        plugin_thread = PluginWrapper(smarthome, plugin, class_name, classpath, args, instance, self.meta, self._gtrans)
                         if plugin_thread._init_complete == True:
                             try:
                                 self._plugins.append(plugin_thread.plugin)
@@ -249,27 +249,27 @@ class Plugins():
         return args
 
 
-    def _get_classname_and_classpath(self, plg_conf, plugin_name):
+    def _get_class_name_and_classpath(self, plg_conf, plugin_name):
         """
-        Returns the classname and the classpath for the actual plugin
+        Returns the class_name and the classpath for the actual plugin
 
         :param plg_conf: loaded section of the plugin.yaml for the actual plugin
         :param plugin_name: Plugin name (to be used, for building classpass, if it is not specified in the configuration
         :type plg_conf: dict
         :type plugin_name: str
 
-        :return: classname, classpass
+        :return: class_name, classpass
         :rtype: str, str
         """
-        classname = plg_conf.get(KEY_CLASS_NAME,'')
+        class_name = plg_conf.get(KEY_CLASS_NAME,'')
         plugin_version = ''
         if plugin_name == '':
             plugin_version = plg_conf.get('plugin_version','').lower()
             if plugin_version != '':
                 plugin_version = '._pv_' + plugin_version.replace('.','_')
 
-        if classname == '':
-            classname = self.meta.get_string('classname')
+        if class_name == '':
+            class_name = self.meta.get_string('class_name')
         try:
             classpath = plg_conf[KEY_CLASS_PATH]
         except:
@@ -277,8 +277,8 @@ class Plugins():
                 classpath = ''
             else:
                 classpath = 'plugins.' + plugin_name
-#        logger.warning("_get_classname_and_classpath: plugin_name = {}, classpath = {}, classname = {}".format(plugin_name, classpath, classname))
-        return (classname, classpath+plugin_version)
+#        logger.warning("_get_class_name_and_classpath: plugin_name = {}, classpath = {}, class_name = {}".format(plugin_name, classpath, class_name))
+        return (class_name, classpath+plugin_version)
 
 
     def _get_instancename(self, plg_conf):
@@ -299,14 +299,14 @@ class Plugins():
         return instance
 
 
-    def _test_duplicate_pluginconfiguration(self, plugin, classname, instance):
+    def _test_duplicate_pluginconfiguration(self, plugin, class_name, instance):
         """
-        Returns True, if a plugin instance of the classname is already loaded by another configuration section
+        Returns True, if a plugin instance of the class_name is already loaded by another configuration section
 
         :param plugin: Name of the configuration
-        :param classname: Name of the class to check
+        :param class_name: Name of the class to check
         :type plugin: str
-        :type classname: str
+        :type class_name: str
 
         :return: True, if plugin is already loaded
         :rtype: bool
@@ -319,14 +319,14 @@ class Plugins():
                 if p.get_instance_name() == instance:
                     for t in self._threads:
                         if t.plugin == p:
-                            if t.plugin.__class__.__name__ == classname:
+                            if t.plugin.__class__.__name__ == class_name:
                                 duplicate = True
                                 prev_plugin = t._name
                                 logger.warning("Plugin section '{}' uses same class '{}' and instance '{}' as plugin section '{}'".format(plugin, p.__class__.__name__, 'default' if instance == '' else instance, prev_plugin))
                                 break
 
-            elif p.__class__.__name__ == classname:
-                logger.warning("Multiple classic plugin instances of class '{}' detected".format(classname))
+            elif p.__class__.__name__ == class_name:
+                logger.warning("Multiple classic plugin instances of class '{}' detected".format(class_name))
         return duplicate
 
 
@@ -515,25 +515,25 @@ class PluginWrapper(threading.Thread):
 
     :param smarthome: Instance of the smarthome master-object
     :param name: Section name in plugin configuration file (etc/plugin.yaml)
-    :param classname: Name of the (main) class in the plugin
+    :param class_name: Name of the (main) class in the plugin
     :param classpath: Path to the Python file containing the class
     :param args: Parameter as specified in the configuration file (etc/plugin.yaml)
     :param instance: Name of the instance of the plugin
     :param meta:
     :type samrthome: object
     :type name: str
-    :type classname: str
+    :type class_name: str
     :type classpath: str
     :type args: dict
     :type instance: str
     :type meta: object
     """
 
-    def __init__(self, smarthome, name, classname, classpath, args, instance, meta, gtranslations):
+    def __init__(self, smarthome, name, class_name, classpath, args, instance, meta, gtranslations):
         """
         Initialization of wrapper class
         """
-        logger.debug('PluginWrapper __init__: Section {}, classname {}, classpath {}'.format( name, classname, classpath ))
+        logger.debug('PluginWrapper __init__: Section {}, class_name {}, classpath {}'.format( name, class_name, classpath ))
 
         threading.Thread.__init__(self, name=name)
 
@@ -550,7 +550,7 @@ class PluginWrapper(threading.Thread):
             logger.exception("Plugin '{}' exception during import of __init__.py: {}".format(name, e))
             return
         try:
-            exec("self.plugin = {0}.{1}.__new__({0}.{1})".format(classpath, classname))
+            exec("self.plugin = {0}.{1}.__new__({0}.{1})".format(classpath, class_name))
         except Exception as e:
             logger.exception("Plugin '{}' exception during execution of plugin: {}".format(name, e))
 
@@ -575,7 +575,7 @@ class PluginWrapper(threading.Thread):
 #            self.get_implementation()._config_section = name
             self.get_implementation()._set_shortname(str(classpath).split('.')[1])
             self.get_implementation()._classpath = classpath
-            self.get_implementation()._set_classname(classname)
+            self.get_implementation()._set_class_name(class_name)
             # if instance != '' war auskommentiert, reaktiviert: 26.01.2018 MS
             if self.get_implementation().ALLOW_MULTIINSTANCE is None:
                 self.get_implementation().ALLOW_MULTIINSTANCE = self.meta.get_bool('multi_instance')
@@ -596,15 +596,15 @@ class PluginWrapper(threading.Thread):
             self.get_implementation()._configname = name
             self.get_implementation()._shortname = str(classpath).split('.')[1]
             self.get_implementation()._classpath = classpath
-            self.get_implementation()._classname = classname
+            self.get_implementation()._class_name = class_name
             self.get_implementation()._plgtype = ''
         self.get_implementation()._itemlist = []
 
         # get arguments defined in __init__ of plugin's class to self.args
-        exec("self.args = inspect.getargspec({0}.{1}.__init__)[0][1:]".format(classpath, classname))
+        exec("self.args = inspect.getargspec({0}.{1}.__init__)[0][1:]".format(classpath, class_name))
 
         # get list of argument used names, if they are defined in the plugin's class
-        logger.debug("Plugin '{}': args = '{}'".format(classname, str(args)))
+        logger.debug("Plugin '{}': args = '{}'".format(class_name, str(args)))
         arglist = [name for name in self.args if name in args]
         argstring = ",".join(["{}={}".format(name, args[name]) for name in arglist])
 #        logger.debug("Plugin '{}' using arguments {}".format(str(classpath).split('.')[1], arglist))

--- a/modules/admin/README.md
+++ b/modules/admin/README.md
@@ -145,7 +145,7 @@ Startet die SmartHomeNG Server Instanz neu
 `dummy` is a loadlable module. Therefore there is no guarantiee that it is present in every system. Before you can use this module, you have to make sure ist is loaded. You can do it by calling a method of the main smarthome object. Do it like this:
 
 ```
-self.classname = self.__class__.__name__
+self.class_name = self.__class__.__name__
 
 try:
     self.mod_admin = self._sh.get_module('admin')
@@ -155,7 +155,7 @@ except:
 if self.mod_admin == None:
     # Do what is necessary if you can't use the admin interface
     # for your plugin. For example:
-    self.logger.error('{}: Module ''admin'' not loaded - Abort loading of plugin {0}'.format(self.classname))
+    self.logger.error('{}: Module ''admin'' not loaded - Abort loading of plugin {0}'.format(self.class_name))
     return
 ```
 

--- a/modules/admin/__init__.py
+++ b/modules/admin/__init__.py
@@ -181,7 +181,7 @@ class Admin():
             self.mod_http.register_webif(WebInterface( ... ), 
                                self.get_shortname(), 
                                config, 
-                               self.get_classname(), self.get_instance_name(),
+                               self.get_class_name(), self.get_instance_name(),
                                description,
                                webifname,
                                use_global_basic_auth)

--- a/modules/admin/api_plugins.py
+++ b/modules/admin/api_plugins.py
@@ -346,7 +346,7 @@ class PluginsInfoController(RESTResource):
                     plugin['attributes'].append(a_dict)
 
                 plugin['metadata']['classpath'] = x._classpath  # str
-                plugin['metadata']['classname'] = x.get_classname()
+                plugin['metadata']['class_name'] = x.get_class_name()
             else:
                 plugin['pluginname'] = x._shortname
                 plugin['configname'] = x._configname
@@ -359,7 +359,7 @@ class PluginsInfoController(RESTResource):
                 plugin['attributes'] = []
 
                 plugin['metadata']['classpath'] = str(x._classpath)  # str
-                plugin['metadata']['classname'] = str(x._classname)  # str
+                plugin['metadata']['class_name'] = str(x._class_name)  # str
                 plugin['stopped'] = False
 
             plugin['metadata']['type'] = x._metadata.get_string('type')

--- a/modules/admin/module.yaml
+++ b/modules/admin/module.yaml
@@ -1,7 +1,7 @@
 # Metadata for the plugin
 module:
     # Global module attributes
-    classname: Admin
+    class_name: Admin
     version: 1.6.0
     sh_minversion: 1.5b
 #    sh_maxversion: 1.3             # maximum shNG version to use this plugin (leave empty if latest)

--- a/modules/admin/webif/static/assets/testdata/api/config/default.json
+++ b/modules/admin/webif/static/assets/testdata/api/config/default.json
@@ -12,7 +12,7 @@
     },
     "meta": {
       "module": {
-        "classname": "None",
+        "class_name": "None",
         "version": "1.5.7",
         "description": {
           "de": "Core des SmartHomeNG Systems",
@@ -123,7 +123,7 @@
     },
     "meta": {
       "module": {
-        "classname": "Http",
+        "class_name": "Http",
         "version": "1.4.7",
         "sh_minversion": 1.4,
         "description": {
@@ -273,7 +273,7 @@
     },
     "meta": {
       "module": {
-        "classname": "Admin",
+        "class_name": "Admin",
         "version": "0.2.2",
         "sh_minversion": "1.5a",
         "description": {

--- a/modules/admin/webif/static/assets/testdata/api/plugins/config/default.json
+++ b/modules/admin/webif/static/assets/testdata/api/plugins/config/default.json
@@ -25,7 +25,7 @@
           "version": "1.4.13",
           "sh_minversion": "1.4e",
           "multi_instance": false,
-          "classname": "BackendServer"
+          "class_name": "BackendServer"
         },
         "parameters": {
           "updates_allowed": {
@@ -85,7 +85,7 @@
           "version": "1.4.0",
           "sh_minversion": "1.3b",
           "multi_instance": false,
-          "classname": "Blockly"
+          "class_name": "Blockly"
         },
         "parameters": {
           "section_prefix": {
@@ -129,7 +129,7 @@
           "sh_minversion": 1.4,
           "multi_instance": false,
           "restartable": "unknown",
-          "classname": "CLI"
+          "class_name": "CLI"
         },
         "parameters": {
           "update": {
@@ -264,7 +264,7 @@
           "version": "1.5.0",
           "sh_minversion": "1.4c",
           "multi_instance": false,
-          "classname": "Develop"
+          "class_name": "Develop"
         }
       },
       "_description": {
@@ -285,7 +285,7 @@
           "version": "1.5.0",
           "sh_minversion": "1.4c",
           "multi_instance": false,
-          "classname": "Logconf"
+          "class_name": "Logconf"
         }
       },
       "_description": {
@@ -312,7 +312,7 @@
           "sh_minversion": "1.4d",
           "multi_instance": true,
           "restartable": "unknown",
-          "classname": "Homematic"
+          "class_name": "Homematic"
         },
         "parameters": {
           "host": {
@@ -426,7 +426,7 @@
           "sh_minversion": 1.4,
           "multi_instance": true,
           "restartable": "unknown",
-          "classname": "KNX",
+          "class_name": "KNX",
           "attribute_prefix": "knx"
         },
         "parameters": {
@@ -980,7 +980,7 @@
           "version": "1.4.6",
           "sh_minversion": 1.4,
           "multi_instance": true,
-          "classname": "Mqtt"
+          "class_name": "Mqtt"
         },
         "parameters": {
           "host": {
@@ -1317,7 +1317,7 @@
           "sh_minversion": "1.4c",
           "multi_instance": false,
           "restartable": "unknown",
-          "classname": "Simulation"
+          "class_name": "Simulation"
         },
         "parameters": {
           "data_file": {
@@ -1387,7 +1387,7 @@
           "sh_minversion": 1.3,
           "multi_instance": true,
           "restartable": true,
-          "classname": "SmartVisu"
+          "class_name": "SmartVisu"
         },
         "parameters": {
           "smartvisu_dir": {
@@ -1613,7 +1613,7 @@
           "sh_minversion": 1.4,
           "multi_instance": false,
           "restartable": "unknown",
-          "classname": "TankerKoenig"
+          "class_name": "TankerKoenig"
         },
         "parameters": {
           "apikey": {
@@ -1735,7 +1735,7 @@
           "sh_minversion": "1.4c",
           "multi_instance": false,
           "restartable": "unknown",
-          "classname": "WebSocket"
+          "class_name": "WebSocket"
         },
         "parameters": {
           "ip": {
@@ -1974,7 +1974,7 @@
           "sh_minversion": "1.4c",
           "multi_instance": true,
           "restartable": "unknown",
-          "classname": "Wunderground"
+          "class_name": "Wunderground"
         },
         "parameters": {
           "apikey": {
@@ -2162,7 +2162,7 @@
           "sh_minversion": "1.4c",
           "multi_instance": true,
           "restartable": "unknown",
-          "classname": "Wunderground"
+          "class_name": "Wunderground"
         },
         "parameters": {
           "apikey": {
@@ -2340,7 +2340,7 @@
           "version": "1.4c.0",
           "sh_minversion": "1.3a",
           "multi_instance": false,
-          "classname": "Widgets"
+          "class_name": "Widgets"
         },
         "parameters": null,
         "item_attributes": null
@@ -2375,7 +2375,7 @@
           "version": "1.5.4",
           "sh_minversion": "1.4c",
           "multi_instance": true,
-          "classname": "AVM"
+          "class_name": "AVM"
         },
         "parameters": {
           "username": {
@@ -2649,7 +2649,7 @@
           "version": "1.5.4",
           "sh_minversion": "1.4c",
           "multi_instance": true,
-          "classname": "AVM"
+          "class_name": "AVM"
         },
         "parameters": {
           "username": {
@@ -2924,7 +2924,7 @@
           "sh_minversion": "1.3c",
           "multi_instance": true,
           "restartable": "unknown",
-          "classname": "Enigma2"
+          "class_name": "Enigma2"
         },
         "parameters": {
           "username": {
@@ -3215,7 +3215,7 @@
           "sh_minversion": "1.3c",
           "multi_instance": true,
           "restartable": "unknown",
-          "classname": "Enigma2"
+          "class_name": "Enigma2"
         },
         "parameters": {
           "username": {
@@ -3506,7 +3506,7 @@
           "sh_minversion": "1.3c",
           "multi_instance": true,
           "restartable": "unknown",
-          "classname": "Enigma2"
+          "class_name": "Enigma2"
         },
         "parameters": {
           "username": {
@@ -3786,7 +3786,7 @@
           "version": "1.3.0",
           "sh_minversion": "1.4c",
           "multi_instance": false,
-          "classname": "OperationLog"
+          "class_name": "OperationLog"
         },
         "parameters": null,
         "item_attributes": null
@@ -3824,7 +3824,7 @@
           "version": "1.4.2",
           "sh_minversion": "1.3c",
           "multi_instance": false,
-          "classname": "HUE"
+          "class_name": "HUE"
         },
         "parameters": {
           "hue_ip": {
@@ -3918,7 +3918,7 @@
             "de": "Implementierung von ...",
             "en": "GImplementation of ..."
           },
-          "classname": "Classic"
+          "class_name": "Classic"
         }
       }
     },
@@ -3944,7 +3944,7 @@
           "sh_minversion": "1.4c",
           "multi_instance": true,
           "restartable": "unknown",
-          "classname": "Database"
+          "class_name": "Database"
         },
         "parameters": {
           "driver": {
@@ -4553,7 +4553,7 @@
           "sh_minversion": 1.5,
           "multi_instance": false,
           "restartable": "unknown",
-          "classname": "WebServices"
+          "class_name": "WebServices"
         },
         "parameters": {
           "mode": {
@@ -4616,7 +4616,7 @@
           "sh_minversion": 1.1,
           "multi_instance": true,
           "restartable": "unknown",
-          "classname": "WakeOnLan"
+          "class_name": "WakeOnLan"
         },
         "parameters": "NONE",
         "item_attributes": {
@@ -4666,7 +4666,7 @@
           "version": "1.5.0",
           "sh_minversion": 1.4,
           "multi_instance": false,
-          "classname": "SamplePlugin"
+          "class_name": "SamplePlugin"
         }
       },
       "_description": {

--- a/modules/admin/webif/static/assets/testdata/api/plugins/info/default.json
+++ b/modules/admin/webif/static/assets/testdata/api/plugins/info/default.json
@@ -83,7 +83,7 @@
       "maintainer": "psilo",
       "tester": "msinn",
       "classpath": "plugins.homematic",
-      "classname": "Homematic",
+      "class_name": "Homematic",
       "sh_minversion": "",
       "sh_maxversion": ""
     },
@@ -175,7 +175,7 @@
       "maintainer": "psilo",
       "tester": "Sandman60, msinn",
       "classpath": "plugins.homematic",
-      "classname": "Homematic",
+      "class_name": "Homematic",
       "sh_minversion": "",
       "sh_maxversion": ""
   }
@@ -200,7 +200,7 @@
       "maintainer": "psilo",
       "tester": "Sandman60, msinn",
       "classpath": "plugins.homematic",
-      "classname": "Homematic",
+      "class_name": "Homematic",
       "sh_minversion": "",
       "sh_maxversion": ""
     }
@@ -246,7 +246,7 @@
       "maintainer": "msinn",
       "tester": "Sandman60",
       "classpath": "plugins.homematic",
-      "classname": "Homematic",
+      "class_name": "Homematic",
       "sh_minversion": "",
       "sh_maxversion": ""
     }
@@ -268,7 +268,7 @@
       "maintainer": "psilo",
       "tester": "ohinckel",
       "classpath": "plugins.homematic",
-      "classname": "Homematic",
+      "class_name": "Homematic",
       "sh_minversion": "",
       "sh_maxversion": ""
     }
@@ -290,7 +290,7 @@
       "maintainer": "msinn",
       "tester": "",
       "classpath": "plugins.homematic",
-      "classname": "Homematic",
+      "class_name": "Homematic",
       "sh_minversion": "",
       "sh_maxversion": ""
     }

--- a/modules/core/module.yaml
+++ b/modules/core/module.yaml
@@ -1,7 +1,7 @@
 # Metadata for the core parameter (etc/smarthome.yaml)
 module:
     # Global pseido-module attributes
-    classname: None
+    class_name: None
     version: 1.5.7
     description:
         de: 'Core des SmartHomeNG Systems'

--- a/modules/http/README.md
+++ b/modules/http/README.md
@@ -95,7 +95,7 @@ If set to **True, error-pages (except for error 404) will show the Python traceb
 `http` is a loadlable module. Therefore there is no guarantiee that it is present in every system. Before you can use this module, you have to make sure ist is loaded. You can do it by calling a method of the main smarthome object. Do it like this:
 
 ```
-self.classname = self.__class__.__name__
+self.class_name = self.__class__.__name__
 
 try:
     self.mod_http = self._sh.get_module('http')
@@ -105,7 +105,7 @@ except:
 if self.mod_http == None:
     # Do what is necessary if you can't start a web interface
     # for your plugin. For example:
-    self.logger.error('{}: Module ''http'' not loaded - Abort loading of plugin {0}'.format(self.classname))
+    self.logger.error('{}: Module ''http'' not loaded - Abort loading of plugin {0}'.format(self.class_name))
     return
 ```
 

--- a/modules/http/__init__.py
+++ b/modules/http/__init__.py
@@ -622,7 +622,7 @@ class Http():
             self.mod_http.register_webif(WebInterface( ... ),
                                self.get_shortname(),
                                config,
-                               self.get_classname(), self.get_instance_name(),
+                               self.get_class_name(), self.get_instance_name(),
                                description,
                                webifname,
                                use_global_basic_auth)
@@ -695,7 +695,7 @@ class Http():
             self.mod_http.register_service(Webservice( ... ),
                                    self.get_shortname(),
                                    config,
-                                   self.get_classname(), self.get_instance_name(),
+                                   self.get_class_name(), self.get_instance_name(),
                                    description,
                                    servicename,
                                    use_global_basic_auth)

--- a/modules/http/module.yaml
+++ b/modules/http/module.yaml
@@ -1,7 +1,7 @@
 # Metadata for the plugin
 module:
     # Global module attributes
-    classname: Http
+    class_name: Http
     version: 1.6.0
     sh_minversion: 1.5b
 #   sh_maxversion:              # maximum shNG version to use this plugin (leave empty if latest)

--- a/modules/mqtt/README.md
+++ b/modules/mqtt/README.md
@@ -86,7 +86,7 @@ If set to **True, error-pages (except for error 404) will show the Python traceb
 `mqtt` is a loadlable module. Therefore there is no guarantiee that it is present in every system. Before you can use this module, you have to make sure ist is loaded. You can do it by calling a method of the main smarthome object. Do it like this:
 
 ```
-self.classname = self.__class__.__name__
+self.class_name = self.__class__.__name__
 
 try:
     self.mod_mqtt = self._sh.get_module('mqtt')
@@ -96,7 +96,7 @@ except:
 if self.mod_mqtt == None:
     # Do what is necessary if you can't use the mqtt protocol
     # for your plugin. For example:
-    self.logger.error('{}: Module ''mqtt'' not loaded - Abort loading of plugin {0}'.format(self.classname))
+    self.logger.error('{}: Module ''mqtt'' not loaded - Abort loading of plugin {0}'.format(self.class_name))
     return
 ```
 

--- a/modules/mqtt/module.yaml
+++ b/modules/mqtt/module.yaml
@@ -1,7 +1,7 @@
 # Metadata for the plugin
 module:
     # Global plugin attributes
-    classname: Mqtt
+    class_name: Mqtt
     version: 1.5.0
     sh_minversion: 1.5
 #   sh_maxversion:              # maximum shNG version to use this plugin (leave empty if latest)

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -4,7 +4,7 @@
 #   |            DON'T EDIT THIS FILE               |
 #   |           THIS FILE IS GENERATED              |
 #   |       BY tools/build_requirements.py          |
-#   |            ON 03.05.2019 22:32                |
+#   |            ON 01.11.2019 15:46                |
 #   |                                               |
 #   |               INSTALL WITH:                   |
 #   | sudo pip3 install -r requirements/all.txt     |
@@ -37,6 +37,9 @@ minimalmodbus>=0.7
 # plugin withings_health
 nokia>=1.0.0,<=1.2.0
 
+# plugin uzsu
+numpy
+
 # plugin mqtt
 paho-mqtt>=1.2.2
 
@@ -45,6 +48,9 @@ psutil
 
 # plugin appletv
 pyatv==0.3.9
+
+# plugin stateengine
+pydotplus
 
 # plugin homematic
 pyhomematic>=0.1.28
@@ -55,15 +61,18 @@ pyjq
 # SmartHomeNG-module admin
 pyjwt>=1.6.4
 
+# plugin trovis557x
+pymodbus>=2.2.0
+
 # plugin avdevice
-# plugin priv_lintronic
 # plugin systemair
 # plugin dlms
-pyserial>=3.2.1
+# plugin thz
+pyserial>=3.4.0
 
 # SmartHomeNG-lib
-# plugin blockly
 # plugin backend
+# plugin blockly
 python-dateutil>=2.5.3
 
 # plugin pushbullet
@@ -71,6 +80,9 @@ python-magic>=0.4.12
 
 # plugin zwave
 python-openzwave>=0.4.0.35
+
+# plugin snap7_logo
+python-snap7>=0.10
 
 # plugin telegram
 python-telegram-bot>=9.0.0
@@ -98,20 +110,14 @@ ruamel.yaml>=0.13.7,<=0.15.74;python_version<'3.7'
 ruamel.yaml>0.15.0,<=0.15.74;python_version>='3.7'
 
 # plugin uzsu
-scipy>=1.1.0
+scipy>=1.1.0,<=1.2.1
 
-# plugin harmony
 # plugin xmpp
+# plugin harmony
 sleekxmpp>=1.3.1
-
-# plugin priv_telegram_1_1_3
-telepot>=8.3
 
 # plugin sonos
 tinytag>=0.18.0
-
-# plugin priv_telegram_1_1_3
-urllib3>=1.9.1
 
 # plugin smarttv
 websocket-client>=0.44.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #   |            DON'T EDIT THIS FILE               |
 #   |           THIS FILE IS GENERATED              |
 #   |       BY tools/build_requirements.py          |
-#   |            ON 03.05.2019 22:32                |
+#   |            ON 01.11.2019 15:46                |
 #   |                                               |
 #   |               INSTALL WITH:                   |
 #   | sudo pip3 install -r requirements/base.txt    |

--- a/tests/resources/module_dummy/module.yaml
+++ b/tests/resources/module_dummy/module.yaml
@@ -1,7 +1,7 @@
 # Metadata for the plugin
 module:
     # Global plugin attributes
-    classname: dummy
+    class_name: dummy
     version: 1.x.y
     sh_minversion: 1.3a
 #   sh_maxversion:              # maximum shNG version to use this plugin (leave empty if latest)

--- a/tests/resources/module_faulty/module.yaml
+++ b/tests/resources/module_faulty/module.yaml
@@ -1,7 +1,7 @@
 # Metadata for the plugin
 module:
     # Global plugin attributes
-    classname: dummy
+    class_name: dummy
     version: 1.x.yz
     sh_minversion: 1.3a
 #   sh_maxversion:              # maximum shNG version to use this plugin (leave empty if latest)

--- a/tests/resources/test_metadata/module.yaml
+++ b/tests/resources/test_metadata/module.yaml
@@ -1,7 +1,7 @@
 # Metadata for the plugin
 module:
     # Global plugin attributes
-    classname: test_metadata
+    class_name: test_metadata
     version: 1.x.y
     sh_minversion: 1.3a
 #   sh_maxversion:              # maximum shNG version to use this plugin (leave empty if latest)

--- a/tools/plugin_metadata_checker.py
+++ b/tools/plugin_metadata_checker.py
@@ -322,7 +322,7 @@ def display_metadata(plg, with_description):
         disp_formatted('Restartable', str(metadata['plugin'].get('restartable', '-')))
         disp_formatted('shNG min. Version', str(metadata['plugin'].get('sh_minversion', '-')))
         disp_formatted('shNG max. Version', str(metadata['plugin'].get('sh_maxversion', '-')))
-        disp_formatted('Classname', metadata['plugin'].get('classname', '-'))
+        disp_formatted('Classname', metadata['plugin'].get('class_name', '-'))
 
         disp_formatted('Maintainer', metadata['plugin'].get('maintainer', '-'))
         disp_formatted('Tester', metadata['plugin'].get('tester', '-'))
@@ -521,8 +521,8 @@ def check_metadata(plg, with_description, check_quiet=False, only_inc=False, lis
     else:
         if metadata['plugin'].get('version', None) == None:
             disp_error('No version number given', "Add 'version:' to the plugin section")
-        if metadata['plugin'].get('classname', None) == None:
-            disp_error('No classname for the plugin', "Add 'classname:' to the plugin section and set it to the name of the Python class that implements the plugin")
+        if metadata['plugin'].get('class_name', None) == None:
+            disp_error('No class_name for the plugin', "Add 'class_name:' to the plugin section and set it to the name of the Python class that implements the plugin")
 
         if metadata['plugin'].get('type', None) == None:
             disp_warning('No plugin type set', "Add 'type:' to the plugin section")


### PR DESCRIPTION
class_name should be written always the same - leads to confusion if it is sometimes spelled classname while meaning the same thing. Best example: https://knx-user-forum.de/forum/supportforen/smarthome-py/1422178-class_name-und-classname-konsolidierung-der-schreibweisen - this has to be merged together with the changes in the plugins (see https://github.com/smarthomeNG/plugins/pull/293)!