### PR TITLE
lib.config: remove name attribute from struct root before merging

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -513,7 +513,10 @@ def add_struct_to_item_template(path, struct_name, template, struct_dict, instan
         # add struct/template to temporary item(template) tree
         #logger.debug("- add_struct_to_item_template: struct_dict = {}".format(dict(struct_dict)))
         #logger.debug("- add_struct_to_item_template: struct '{}' to item '{}'".format(struct_name, path))
-        nested_put(template, path, copy.deepcopy(struct))
+        tmp_struct = copy.deepcopy(struct)
+        if 'name' in tmp_struct and isinstance(struct.get('name'), str):
+            del tmp_struct['name']
+        nested_put(template, path, tmp_struct)
         if instance != '' or True:
             # add instance to items added by template struct
             subtree = nested_get(template, path)

--- a/lib/config.py
+++ b/lib/config.py
@@ -514,8 +514,12 @@ def add_struct_to_item_template(path, struct_name, template, struct_dict, instan
         #logger.debug("- add_struct_to_item_template: struct_dict = {}".format(dict(struct_dict)))
         #logger.debug("- add_struct_to_item_template: struct '{}' to item '{}'".format(struct_name, path))
         tmp_struct = copy.deepcopy(struct)
-        if 'name' in tmp_struct and isinstance(struct.get('name'), str):
-            del tmp_struct['name']
+        if 'name' in tmp_struct and isinstance(struct["name"], str):
+            from lib.smarthome import SmartHome
+            _sh = SmartHome.get_instance()
+            if Utils.to_bool(getattr(_sh, '_struct_strip_name', False)):
+                del tmp_struct['name']
+                logger.debug(f'removed "name" attribute from struct {struct_name}')
         nested_put(template, path, tmp_struct)
         if instance != '' or True:
             # add instance to items added by template struct

--- a/lib/smarthome.py
+++ b/lib/smarthome.py
@@ -107,6 +107,9 @@ from lib.systeminfo import Systeminfo
 #VERSION = bin.shngversion.get_shng_version()
 
 
+_sh_instance = None
+
+
 #####################################################################
 # Classes
 #####################################################################
@@ -200,6 +203,15 @@ class SmartHome():
         self.shng_status = {'code': 0, 'text': 'Initializing'}
         self._logger = logging.getLogger(__name__)
         self._logger_main = logging.getLogger(__name__)
+
+        global _sh_instance
+        if _sh_instance is not None:
+            import inspect
+            curframe = inspect.currentframe()
+            calframe = inspect.getouterframes(curframe, 4)
+            self._logger.critical("A second 'smarthome' object has been created. There should only be ONE instance of class 'smarthome'!!! Called from: {} ({})".format(calframe[1][1], calframe[1][3]))
+        else:
+            _sh_instance = self
 
         # keep for checking on restart command
         self._mode = MODE
@@ -1315,3 +1327,11 @@ class SmartHome():
 
         self._deprecated_warning('Shtime-API')
         return self.shtime.runtime()
+
+
+    @staticmethod
+    def get_instance():
+        """ returns the instance of running smarthome class """
+        global _sh_instance
+        return _sh_instance
+


### PR DESCRIPTION
Vorschlag zur Lösung für fix #594 

Vor dem Mergen des Structs ins Item-Template wird ein ggf. vorhandenes Attribut 'name' entfernt, das Item behält seinen ursprünglichen Namen.

TODO:
Aus meiner Sicht gibt es drei Wege:
a) der Name aus dem Struct überschreibt den des Items (status quo)
b) der Name des Structs wird ignoriert (PR)
c) der Name des Structs wird nur übernommen, wenn das Item keinen Namen hat.

Vor- und Nachteile:
a) + nonbreaking für alle möglichen Anwendungen
     - ggf. Namensdubletten bei mehrfacher Verwendung
b) + ggf. vorhandener Item-Name wird nicht überschrieben
     + keine Namensdubletten aus struct
     - ggf. breaking change (falls "feature" bisher verwendet)
c) + ggf. vergebener Item-Name wird beibehalten
     - ggf. Namensdubletten bei mehrfacher Verwendung
     - ggf. breaking change (falls "feature" bisher verwendet)
     - uneinheitliches Verhalten

Mein Favorit wäre auch b), weil ich die Übernahme des Namens struct -> item unlogisch finde.

Man könnte einen globalen Parameter (smarthome.yaml?) einführen, der im default den neuen Modus verwendet und bei ausdrücklicher Nutzung das alte Verhalten beibehält -- ich halte das allerdings für relativ unwahrscheinlich.

Vorschläge, Meinungen?