### PR TITLE
doc: updated description for items/eval and items/cycle

### DIFF
--- a/doc/user/source/referenz/items/standard_attribute/cycle.rst
+++ b/doc/user/source/referenz/items/standard_attribute/cycle.rst
@@ -10,7 +10,8 @@ der verknüpften Logik oder Eval-Funktion).
 .. code-block:: yaml
 
    item:
-       cycle: 10
+       type: num
+       cycle: 10 = 0
        enforce_updates: 'true'
 
 ruft das Item alle 10 Sekunden auf und sorgt dadurch für das triggern
@@ -18,17 +19,18 @@ von verknüpften Logiken und/oder Eval-Funktionen. Dazu muss
 ``enforce_updates`` auf ``true``\ stehen, damit das Triggern erfolgt,
 auch wenn sich der Wert des Items nicht ändert.
 
-.. code-block:: yaml
-
-   item:
-       type: num
-       cycle: 10 = 0
-   #    enforce_updates: true
-
-setzt alle 10 Sekunden den Wert des Items auf 0. Wenn mit diesem Item
+Gleichzeitig wird bei jedem Aufruf von ``cycle``, also hier alle 10 Sekunden, der Wert des Items auf 0 gesetzt. Wenn mit diesem Item
 Logiken und/oder Eval-Funktionen verknüpft sind, muss
 ``enforce_updates`` auf ``true``\ stehen, damit das Triggern erfolgt,
 auch wenn sich der Wert des Items nicht ändert.
+
+.. hint:
+
+  Die Syntax ``cycle: 10 = None`` versucht, den Wert ``None`` zuzuweisen und nicht,
+  wie bei ``eval``, den Wert des Items nicht zu verändern.
+
+  Die Zuweisung von ``None`` zu einem `num` oder `bool`-Item erzeugt eine Warnung, weil ``None`` nicht in `num` oder `bool` konvertiert werden kann. Wenn das Item den Typ `str` hat, wird der Wert ``"None"`` zugewiesen!
+
 
 Bitte beachten: `Datentyp der
 Wertzuweisung <#datentyp-der-wertzuweisung>`__

--- a/doc/user/source/referenz/items/standard_attribute/cycle.rst
+++ b/doc/user/source/referenz/items/standard_attribute/cycle.rst
@@ -26,8 +26,7 @@ auch wenn sich der Wert des Items nicht ändert.
 
 .. hint:
 
-  Die Syntax ``cycle: 10 = None`` versucht, den Wert ``None`` zuzuweisen und nicht,
-  wie bei ``eval``, den Wert des Items nicht zu verändern.
+  Die Syntax ``cycle: 10 = None`` funktioniert nicht so, wie das bei ``eval: None`` funktioniert. Es gibt keine Möglichkeit, mit ``cycle`` nur zu triggern, aber keinen neuen Wert zuzuweisen.
 
   Die Zuweisung von ``None`` zu einem `num` oder `bool`-Item erzeugt eine Warnung, weil ``None`` nicht in `num` oder `bool` konvertiert werden kann. Wenn das Item den Typ `str` hat, wird der Wert ``"None"`` zugewiesen!
 

--- a/doc/user/source/referenz/items/standard_attribute/eval.rst
+++ b/doc/user/source/referenz/items/standard_attribute/eval.rst
@@ -253,3 +253,5 @@ den Ausdruck **sh.self.prev_value()** zugegriffen werden.
    Wenn man jedoch ein Item nur verändern möchte wenn die **if** Bedingung erfüllt ist und sonst
    unverändert lassen möchte, muss als **else** Zweig der Ausdruck **else None** angegeben werden.
    **None** bewirkt, dass das Item unverändert bleibt, und somit auch keine Trigger ausgelöst werden.
+
+   Diese Art, per ``None`` Werte nicht zuzuweisen, funktioniert **nur** bei ``eval``; bei anderen Attributen wie z.B. ``cycle`` kann dies nicht genutzt werden.


### PR DESCRIPTION
cycle: changed example in regard to syntax "cycle: duration = value" and added hint that None doesn't work as with eval

eval: added hint that None only works with eval, not with e.g. cycle