### PR TITLE
lib.item: add methods for list/dict manipulation

### DIFF
--- a/doc/user/source/referenz/items/item_zugriff.rst
+++ b/doc/user/source/referenz/items/item_zugriff.rst
@@ -193,7 +193,7 @@ angezeigt.
 |
 
 Erweiterter Zugriff auf List- und Dict-Items :redsup:`neu`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------------------------
 
 Mit den Erweiterungen wird der Zugriff auf Items vom Typ `list` oder `dict`
 noch mehr dem "normalen" Handling von Python angepasst.
@@ -223,7 +223,7 @@ normalen Zugriff auf Items - entsprechend gesetzt werden können.
 
 
 List-Items
-----------
+~~~~~~~~~~
 
 Die Methode `append` hängt Werte an die Liste an:
 
@@ -280,7 +280,7 @@ Die Methode `remove` entfernt das angegebene Element aus der Liste:
 
 
 Dict-Items
-----------
+~~~~~~~~~~
 
 Die Methode `get` gibt den Wert für den angegebenen Key zurück. Wenn der Key
 im dict nicht existiert, wird `None` oder der übergebene Default-Wert zurückgegeben:

--- a/doc/user/source/referenz/items/item_zugriff.rst
+++ b/doc/user/source/referenz/items/item_zugriff.rst
@@ -192,3 +192,135 @@ angezeigt.
 
 |
 
