### PR TITLE
workflow: fix unittest for forked repos in core

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -46,19 +46,23 @@ jobs:
       - name: Checkout core from branch '${{ github.base_ref }} branch'
         uses: actions/checkout@v3
         with:
-          repository: smarthomeNG/smarthome
+          repository: ${{ github.repository_owner }}/smarthome
           ref: ${{ github.base_ref }}
 
-      - name: Checkout plugins from branch '${{steps.extract_branch.outputs.branch}}' (for push)
-        if: github.event_name != 'pull_request'
+      - name: Check if branch '${{ steps.extract_branch.outputs.branch }}' exists in smarthomeNG/plugins
+        run: echo "code=$(git ls-remote --exit-code --heads https://github.com/smarthomeNG/plugins ${{ steps.extract_branch.outputs.branch }} > /dev/null; echo $? )" >>$GITHUB_OUTPUT
+        id: shng_branch_check
+
+      - name: Checkout plugins from branch '${{ steps.extract_branch.outputs.branch }}' (for push on known smarthomeNG/plugins branch)
+        if: github.event_name != 'pull_request' && steps.shng_branch_check.outputs.code == '0'
         uses: actions/checkout@v3
         with:
           repository: smarthomeNG/plugins
-          ref: ${{steps.extract_branch.outputs.branch}}
+          ref: ${{ steps.extract_branch.outputs.branch }}
           path: plugins
 
-      - name: Checkout plugins from branch 'develop' (for pull request)
-        if: github.event_name == 'pull_request'
+      - name: Checkout plugins from branch 'develop' (for pull request or push on unknown smarthomeNG/plugins branch)
+        if: github.event_name == 'pull_request' || steps.shng_branch_check.outputs.code == '2'
         uses: actions/checkout@v3
         with:
           repository: smarthomeNG/plugins


### PR DESCRIPTION
Beim Pushen in eigenen core-branch versucht GitHub beim Testen, denselben branch aus plugins auszuchecken - was erwartbar fehlschlägt.

Dieser PR ist analog zu https://github.com/smarthomeNG/plugins/pull/751 aufgebaut, ich weiß aber nicht, wie man das testen kann...?