### PR TITLE
shtime: current_monthname

### DIFF
--- a/bin/locale.yaml
+++ b/bin/locale.yaml
@@ -35,6 +35,19 @@ global_translations:
     'Samstag':         {'de': '=', 'en': 'Saturday', 'fr': 'Samedi'}
     'Sonntag':         {'de': '=', 'en': 'Sunday', 'fr': 'Dimanche'}
 
+    'Januar':          {'de': '=', 'en': 'January', 'fr': 'Janvier'}
+    'Februar':         {'de': '=', 'en': 'February', 'fr': 'Février'}
+    'März':            {'de': '=', 'en': 'March', 'fr': 'Mars'}
+    'April':           {'de': '=', 'en': 'April', 'fr': 'Avril'}
+    'Mai':             {'de': '=', 'en': 'May', 'fr': 'Mai'}
+    'Juni':            {'de': '=', 'en': 'June', 'fr': 'Juin'}
+    'Juli':            {'de': '=', 'en': 'July', 'fr': 'Juillet'}
+    'August':          {'de': '=', 'en': 'August', 'fr': 'Août'}
+    'September':       {'de': '=', 'en': 'September', 'fr': 'Septembre'}
+    'Oktober':         {'de': '=', 'en': 'October', 'fr': 'Octobre'}
+    'November':        {'de': '=', 'en': 'November', 'fr': 'Novembre'}
+    'Dezember':        {'de': '=', 'en': 'December', 'fr': 'Décembre'}
+
     'Host':            {'de': '=', 'en': '=', 'fr': 'Hôte'}
     'Port':            {'de': '=', 'en': '=', 'fr': '='}
     'IP':              {'de': '=', 'en': '=', 'fr': '='}

--- a/doc/user/source/referenz/smarthomeng/feiertage_datum_zeit.rst
+++ b/doc/user/source/referenz/smarthomeng/feiertage_datum_zeit.rst
@@ -121,6 +121,8 @@ Die Funktionen für das Datums-Handling sind folgende:
 +-----------------------------------------------+----------------------------------------------------------------------------------+
 | shtime.current_month(offset=0)                | Liefert den aktuellen Monat                                                      |
 +-----------------------------------------------+----------------------------------------------------------------------------------+
+| shtime.current_monthname(offset=0)            | Liefert den Namens des aktuellen Monats                                          |
++-----------------------------------------------+----------------------------------------------------------------------------------+
 | shtime.current_day(offset=0)                  | Liefert den aktuellen Tag                                                        |
 +-----------------------------------------------+----------------------------------------------------------------------------------+
 | shtime.day_of_year(date=None, offset=0)       | Liefert als Ergebnis, der wievielte Tag im Jahr das angegebene Datum ist         |

--- a/lib/shtime.py
+++ b/lib/shtime.py
@@ -656,6 +656,47 @@ class Shtime:
         return (self.today() + dateutil.relativedelta.relativedelta(months=offset)).month
 
 
+    def current_monthname(self, offset=0):
+        """
+        Return the name of the current month for a given date
+
+        :param offset: negative number for previous months, positive for future ones
+        :type offset: int
+
+        :return: monthname NAME
+        :rtype: str
+        """
+        month = self.current_month(offset)
+        if month == 1:
+            monthname = "Januar"
+        elif month == 2:
+            monthname = "Februar"
+        elif month == 3:
+            monthname = "März"
+        elif month == 4:
+            monthname = "April"
+        elif month == 5:
+            monthname = "Mai"
+        elif month == 6:
+            monthname = "Juni"
+        elif month == 7:
+            monthname = "Juli"
+        elif month == 8:
+            monthname = "August"
+        elif month == 9:
+            monthname = "September"
+        elif month == 10:
+            monthname = "Oktober"
+        elif month == 11:
+            monthname = "November"
+        elif month == 12:
+            monthname = "Dezember"
+        else:
+            monthname = "?"
+
+        return self.translate(monthname)
+
+
     def current_day(self, offset=0):
         """
         Return the current day


### PR DESCRIPTION
Für ein neues Plugin wäre es hilfreich den deutschen Monatsnamen direkt zu erhalten.
Da das vielleicht auch an anderen Stellen (z.B. Logiken) hilfreich sein könnte, hab ich das mal in shtime implementiert.