### PR TITLE
Update item.py

### DIFF
--- a/lib/item/item.py
+++ b/lib/item/item.py
@@ -1546,7 +1546,7 @@ class Item():
         return self.__methods_to_trigger
 
 
-    def timer(self, time, value, auto=False, compat=ATTRIB_COMPAT_DEFAULT):
+    def timer(self, time, value, auto=False, compat=ATTRIB_COMPAT_DEFAULT, source=None):
         time = self._cast_duration(time)
         value = self._castvalue_to_itemtype(value, compat)
         if auto:
@@ -1555,7 +1555,10 @@ class Item():
         else:
             caller = 'Timer'
         next = self.shtime.now() + datetime.timedelta(seconds=time)
-        self._sh.scheduler.add(self._itemname_prefix+self.id() + '-Timer', self.__call__, value={'value': value, 'caller': caller}, next=next)
+        if source is None:
+            self._sh.scheduler.add(self._itemname_prefix+self.id() + '-Timer', self.__call__, value={'value': value, 'caller': caller}, next=next)
+        else:
+            self._sh.scheduler.add(self._itemname_prefix+self.id() + '-Timer', self.__call__, value={'value': value, 'caller': caller, 'source': source}, next=next)
 
 
     def remove_timer(self):


### PR DESCRIPTION
Added attribute source to timer function.

Using the attribute 'source' of an item function, it is possible to determine
who triggered an item change from the backend, and from within custom logics,
e.g. sh.EG.Bathroom.Light(1, source='automatic_lightning.py')

Unfortunatley this is not implemented for the timer function,
i.e.
sh.EG.Bathroom.Light.timer('30', 1, source='automatic_lightning.py')
won't work.

This code change adds the optional argument source to the timer function and calls the corresponding scheduler function
with the source argument
if a source has been specified.