### PR TITLE
lib.items: optionally return items sorted

### DIFF
--- a/lib/item/items.py
+++ b/lib/item/items.py
@@ -292,16 +292,23 @@ class Items():
             return self.__item_dict[string]
 
 
-    def return_items(self):
+    def return_items(self, sorted=False):
         """
         Function to return a list with all defined items
+
+        :param sorted: return list sorted alphabetically, defaults to False
+        :type sorted: bool
 
         :return: List of all items
         :rtype: list
         """
 
-        for item in self.__items:
-            yield self.__item_dict[item]
+        if sorted:
+            for item in sorted(self.__items):
+                yield self.__item_dict[item]
+        else:
+            for item in self.__items:
+                yield self.__item_dict[item]
 
 
     def match_items(self, regex):


### PR DESCRIPTION
Items.return_items() returns a list of path names for all items registered in shng.

As return_items() is a generator, sorting the item paths "afterwards" would comprise collecting all iterated items, building a list, sorting it and iterating again.

This patch enables getting a sorted list in the first place. The data structures in the Items class remain unchanged; only the list of item paths is returned alphabetically, which also means shorter item paths first, so the item tree is traversed from the root item down, ensuring every parent item is returned before its children.

Overhead for calling return_item() is a single if-statement checking for the (default false) boolean parameter.