### PR TITLE
lib.item: introduce new property last_trigger(_by/_age)

### DIFF
--- a/doc/user/source/referenz/items/funktionen.rst
+++ b/doc/user/source/referenz/items/funktionen.rst
@@ -47,26 +47,55 @@ genutzt werden können.
 
 
 Weiterhin werden die folgenden Funktionen unterstützt, die jedoch **ab SmartHomeNG v1.6** nicht mehr genutzt werden sollen.
-Bitte stattdessen die entsprechenden in SmartHomeNG v1.6 eingeführten Properties benutzen.
+Bitte stattdessen die entsprechenden in SmartHomeNG v1.6 eingeführten :doc:`Properties </referenz/items/properties>` benutzen.
 
 +------------------------+------------------------------------------------------------------------------+
 | **Funktion**           | **Beschreibung**                                                             |
 +========================+==============================================================================+
 | id()                   | Liefert den item-Pfad des Items zurück. Aufruf: sh.item.id()                 |
 +------------------------+------------------------------------------------------------------------------+
+| ()                     | Liefert den aktuellen Wert des Items zurück. Aufruf: sh.item()               |
++------------------------+------------------------------------------------------------------------------+
+| prev_value()           | Liefert den Wert des Items zurück, den es vor der letzten Änderung hatte.    |
++------------------------+------------------------------------------------------------------------------+
 | last_update()          | Liefert ein *datetime* Objekt mit dem Zeitpunkt des letzten Updates des      |
 |                        | Items zurück. Im Gegensatz zu **last_change()** wird dieser Zeitstempel auch |
+|                        | verändert, wenn sich bei einem Update der Wert des Items nicht ändert.       |
++------------------------+------------------------------------------------------------------------------+
+| prev_update()          | Liefert ein *datetime* Objekt mit dem Zeitpunkt des vorletzten Updates des   |
+|                        | Items zurück. Im Gegensatz zu **prev_change()** wird dieser Zeitstempel auch |
 |                        | verändert, wenn sich bei einem Update der Wert des Items nicht ändert.       |
 +------------------------+------------------------------------------------------------------------------+
 | last_change()          | Liefert ein *datetime* Objekt mit dem Zeitpunkt der letzten Änderung des     |
 |                        | Items zurück.                                                                |
 +------------------------+------------------------------------------------------------------------------+
-| age()                  | Liefert das Alter des Items seit der letzten Änderung des Wertes in Sekunden |
-|                        | zurück.                                                                      |
+| prev_change()          | Liefert ein *datetime* Objekt mit dem Zeitpunkt der vorletzten Änderung des  |
+|                        | Items zurück.                                                                |
++------------------------+------------------------------------------------------------------------------+
+| last_trigger()         | Liefert ein *datetime* Objekt mit dem Zeitpunkt der letzten eval Triggerung  |
+|                        | des Items zurück. Hat das Item kein eval Attribut oder wurde es nicht        |
+|                        | getriggert, wird der Zeitpunkt des letzten Updates übermittelt.              |
+|                        | (Neu **ab SmartHomeNG v1.9.1**)                                              |
++------------------------+------------------------------------------------------------------------------+
+| prev_trigger()         | Liefert ein *datetime* Objekt mit dem Zeitpunkt der vorletzten eval          |
+|                        | Triggerung des Items zurück. (Neu **ab SmartHomeNG v1.9.1**)                 |
 +------------------------+------------------------------------------------------------------------------+
 | update_age()           | Liefert das Alter des Items seit dem letzten Update in Sekunden zurück. Das  |
 |                        | Update Age wird auch gesetzt, wenn sich bei einem Update der Wert des Items  |
 |                        | nicht ändert. (Neu **ab SmartHomeNG v1.4**)                                  |
