### PR TITLE
Improve and extend log_text / log_rules for item logging

### DIFF
--- a/doc/user/source/referenz/items/standard_attribute/log_change.rst
+++ b/doc/user/source/referenz/items/standard_attribute/log_change.rst
@@ -87,11 +87,24 @@ Unterstützt werden folgende Variablen/Platzhalter:
 +-----------------+------------------------------------------------------------------------------+
 |  {pid}          |  ID (Pfad) des Parent-Items                                                  |
 +-----------------+------------------------------------------------------------------------------+
-|  {lowlimit}     |  unterer Grenzwert für Logeinträge                                           |
+|  {lowlimit}     |  unterer Grenzwert für Logeinträge aus dem ``log_rules`` Attribut            |
 +-----------------+------------------------------------------------------------------------------+
-|  {highlimit}    |  oberer Grenzwert für Logeinträge                                            |
+|  {highlimit}    |  oberer Grenzwert für Logeinträge aus dem ``log_rules`` Attribut             |
 +-----------------+------------------------------------------------------------------------------+
-
+|  {stamp}        |  aktueller UNIX Zeitstempel                                                  |
++-----------------+------------------------------------------------------------------------------+
+|  {time}         |  aktuelle Uhrzeit im Format HH:MM:SS                                         |
++-----------------+------------------------------------------------------------------------------+
+|  {date}         |  aktuelles Datum im Format DD.MM.YYYY                                        |
++-----------------+------------------------------------------------------------------------------+
+|  {now}          |  aktuelle Zeit im Format von sh.now (YYYY-MM-DD HH:MM:SS.ss+TZ)              |
++-----------------+------------------------------------------------------------------------------+
+|  {itemvalue}    |  der Wert eines Items (z.B, ein Text) aus dem ``log_rules`` Attribut         |
++-----------------+------------------------------------------------------------------------------+
+|  {filter}       |  der aktuell aktive (positive) Filter                                        |
++-----------------+------------------------------------------------------------------------------+
+|  {exclude}      |  der aktuell aktive negative Filter                                          |
++-----------------+------------------------------------------------------------------------------+
 
 eval-Ausdrücke in log_text
 --------------------------
@@ -112,7 +125,7 @@ Attribut *log_mapping*
 Über das **log_mapping** Attribut kann festgelegt werden, auf welche Werte/Strings der Wert eines Items für das
 Logging gemappt werden soll. Das Attribut **log_mapping** enthält dazu in einem String die Beschreibung eines
 dicts. Wobei der Key den zu übersetzenden/mappenden Wert angibt und der dazu gehörige Value des dicts den String
-angeibt, der über die Variable ``{mvalue}`` ausgegeben wird.
+angibt, der über die Variable ``{mvalue}`` ausgegeben wird.
 
 **Beispiel:**
 
@@ -135,20 +148,38 @@ anzuwenden sind. Das Attribut **log_rules** enthält dazu in einem String die Be
 
 .. code-block:: yaml
 
-    log_rules: "{
-        'lowlimit' : -1.0,
-        'highlimit': 10.0,
-        'filter': [1, 2, 5]
-        }"
+    item:
+        type: num
+        log_rules: "{
+            'lowlimit' : -1.0,
+            'highlimit': 10.0,
+            'filter': [1, 2, 5],
+            'exclude': '.exclude_values',
+            'itemvalue': '.text'
+            }"
 
-Die Filter Liste hat dabei vorrang. Es wird also nur bei den Werten 1, 2 und 5 geloggt, obwohl lowlimit und
-highlimit weitere Werte zulassen würden.
+        exclude_values:
+            type: list
+            initial_value: [2, 10]
+            cache: True
 
+        text:
+            type: str
+            initial_value: 'This is the log message'
+            cache: True
+
+Die Filter Liste hat dabei Vorrang. Es wird also nur bei den Werten 1, 2 und 5 geloggt, obwohl lowlimit und
+highlimit weitere Werte zulassen würden bzw. exclude einen der Werte ausschließen würde.
+
+.. hint::
+
+    Sämtliche Werte in den log_rules können ab SmartHomeNG 1.10 auch in Items hinterlegt werden.
+    Der Verweis auf das jeweilige Item erfolgt dabei durch den absoluten oder relativen Itempfad als String (ohne sh.).
 
 lowlimit
 --------
 
-``lowlimit`` ein Wert der angibt, unterhalb welchen Wertes des Items **kein** Logeintrag geschrieben werden soll.
+``lowlimit`` Ein Wert, der angibt, unterhalb welchen Wertes des Items **kein** Logeintrag geschrieben werden soll.
 Werte werden geschrieben, Wenn **lowlimit** <= **value** ist.
 
 **low_limit** kann nur auf Items vom Typ **num** angewendet werden.
@@ -157,7 +188,7 @@ Werte werden geschrieben, Wenn **lowlimit** <= **value** ist.
 highlimit
 ---------
 
-``highlimit`` ein Wert der angibt, oberhalb welchen Wertes des Items **kein** Logeintrag geschrieben werden soll.
+``highlimit`` Ein Wert, der angibt, oberhalb welchen Wertes des Items **kein** Logeintrag geschrieben werden soll.
 Werte werden geschrieben, Wenn **value** < **highlimit** ist.
 
 **highlimit** kann nur auf Items vom Typ **num** angewendet werden.
@@ -166,8 +197,26 @@ Werte werden geschrieben, Wenn **value** < **highlimit** ist.
 filter
 ------
 
-``filter`` eine Werteliste die angibt, bei welchen Werten des Items ein Logeintrag geschrieben werden soll.
+``filter`` Eine Werteliste, die angibt, bei welchen Werten des Items ein Logeintrag geschrieben werden soll.
 
 Wenn das Item vom Typ **num** ist, muss die Liste auch numerische Werte (int oder float) enthalten
 (``'filter': [1, 2, 5, 2.1]``). Falls das Item von einem anderen Datentyp ist, muss die Liste Strings
 enthalten (``'filter': ['1', '2', '5']``).
