### PR TITLE
mqtt: add error handling for non-decodable utf-8 messages

### DIFF
--- a/modules/mqtt/__init__.py
+++ b/modules/mqtt/__init__.py
@@ -509,7 +509,13 @@ class Mqtt(Module):
         """
         datatype = subscription_dict.get('payload_type', 'foo')
         bool_values = subscription_dict.get('bool_values', None)
-        payload = self.cast_from_mqtt(datatype, payload, bool_values)
+        try:
+            payload = self.cast_from_mqtt(datatype, payload, bool_values)
+        except UnicodeDecodeError:
+            # log error and stop further processing of message
+            self.logger.warning(f'received non-decodable mqtt message: {payload}, ignoring')
+            return False
+
         plugin = subscription_dict.get('callback', None)
 
         subscription_found = False

--- a/modules/mqtt/__init__.py
+++ b/modules/mqtt/__init__.py
@@ -572,7 +572,7 @@ class Mqtt(Module):
                         else:
                             self.logger.error("_on_mqtt_message: received topic for unknown subscriber_type '{}'".format(subscriber_type))
                     except UnicodeDecodeError:
-                        self.logger.error(f"_on_mqtt_message: received ill-formed message with topic '{message.topic}', payload '{message.payload}', discarding")
+                        self.logger.warning(f"_on_mqtt_message: received ill-formed message with topic '{message.topic}', payload '{message.payload}', discarding")
                         return
 
         if not subscription_found:


### PR DESCRIPTION
On receiving ill-formed utf-8 messages containing illegal binary data, the mqtt module throws an exception - and stops receiving further messages.

To fix this, the unicode decode error is caught, logged and the payload is discarded. 