++------------------------+------------------------------------------------------------------------------+
+| prev_update_age()      | Liefert das Alter des vorangegangenen Updates in Sekunden zurück.            |
++------------------------+------------------------------------------------------------------------------+
+| age()                  | Liefert das Alter des Items seit der letzten Änderung des Wertes in Sekunden |
+|                        | zurück.                                                                      |
++------------------------+------------------------------------------------------------------------------+
+| prev_age()             | Liefert das Alter des vorangegangenen geänderten Wertes in Sekunden zurück.  |
++------------------------+------------------------------------------------------------------------------+
+| trigger_age()          | Liefert das Alter der letzten Eval Triggerung in Sekunden zurück.            |
+|                        | (Neu **ab SmartHomeNG v1.9.1**)                                              |
++------------------------+------------------------------------------------------------------------------+
+| prev_trigger_age()     | Liefert das Alter der vorletzten Eval Triggerung in Sekunden zurück.         |
+|                        | (Neu **ab SmartHomeNG v1.9.1**)                                              |
 +------------------------+------------------------------------------------------------------------------+
 | changed_by()           | Liefert einen String zurück, der auf das Objekt hinweist, welches das Item   |
 |                        | zuletzt geändert hat.                                                        |
@@ -74,19 +103,11 @@ Bitte stattdessen die entsprechenden in SmartHomeNG v1.6 eingeführten Propertie
 | updated_by()           | Liefert einen String zurück, der auf das Objekt hinweist, durch welches      |
 |                        | das Item zuletzt ein Update erfahren hat.                                    |
 +------------------------+------------------------------------------------------------------------------+
-| prev_value()           | Liefert den Wert des Items zurück, den es vor der letzten Änderung hatte.    |
+| triggered_by()         | Liefert einen String zurück, der auf das Objekt hinweist, durch welches      |
+|                        | eine eventuell vorhandene eval Expression getriggert wurde.                  |
+|                        | (Neu **ab SmartHomeNG v1.9.1**)                                              |
 +------------------------+------------------------------------------------------------------------------+
-| prev_update()          | Liefert ein *datetime* Objekt mit dem Zeitpunkt des vorletzten Updates des   |
-|                        | Items zurück. Im Gegensatz zu **prev_change()** wird dieser Zeitstempel auch |
-|                        | verändert, wenn sich bei einem Update der Wert des Items nicht ändert.       |
-+------------------------+------------------------------------------------------------------------------+
-| prev_change()          | Liefert ein *datetime* Objekt mit dem Zeitpunkt der vorletzten Änderung des  |
-|                        | Items zurück.                                                                |
-+------------------------+------------------------------------------------------------------------------+
-| prev_update_age()      | Liefert das Alter des vor-vorangegangenen Wertes in Sekunden zurück.         |
-+------------------------+------------------------------------------------------------------------------+
-| prev_age()             | Liefert das Alter des vorangegangenen Wertes in Sekunden zurück.             |
-+------------------------+------------------------------------------------------------------------------+
+
 
 
 Beispiele für die Nutzung von Funktionen
@@ -115,3 +136,11 @@ Die folgende Beispiel Logik nutzt einige der oben beschriebenen Funktionen:
 
    # will in- or decrement the living room light to 100 by a stepping of ``1`` and a timedelta of ``2.5`` seconds.
    sh.living.light.fade(100, 1, 2.5)
+
+Der folgende Beispiel eval Ausdruck sorgt dafür, dass ein Item den zugewiesenen Wert nur dann übernimmt,
+wenn die Wertänderung bzw. das Anstoßen der eval Funktion über das Admin Interface erfolgt ist und das
+letzte Update vor der aktuellen Triggerung über 10 Sekunden zurück liegt.
+
+.. code-block:: python
+
+  eval: value if sh..self.triggered_by().startswith('admin') and sh..self.update_age() > 10 else None

--- a/doc/user/source/referenz/items/properties.rst
+++ b/doc/user/source/referenz/items/properties.rst
@@ -13,6 +13,7 @@ genutzt werden können. Alle Properties sind zumindest lesend (r/o) zugreifbar. 
 auch beschrieben (r/w) werden.
 
 Properties sind **ab SmartHomeNG v1.6** verfügbar.
+Die Properties ``last/prev_trigger(_by/_age)`` sind **ab SmartHomeNG v1.9.1** verfügbar.
 
 
 Properties werden in Logiken und eval-Ausdrücken folgendermaßen abgerufen:
