### PR TITLE
fix startup error on empty plugins/modules config

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -69,9 +69,9 @@ def parse_basename(basename, configtype=''):
     if config == {}:
         if not (configtype == 'logics'):
             if configtype == 'module':
-                logger.error("No valid file '{}.yaml' found with {} configuration".format(basename, configtype))
+                logger.warning("No valid file '{}.yaml' found with {} configuration".format(basename, configtype))
             else:
-                logger.critical("No valid file '{}.*' found with {} configuration".format(basename, configtype))
+                logger.error("No valid file '{}.*' found with {} configuration".format(basename, configtype))
     return config
 
 

--- a/lib/item/item.py
+++ b/lib/item/item.py
@@ -341,8 +341,9 @@ class Item():
 
                     # Test if the plugin-specific attribute contains a valid value
                     # and set the default value, if needed
-                    value = self.plugins.meta.check_itemattribute(self, attr.split('@')[0], value, self._filename)
-                    self.conf[attr] = value
+                    if hasattr(self.plugins, 'meta'):
+                        value = self.plugins.meta.check_itemattribute(self, attr.split('@')[0], value, self._filename)
+                        self.conf[attr] = value
 
         self.property.init_dynamic_properties()
 


### PR DESCRIPTION
starting without / with empty modules.yaml results in ERROR; as shng runs fine without modules, this is corrected to "WARNING"

starting without / with empty plugins.yaml results in CRITICAL; as shng "runs" fine without plugins (albeit without functionality), this is corrected to "ERROR".

Furthermore, without plugins loaded, the lib.plugins.meta object is not initialized; creating items tries to access it resulting in errors. Fixed by checking availability of meta object