### PR TITLE
[Docu of ReverseProxy]: Correction of docu if reverseProxy has an other IP than the smarthome server

### DIFF
--- a/doc/user/source/visualisierung/reverse_proxy.rst
+++ b/doc/user/source/visualisierung/reverse_proxy.rst
@@ -172,7 +172,7 @@ noch einen Block als Schutz gegen Denial of Service Angriffe ergänzen:
        # websocket for shng
        ##
        upstream websocket {
-         server 127.0.0.1:2424;
+         server <SmartHomeNG LAN IP>:2424;
        }
 
        ##


### PR DESCRIPTION
If the smarthome server has an other IP adress than the ReverseProxy then the following entry lead to a not working websocket connection!
```
       ##
       # websocket for shng
       ##
       upstream websocket {
         server 127.0.0.1:2424;
       }
```
Thus the docu has to be corrected to keep more general to work also, when the IP adresses differs.
The better solution is this:
```
       ##
       # websocket for shng
       ##
       upstream websocket {
         server <SmartHomeNG LAN IP>:2424;
       }
```