@@ -61,6 +62,15 @@ Werte für Properties, die auch geschrieben werden können (z.B. in Logiken), we
 | last_change_by       | r/o        | str      | Liefert einen String zurück, der auf das Objekt hinweist, welches das Item   |
 |                      |            |          | zuletzt geändert hat.                                                        |
 +----------------------+------------+----------+------------------------------------------------------------------------------+
+| last_trigger         | r/o        | datetime | Liefert ein *datetime* Objekt mit dem Zeitpunkt der letzten eval Triggerung  |
+|                      |            |          | des Items zurück. Hat das Item kein eval Attribut oder wurde es nicht        |
+|                      |            |          | getriggert, wird der Zeitpunkt des letzten Updates übermittelt.              |
++----------------------+------------+----------+------------------------------------------------------------------------------+
+| last_trigger_age     | r/o        | float    | Liefert das Alter der letzten Eval Triggerung in Sekunden zurück.            |
++----------------------+------------+----------+------------------------------------------------------------------------------+
+| last_trigger_by      | r/o        | str      | Liefert einen String zurück, der auf das Objekt hinweist, durch welches      |
+|                      |            |          | eine eventuell vorhandene eval Expression getriggert wurde.                  |
++----------------------+------------+----------+------------------------------------------------------------------------------+
 | last_update          | r/o        | datetime | Liefert ein *datetime* Objekt mit dem Zeitpunkt des letzten Updates des      |
 |                      |            |          | Items zurück. Im Gegensatz zu **last_change()** wird dieser Zeitstempel auch |
 |                      |            |          | verändert, wenn sich bei einem Update der Wert des Items nicht ändert.       |
@@ -95,19 +105,27 @@ Werte für Properties, die auch geschrieben werden können (z.B. in Logiken), we
 | prev_change          | r/o        | datetime | Liefert ein *datetime* Objekt mit dem Zeitpunkt der vorletzten Änderung des  |
 |                      |            |          | Items zurück.                                                                |
 +----------------------+------------+----------+------------------------------------------------------------------------------+
-| prev_change_age      | r/o        | float    | Liefert das Alter des vorangegangenen Wertes in Sekunden zurück.             |
+| prev_change_age      | r/o        | float    | Liefert das Alter des vorangegangenen (geänderten) Wertes in Sekunden zurück.|
 +----------------------+------------+----------+------------------------------------------------------------------------------+
 | prev_change_by       | r/o        | str      | Liefert einen String zurück, der auf das Objekt hinweist, welches das Item   |
-|                      |            |          | das vorletzte mal geändert hat.                                              |
+|                      |            |          | das vorletzte Mal geändert hat.                                              |
++----------------------+------------+----------+------------------------------------------------------------------------------+
+| prev_trigger         | r/o        | datetime | Liefert ein *datetime* Objekt mit dem Zeitpunkt der vorletzten eval          |
+|                      |            |          | Triggerung des Items zurück.                                                 |
++----------------------+------------+----------+------------------------------------------------------------------------------+
+| prev_trigger_age     | r/o        | float    | Liefert das Alter der vorletzten Eval Triggerung in Sekunden zurück.         |
++----------------------+------------+----------+------------------------------------------------------------------------------+
+| prev_trigger_by      | r/o        | str      | Liefert einen String zurück, der auf das Objekt hinweist, durch welches      |
+|                      |            |          | eine eventuell vorhandene eval Expression das vorletzte Mal ausgelöst wurde. |
 +----------------------+------------+----------+------------------------------------------------------------------------------+
 | prev_update          | r/o        | datetime | Liefert ein *datetime* Objekt mit dem Zeitpunkt des vorletzten Updates des   |
 |                      |            |          | Items zurück. Im Gegensatz zu **prev_change()** wird dieser Zeitstempel auch |
 |                      |            |          | verändert, wenn sich bei einem Update der Wert des Items nicht ändert.       |
 +----------------------+------------+----------+------------------------------------------------------------------------------+
