### PR TITLE
Mqtt: locking cleanup and deadlock fix

### DIFF
--- a/lib/model/mqttplugin.py
+++ b/lib/model/mqttplugin.py
@@ -67,14 +67,11 @@ class MqttPlugin(SmartPlugin):
         Should be called from the run method of a plugin
         """
         if self.mod_mqtt:
-            # lock
-            self._subscribed_topics_lock.acquire()
-            for topic in self._subscribed_topics:
-                # start subscription to all items for this topic
-                for item_path in self._subscribed_topics[topic]:
-                    self._start_subscription(topic, item_path)
-            # unlock
-            self._subscribed_topics_lock.release()
+            with self._subscribed_topics_lock:
+                for topic in self._subscribed_topics:
+                    # start subscription to all items for this topic
+                    for item_path in self._subscribed_topics[topic]:
+                        self._start_subscription(topic, item_path)
 
             self._subscriptions_started = True
         return
@@ -86,16 +83,13 @@ class MqttPlugin(SmartPlugin):
         Should be called from the stop method of a plugin
         """
         if self.mod_mqtt:
-            # lock
-            self._subscribed_topics_lock.acquire()
-            for topic in self._subscribed_topics:
-                # stop subscription to all items for this topic
-                for item_path in self._subscribed_topics[topic]:
-                    current = str(self._subscribed_topics[topic][item_path]['current'])
-                    self.logger.info("stop(): Unsubscribing from topic {} for item {}".format(topic, item_path))
-                    self.mod_mqtt.unsubscribe_topic(self.get_shortname() + '-' + current, topic)
-            # unlock
-            self._subscribed_topics_lock.release()
+            with self._subscribed_topics_lock:
+                for topic in self._subscribed_topics:
+                    # stop subscription to all items for this topic
+                    for item_path in self._subscribed_topics[topic]:
+                        current = str(self._subscribed_topics[topic][item_path]['current'])
+                        self.logger.info("stop(): Unsubscribing from topic {} for item {}".format(topic, item_path))
+                        self.mod_mqtt.unsubscribe_topic(self.get_shortname() + '-' + current, topic)
             self._subscriptions_started = False
         return
 
@@ -125,31 +119,27 @@ class MqttPlugin(SmartPlugin):
         :return:
         """
 
-        # lock
-        self._subscribed_topics_lock.acquire()
+        with self._subscribed_topics_lock:
 
-        # test if topic is new
-        if not self._subscribed_topics.get(topic, None):
-            self._subscribed_topics[topic] = {}
-        # add this item to topic
-        if item is None:
-            item_path = '*no_item*'
-        else:
-            item_path = item.path()
-        self._subscribed_topics[topic][item_path] = {}
-        self._subscribe_current_number += 1
-        self._subscribed_topics[topic][item_path]['current'] = self._subscribe_current_number
-        self._subscribed_topics[topic][item_path]['item'] = item
-        self._subscribed_topics[topic][item_path]['qos'] = None
-        self._subscribed_topics[topic][item_path]['payload_type'] = payload_type
-        if callback:
-            self._subscribed_topics[topic][item_path]['callback'] = callback
-        else:
-            self._subscribed_topics[topic][item_path]['callback'] = self._on_mqtt_message
-        self._subscribed_topics[topic][item_path]['bool_values'] = bool_values
-
-        # unlock
-        self._subscribed_topics_lock.release()
+            # test if topic is new
+            if not self._subscribed_topics.get(topic, None):
+                self._subscribed_topics[topic] = {}
+            # add this item to topic
+            if item is None:
+                item_path = '*no_item*'
+            else:
+                item_path = item.path()
+            self._subscribed_topics[topic][item_path] = {}
+            self._subscribe_current_number += 1
+            self._subscribed_topics[topic][item_path]['current'] = self._subscribe_current_number
+            self._subscribed_topics[topic][item_path]['item'] = item
+            self._subscribed_topics[topic][item_path]['qos'] = None
+            self._subscribed_topics[topic][item_path]['payload_type'] = payload_type
+            if callback:
+                self._subscribed_topics[topic][item_path]['callback'] = callback
+            else:
+                self._subscribed_topics[topic][item_path]['callback'] = self._on_mqtt_message
+            self._subscribed_topics[topic][item_path]['bool_values'] = bool_values
 
         if self._subscriptions_started:
             # directly subscribe to added subscription, if subscribtions are started


### PR DESCRIPTION
I was wondering why stopping of SmarthomeNG takes so long and still ends in a kill.
I found several vulnerable locations and a deadlock in mqtt module.

Commit 1: "mqtt: fixed locking problems; use with for locking"
This is replacing the correct pattern
```
lock
try:
  ...
  do_something()
  ...
finally:
  unlock
```
and the wrong pattern 
```
lock
...
do_somthing()
...
unlock
```
with "with"
```
with lock:
  ...
  do_somthing()
  ...
```
Using with here has the advantage that it is easier to handle because you can't forget the unlock und even better you can't forget the "try:   finally: ",
This commit fixes therefore several parts where locking/unlocking was done without "try: finally:" which leads to left locks in case of exceptions. That means mostly the code will work, but in (rare) error cases it keeps locked and stops working. These bugs are hard to find.

Commit 2: "mqtt: Avoid deadlock"
This fixes a deadlock which happend in my installation on nearly every shutdown. The problem is the self._subscribed_topics_lock. This lock is used in a callback from the mqtt lib ` _on_mqtt_message()`. The mqtt lib itself is using own locks inside of it. The deadlock happens when mqtt receives messages from the broker while unsubscribe is called. The lock is held before `unsubscribe()` is called. On message receive some internal mqtt locks are held and when it reaches the lock aquire in `_on_mqtt_message()` it waits for this lock. The lock would be released when unsubscribe is finished, but unsubscribe can't finish because it wants to send a message to the broker. For sending this message it needs a lock inside mqtt which is held by the message receive.

That means the deadlock will happen when it receives messages while unsubscribing. The more messages it receive the higher is the possibility to get into this situation.
The fix avoids the lock before calling unsubscribe.