+Erweiterter Zugriff auf List- und Dict-Items :redsup:`neu`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Mit den Erweiterungen wird der Zugriff auf Items vom Typ `list` oder `dict`
+noch mehr dem "normalen" Handling von Python angepasst.
+
+Ein Item vom Typ List erhält ein Item-Attribut `list`, vom Typ Dict erhält
+analog das Attribut `dict`. Diese Attribute besitzen typspezifische Methoden
+zum Zugriff auf und Ändern von den jeweiligen Item-Werten.
+
+Mit Ausnahme der (nur lesenden) Methode `get` für dict-Items unterstützen alle
+Methoden die optionalen Parameter `caller`, `source` und `dest`, die - wie beim
+normalen Zugriff auf Items - entsprechend gesetzt werden können.
+
+.. note::
+
+    Alle Methoden sind im Wesentlichen mit den entsprechenden Methoden der `list`-
+    bzw. `dict`-Klassen identisch; das genaue Verhalten kann bei Bedarf in der
+    Python-Dokumentation nachgelesen werden.
+
+    Ausnahmen sind die Methode `prepend` (existiert so in Python nicht) und 
+    `delete`, welche das Verhalten von `del` nachbildet, aus Syntaxgründen aber
+    anders benannt werden musste.
+
+    Analog zu den Python-Funktionen ist keine zusätzliche Fehlerbehandlung 
+    implementiert, so dass ungültige Indizes oder Keys nicht abgefangen werden.
+    Die Behandlung dieser Fehler obliegt - wie beim normalen Umgang mit Listen
+    und Dicts - dem Nutzer.
+
+
+List-Items
+----------
+
+Die Methode `append` hängt Werte an die Liste an:
+
+..code-block:: python
+
+    sh.Oma.Papa.Kind.list.append('foo')
+
+Die Methode `prepend` fügt Werte am Beginn der List ein:
+
+..code-block:: python
+
+    sh.Oma.Papa.Kind.list.prepend(bar')
+
+Die Methode `insert` fügt Werte an der angegebenen Stelle `index` ein:
+
+..code-block:: python
+
+    sh.Oma.Papa.Kind.list.insert(2, 'baz')
+
+Die Methode `pop` entfernt den letzten (bzw. angegebenen) Wert der Liste und gibt ihn zurück:
+
+..code-block:: python
+
+    value = sh.Oma.Papa.Kind.list.pop()
+    value = sh.Oma.Papa.Kind.list.pop(2)
+
+Die Methode `extend` hängt die Elemente der übergebenen Liste an die Liste des Items an:
+def extend(self, value, caller='Logic', source=None, dest=None):
+
+..code-block:: python
+
+    sh.Oma.Papa.Kind.list.extend(['foo', 'bar'])
+
+Die Methode `clear` leert die Liste:
+
+..code-block:: python
+
+    sh.Oma.Papa.Kind.list.clear()
+
+Die Methode `delete` entspricht dem Python-Befehl `del list[x[:y]]` und löscht das
+bzw. die angegebenen Elemente der Liste. Aus Syntaxgründen heißt die Methode `delete`
+statt `del` und der Index bzw. der Index-Bereich muss als String übergeben werden:
+
+..code-block:: python
+
+    sh.Oma.Papa.Kind.list.delete(2)
+    sh.Oma.Papa.Kind.list.delete("1:3")
+
+Die Methode `remove` entfernt das angegebene Element aus der Liste:
+
+..code-block:: python
+
+    sh.Oma.Papa.Kind.list.remove('foo')
+
+
+Dict-Items
+----------
+
+Die Methode `get` gibt den Wert für den angegebenen Key zurück. Wenn der Key
+im dict nicht existiert, wird `None` oder der übergebene Default-Wert zurückgegeben:
+
+..code-block:: python
+
+    value1 = sh.Oma.Papa.Kind.dict.get('foo')
+
+..code-block:: python
+
+    value2 = sh.Oma.Papa.Kind.dict.get('bar', 42)
+
+Die Methode `delete` entspricht dem Python-Befehl `del dict[key]` und lösche den 
+angegebenen Key aus dem dict:
+
+..code-block:: python
+
+    sh.Oma.Papa.Kind.dict.delete('foo')
+
+Die Methode `clear` leert das dict:
+
+..code-block:: python
+
+    sh.Oma.Papa.Kind.dict.clear()
+
+Die Methode `pop` entfernt den angegebenen Key aus dem dict und liefert den
+entfernten Wert zurück:
+
+..code-block:: python
+
+    value = sh.Oma.Papa.Kind.dict.pop('bar')
+
+Die Methode `popitem` entfernt den zuletzt hinzugefügten Key aus dem dict und liefert das Set `(key, value)` zurück:
+
+..code-block:: python
+
+    (key, value) = sh.Oma.Papa.Kind.dict.popitem()
+
+Die Methode `update` aktualisiert das dict mit dem Inhalt des übergebenen dict:
+
+..code-block:: python
+
+    sh.Oma.Papa.Kind.dict.update({'foo': 42, 'bar': 23})

--- a/lib/item/item.py
+++ b/lib/item/item.py
@@ -248,6 +248,17 @@ class Item():
             raise AttributeError
         self.cast = globals()['cast_' + self._type]
 
+#
+# add type methods
+#
+        ext_item_functions = {
+            'list': ['append', 'prepend', 'insert', 'pop', 'extend', 'clear', 'delete', 'remove'],
+            'dict': ['get', 'delete', 'clear', 'pop', 'popitem', 'update']
+        }
+        if self._type in ['list', 'dict']:
+            for func in ext_item_functions[self._type]:
+                setattr(self, func, getattr(self, f'_Item__{self._type}_{func}'))
+
         #############################################################
         # Item Attributes
         #############################################################
@@ -1369,6 +1380,110 @@ class Item():
 
         return result
 
+#
+# drop-in functions for list/dict handling
+#
+# these mimic list/dict modification functions by wrapping around __call__
+#
+# on item type initialization, only the "matching" method can be inserted
+# into the item instance as methods with their respective "original" names,
+# i.e. Item.__list__append becomes Item.append
+#
+# To keep some compatibility, all methods support optional caller, source and
+# dest arguments, which are directly passed to __call__
+#
+# these don't provide error handling as no sensible result would be possible.
+# As in using "raw" lists/dicts, errors must be handles by the caller
+# (logic, eval, console, ...)
+#
+
+# list functions
+
+    def __list_append(self, value, caller='Logic', source=None, dest=None):
+        self.__call__(value, caller, source, dest, index='append')
+
+    def __list_prepend(self, value, caller='Logic', source=None, dest=None):
+        self.__call__(value, caller, source, dest, index='prepend')
+
+    def __list_insert(self, index, value, caller='Logic', source=None, dest=None):
+        tmplist = copy.deepcopy(self._value)
+        tmplist.insert(index, value)
+        self.__call__(tmplist, caller, source, dest)
+
+    def __list_pop(self, index=None, caller='Logic', source=None, dest=None):
+        tmplist = copy.deepcopy(self._value)
+        if index is None:
+            ret = tmplist.pop()
+        else:
+            ret = tmplist.pop(index)
+        self.__call__(tmplist, caller, source, dest)
+        return ret
+
+    def __list_extend(self, value, caller='Logic', source=None, dest=None):
+        tmplist = copy.deepcopy(self._value)
+        tmplist.extend(value)
+        self.__call__(tmplist, caller, source, dest)
+
+    def __list_clear(self, caller='Logic', source=None, dest=None):
+        self.__call__([], caller, source, dest)
+
+    def __list_delete(self, value, caller='Logic', source=None, dest=None):
+        """
+            mimic the del list[x:y] behaviour - supply "x:y" as value
+            needs to be called delete instead of del for syntax reasons
+        """
+        splits = str(value).count(':')
+        tmplist = copy.deepcopy(self._value)
+        if splits == 0:
+            x = int(value)
+            del tmplist[x]
+        if splits == 1:
+            x, y = [int(i) for i in value.split(':')]
+            del tmplist[x:y]
+        elif splits == 2:
+            x, y, z = [int(i) for i in value.split(':')]
+            del tmplist[x:y:z]
+        self.__call__(tmplist, caller, source, dest)
+
+    def __list_remove(self, value, caller='Logic', source=None, dest=None):
+        tmplist = copy.deepcopy(self._value)
+        tmplist.remove(value)
+        self.__call__(tmplist, caller, source, dest)
+
+# dict functions
+
+    def __dict_get(self, key, caller='Logic', source=None, dest=None, default=None):
+        return self.__call__(key=key, default=default, caller=caller, source=source, dest=dest)
+
+    def __dict_delete(self, key, caller='Logic', source=None, dest=None):
+        """ needs to be called delete instead of del for syntax reasons """
+        tmpdict = copy.deepcopy(self._value)
+        del tmpdict[key]
+        self.__call__(tmpdict, caller, source, dest)
+
+    def __dict_clear(self, caller='Logic', source=None, dest=None):
+        self.__call__({}, caller, source, dest)
+
+    def __dict_pop(self, key, caller='Logic', source=None, dest=None, default=None):
+        tmpdict = copy.deepcopy(self._value)
+        ret = tmpdict.pop(key, default)
+        self.__call__(tmpdict, caller, source, dest)
+        return ret
+
+    def __dict_popitem(self, caller='Logic', source=None, dest=None):
+        tmpdict = copy.deepcopy(self._value)
+        ret = tmpdict.popitem()
+        self.__call__(tmpdict, caller, source, dest)
+        return ret
+
+    def __dict_update(self, value, caller='Logic', source=None, dest=None):
+        tmpdict = copy.deepcopy(self._value)
+        tmpdict.update(value)
+        self.__call__(tmpdict, caller, source, dest)
+
+#
+#
+#
 
     def __call__(self, value=None, caller='Logic', source=None, dest=None, key=None, index=None, default=None):
         # return value


### PR DESCRIPTION
Ich habe als Vorschlag und zur Diskussion mal meine Idee zum Handling von dicts und lists in Items ergänzt.

Martins Implementation ist unverändert, allerdings legt das Item je nach Typ die folgenden Item-Funktionen an:

list: append, prepend, insert, pop, extend, clear, delete, remove
dict: get, delete, clear, pop, popitem, update

delete statt del, weil del als reserviertes Wort nicht nutzbar ist.

Die Funktionen lassen sich quasi 1:1 wie die originalen list-/dict-Funktionen nutzen, z.B.

```
listitem.append(val)
val = listitem.pop("2:3")

dictitem.update({'foo': 'bar'})
val = dictitem.get('baz', 'sorry')
```

Zusätzlich können allen Funktionen die Parameter `caller`, `source`, `dest` mitgegeben werden.

Intern rufen die Funktionen alle `__call__` auf, so dass alle notwendigen Item-Mechaniken durchlaufen werden.

Ich sehe das Problem, dass für `remove`, `pop` usw. noch weitere zusätzliche Parameter an `__call__` übergeben werden müssen und die Auswertung, welche Parameter und welche nicht übergeben wurden, schnell sehr unübersichtlich und komplex wird.


Das soll keine Kritik an Martins Implementation sein und kein Ersatz, sondern eine Ergänzung (append, prepend, get rufen sogar mit "seiner" neuen Syntax `__call__` auf...).

Ob wir das annehmen wollen oder nicht, wäre ggf. zu diskutieren.

Die Methoden sind alle einzeln getestet. Automatische Tests kann ich leider nicht ohne Weiteres einbauen, weil die Initialisierung der Item-Klasse nicht "normal" durchlaufen wird.