-| prev_update_age      | r/o        | float    | Liefert das Alter des vor-vorangegangenen Wertes in Sekunden zurück.         |
+| prev_update_age      | r/o        | float    | Liefert das Alter des vorangegangenen Updates in Sekunden zurück.            |
 +----------------------+------------+----------+------------------------------------------------------------------------------+
 | prev_update_by       | r/o        | str      | Liefert einen String zurück, der auf das Objekt hinweist, durch welches das  |
-|                      |            |          | Item das vorletzte mal ein Update erfahren hat.                              |
+|                      |            |          | Item das vorletzte Mal ein Update erfahren hat.                              |
 +----------------------+------------+----------+------------------------------------------------------------------------------+
 | prev_value           | r/o        | str      | Liefert den Wert des Items zurück, den es vor der vorletzten Änderung hatte. |
 +----------------------+------------+----------+------------------------------------------------------------------------------+
@@ -129,3 +147,11 @@ Werte für Properties, die auch geschrieben werden können (z.B. in Logiken), we
 |                      |            |          | **schaltaktor** zugegriffen werden: **schaltaktor.property.knx_send**        |
 |                      |            |          | Dyn. Properties sind erst in SmartHomeNG Releases nach v1.6.1 implementiert. |
 +----------------------+------------+----------+------------------------------------------------------------------------------+
+
+Der folgende Beispiel eval Ausdruck sorgt dafür, dass ein Item den zugewiesenen Wert nur dann übernimmt,
+wenn die Wertänderung bzw. das Anstoßen der eval Funktion über das Admin Interface erfolgt ist und das
+letzte Update vor der aktuellen Triggerung über 10 Sekunden zurück liegt.
+
+.. code-block:: python
+
+  eval: value if sh..self.property.last_trigger_by == 'admin' and sh..self.property.last_update_age > 10 else None

--- a/doc/user/source/referenz/items/standard_attribute/eval.rst
+++ b/doc/user/source/referenz/items/standard_attribute/eval.rst
@@ -255,3 +255,35 @@ den Ausdruck **sh..self.prev_value()** zugegriffen werden.
    **None** bewirkt, dass das Item unverändert bleibt, und somit auch keine Trigger ausgelöst werden.
 
    Diese Art, per ``None`` Werte nicht zuzuweisen, funktioniert **nur** bei ``eval``; bei anderen Attributen wie z.B. ``cycle`` kann dies nicht genutzt werden.
+
+
+Abfrage des Auslösers eines **eval** Ausdrucks
+----------------------------------------------
+
+Zu dem Zeitpunkt, wo ein **eval** Ausdruck ausgeführt wird, bezieht sich das Property ``last_update_by`` **nicht** auf
+die aktuellste Auslösung des Items, sondern auf das letzte Update davor. Möchte man nun aber abfragen, durch welches
+Item, Plugin oder durch welche Logik die Ausführung des eval Ausdrucks angestoßen wurde,
+muss das seit SmartHomeNG 1.9.1 implementierte Property ``last_trigger_by`` genutzt werden.
+
+Dabei findet folgender zeitlicher Ablauf statt:
+
+    - Aktualisieren des Itemwerts oder Veränderung eines Triggeritems (eval_trigger)
+    - Setzen und Aktualisieren der ``last_trigger_by`` und dazu passenden Properties
+    - Ausführen des eval Ausdrucks
+    - Ist das Ergebnis des eval Ausdrucks **None**, passiert nichts weiter. Das Item wird nicht aktualisiert,
+      ``last_update_by`` ändert sich ebenfalls nicht.
+    - Ist das Ergebnis des eval Ausdrucks ein erlaubter Wert, wird dieser ins Item geschrieben.
+      ``last_update_by`` und/oder ``last_change_by`` werden entsprechend aktualisiert.
+
+Details zu den verschiedenen Abfragemöglichkeiten sind unter :doc:`Properties </referenz/items/properties>` zu finden.
+
+.. attention::
+
+   Möchte man in einem **eval** Ausdruck abfragen, wodurch der Ausdruck ausgelöst wurde, muss **property.last_trigger_by**
+   genutzt werden. Das **property.last_update_by** wird erst danach (oder bei None gar nicht) aktualisiert.
+
+.. tip::
+
+  War die Auflösung eines **eval** Ausdrucks nicht erfolgreich (weil z.B. die Syntax falsch ist oder ein Item nicht
+  gefunden werden konnte), wird beim ``last_trigger_by`` den Caller- und Source-Angaben noch ein None (als "dest") hinten
+  angehängt. Der Wert beinhaltet somit ``<caller>:<source>:None``.

