### PR TITLE
Update shtime.py

### DIFF
--- a/lib/shtime.py
+++ b/lib/shtime.py
@@ -1001,9 +1001,9 @@ class Shtime:
 
     def is_weekend(self, date=None):
         """
-        Returns True, if the date is a holiday
-
-        Note: Easter sunday is not concidered a holiday (since it is a sunday already)!
+        Returns True, if the date is on a weekend
+        
+        Note: Easter sunday is not considered a holiday (since it is a sunday already)!
 
         :param date: date for which the weekday should be returned. If not specified, today is used
         :type date: str|datetime.datetime|datetime.date|int|float


### PR DESCRIPTION
The differentiation between is_weekend ("if the date is a holiday") and is_holiday ("if the date is a holiday [...]") is not succinct, especially as "holidays" are expressly used in contrast to weekends in this module.

"holiday" isn't wrong for weekend days per se, but this seems misleading at first glance. As this is transferred to the documentation, where you maybe don't want to check the code, the change proposal might clarify this.

Additionally, fixed a typo