+
+
+exclude
+-------
+
+``exclude`` Eine Werteliste, die angibt, bei welchen Werten des Items ein Logeintrag nicht geschrieben werden soll.
+
+Wenn das Item vom Typ **num** ist, muss die Liste auch numerische Werte (int oder float) enthalten
+(``'exclude': [1, 2, 5, 2.1]``). Falls das Item von einem anderen Datentyp ist, muss die Liste Strings
+enthalten (``'exclude': ['1', '2', '5']``).
+
+
+itemvalue
+---------
+
+``itemvalue`` Der absolute oder relative Pfad zu einem Item, dessen Wert ausgelesen werden soll.
+Dies kann beispielsweise dazu genutzt werden, die Lognachricht zur Laufzeit anzupassen.
+ 

--- a/lib/item/item.py
+++ b/lib/item/item.py
@@ -2043,8 +2043,11 @@ class Item():
         items = _items_instance
         try:
             entry = self._log_rules.get('itemvalue', None)
-            item = self.get_absolutepath(entry.strip().replace("sh.", ""), "log_rules")
-            itemvalue = str(_items_instance.return_item(item).property.value)
+            if entry is not None:
+                item = self.get_absolutepath(entry.strip().replace("sh.", ""), "log_rules")
+                itemvalue = str(_items_instance.return_item(item).property.value)
+            else:
+                itemvalue = None
         except Exception as e:
             logger.error(f"{id}: Invalid item in log_text '{self._log_text}'"
                          f" or log_rules '{self._log_rules}' - (Exception: {e})")
@@ -2089,7 +2092,8 @@ class Item():
         defaults = {'filter': [], 'exclude': [], 'lowlimit': None, 'highlimit': None}
         types = {'filter': 'list', 'exclude': 'list', 'lowlimit': 'num', 'highlimit': 'num'}
         entry =  self._log_rules.get(rule_entry, defaults.get(rule_entry))
-        entry = convert_entry(entry, types.get(rule_entry) or self._type)
+        if entry is not None and entry != []:
+            entry = convert_entry(entry, types.get(rule_entry) or self._type)
 
         return entry
 

--- a/lib/item/item.py
+++ b/lib/item/item.py
@@ -2040,6 +2040,15 @@ class Item():
         now = str(shtime.now())
 
         items = _items_instance
+        try:
+            entry = self._log_rules.get('itemvalue', None)
+            item = self.get_absolutepath(entry.strip().replace("sh.", ""), "log_rules")
+            itemvalue = str(_items_instance.return_item(item).property.value)
+        except Exception as e:
+            logger.error(f"{id}: Invalid item in log_text '{self._log_text}'"
+                         f" or log_rules '{self._log_rules}' - (Exception: {e})")
+            itemvalue = "INVALID"
+
         import math
         import lib.userfunctions as uf
         env = lib.env

--- a/lib/item/item.py
+++ b/lib/item/item.py
@@ -2018,15 +2018,13 @@ class Item():
         mlvalue = self._log_mapping.get(lvalue, lvalue)
         name = self._name
         age = round(self._get_last_change_age(), 2)
-        try:
-            pname = self.__parent._name
-        except AttributeError:
-            pname = None
         id = self._path
-        try:
-            pid = self.__parent._path
-        except AttributeError:
+        if self.__parent = _items_instance:
+            pname = None
             pid = None
+        else:
+            pname = self.__parent._name
+            pid = self.__parent._path
         mvalue = self._log_mapping.get(value, value)
         lowlimit = self._get_rule('lowlimit')
         highlimit = self._get_rule('highlimit')

--- a/lib/item/item.py
+++ b/lib/item/item.py
@@ -2018,9 +2018,15 @@ class Item():
         mlvalue = self._log_mapping.get(lvalue, lvalue)
         name = self._name
         age = round(self._get_last_change_age(), 2)
-        pname = self.__parent._name
+        try:
+            pname = self.__parent._name
+        except AttributeError:
+            pname = None
         id = self._path
-        pid = self.__parent._path
+        try:
+            pid = self.__parent._path
+        except AttributeError:
+            pid = None
         mvalue = self._log_mapping.get(value, value)
         lowlimit = self._log_rules.get('lowlimit', None)
         highlimit = self._log_rules.get('highlimit', None)

--- a/lib/item/item.py
+++ b/lib/item/item.py
@@ -2111,11 +2111,11 @@ class Item():
 
             if self._type == 'num':
                 low_limit =  self._get_rule('lowlimit')
-                if low_limit:
+                if low_limit is not None:
                     if low_limit > float(value):
                         return
                 high_limit =  self._get_rule('highlimit')
-                if high_limit:
+                if high_limit is not None:
                     if high_limit <= float(value):
                         return
                 if filter_list != []:

--- a/lib/item/item.py
+++ b/lib/item/item.py
@@ -2028,6 +2028,11 @@ class Item():
 
         sh = self._sh
         shtime = self.shtime
+        time = shtime.now().strftime("%H:%M:%S")
+        date = shtime.now().strftime("%d.%m.%Y")
+        stamp = shtime.now().timestamp()
+        now = str(shtime.now())
+
         items = _items_instance
         import math
         import lib.userfunctions as uf


### PR DESCRIPTION
- added some more options such as time, date, now
- added possibility to implement the value of an item in the log text (e.g. for updating the message)
- added possibility to define all log_rules by an item instead of a distinct value
- some minor improvements
These updates should make (together with logging.yaml) datalog, memlog and operationlog obsolete.