### PR TITLE
Adjusted smartvisu to lowercase.

### DIFF
--- a/doc/user/source/installation/komplettanleitung/04_smartvisu.rst
+++ b/doc/user/source/installation/komplettanleitung/04_smartvisu.rst
@@ -60,7 +60,7 @@ Zugriff auf die SmartVISU testen
 ================================
 
 Mit einem Browser kann nun erstmals auf die SmartVISU zugegriffen werden: Hierbei ist ``<ip-des-servers>`` natürlich
-mit der IP oder dem Hostnamen deines SmartVISU Servers ersetzen: ``http://<ip-des-servers>/smartVISU``.
+mit der IP oder dem Hostnamen deines SmartVISU Servers ersetzen: ``http://<ip-des-servers>/smartvisu``.
 Bei **Checking your configuration** sollte alles mit einem grünen Haken versehen sein. Falls nicht, sind die
 entsprechenden Änderungen vorzunehmen **bevor man weiter macht**.
 


### PR DESCRIPTION
I installed smarthomeNG from scratch, following the Komplettanleitung on a Raspberry Pi. The URL to access the smartVISU is case sensitive here. Since the Komplettanleitung creates a folder named "smartvisu" (lowercase), the URL in the browser needs to be lowercase as well (at least if smartVISU is installed on a linux environment).