--- a/lib/item/property.py
+++ b/lib/item/property.py
@@ -312,6 +312,57 @@ class Property:
         return
 
     @property
+    def last_trigger(self):
+        """
+        Read-Only Property: last_trigger
+
+        Available in SmartHomeNG v1.9.1 and above
+
+        :return: path of the item
+        :rtype: str
+        """
+        return self._item._get_last_trigger()
+
+    @last_trigger.setter
+    def last_trigger(self, value):
+        self._ro_error()
+        return
+
+    @property
+    def last_trigger_age(self):
+        """
+        Read-Only Property: last_trigger_age
+
+        Available in SmartHomeNG v1.9.1 and above
+
+        :return: path of the item
+        :rtype: str
+        """
+        return self._item._get_last_trigger_age()
+
+    @last_trigger_age.setter
+    def last_trigger_age(self, value):
+        self._ro_error()
+        return
+
+    @property
+    def last_trigger_by(self):
+        """
+        Read-Only Property: last_trigger_by
+
+        Available in SmartHomeNG v1.9.1 and above
+
+        :return: path of the item
+        :rtype: str
+        """
+        return self._item._get_last_trigger_by()
+
+    @last_trigger_by.setter
+    def last_trigger_by(self, value):
+        self._ro_error()
+        return
+
+    @property
     def last_value(self):
         """
         Read-Only Property: last_value
@@ -563,6 +614,57 @@ class Property:
 
     @prev_update_by.setter
     def prev_update_by(self, value):
+        self._ro_error()
+        return
+
+    @property
+    def prev_trigger(self):
+        """
+        Read-Only Property: prev_trigger
+
+        Available in SmartHomeNG v1.9.1 and above
+
+        :return: path of the item
+        :rtype: str
+        """
+        return self._item._get_prev_trigger()
+
+    @prev_trigger.setter
+    def prev_trigger(self, value):
+        self._ro_error()
+        return
+
+    @property
+    def prev_trigger_age(self):
+        """
+        Read-Only Property: prev_trigger_age
+
+        Available in SmartHomeNG v1.9.1 and above
+
+        :return: path of the item
+        :rtype: str
+        """
+        return self._item._get_prev_trigger_age()
+
+    @prev_trigger_age.setter
+    def prev_trigger_age(self, value):
+        self._ro_error()
+        return
+
+    @property
+    def prev_trigger_by(self):
+        """
+        Read-Only Property: prev_trigger_by
+
+        Available in SmartHomeNG v1.9.1 and above
+
+        :return: path of the item
+        :rtype: str
+        """
+        return self._item._get_prev_trigger_by()
+
+    @prev_trigger_by.setter
+    def prev_trigger_by(self, value):
         self._ro_error()
         return
 


### PR DESCRIPTION
.. as well as prev_trigger(_by/_age) and according functions. This way it is possible to figure out what has triggered the eval expression. The property might be especially useful inside the eval expression itself but can also be used to figure out what, when (or if) an eval got triggered (without being updated, because maybe the eval didn't succeed or the value has not changed)

Example:
```
eval: value if sh..self.updated_by().startswith('admin') else None
```
only checked the update BEFORE the current update/trigger. It was not possible to figure out what has triggered the CURRENT eval expression (e.g. changing the value directly in the admin IF).

This now gives the correct result without altering any currently available property or function
```
eval: value if sh..self.triggered_by().startswith('admin') else None
```

Maybe this could also be implemented in the Admin IF?