### PR TITLE
scheduler: add method to get all schedulers for smartplugin 

### DIFF
--- a/lib/model/smartplugin.py
+++ b/lib/model/smartplugin.py
@@ -1009,6 +1009,17 @@ class SmartPlugin(SmartObject, Utils):
         self.logger.debug(f"scheduler_get: name = {name}")
         return self._sh.scheduler.get(name, from_smartplugin=True)
 
+    def scheduler_get_all(self):
+        """
+        This methods gets all schedulers for a plugin
+        """
+        plugin = self._pluginname_prefix + self.get_fullname() + "."
+        self.logger.debug(f"scheduler_get_all: plugin = {plugin}")
+        scheduler_list = []
+        for name in self._sh.scheduler.return_all(True):
+            if name.startswith(plugin):
+                scheduler_list.append(name)
+        return scheduler_list
 
     # ----------------------------------------------------------------------------------
     #   Ascyncio handling (to be moved to SmartPlugin?)
@@ -1286,5 +1297,3 @@ class SmartPluginWebIf():
             return lib_translate(txt, vars, plugin_translations='plugin/' + self.plugin.get_shortname(), module_translations='module/http')
         else:
             return lib_translate(txt, vars, module_translations='module/http')
-
-

--- a/lib/model/smartplugin.py
+++ b/lib/model/smartplugin.py
@@ -1014,11 +1014,11 @@ class SmartPlugin(SmartObject, Utils):
         This methods gets all schedulers for a plugin
         """
         plugin = self._pluginname_prefix + self.get_fullname() + "."
-        self.logger.debug(f"scheduler_get_all: plugin = {plugin}")
         scheduler_list = []
         for name in self._sh.scheduler.return_all(True):
             if name.startswith(plugin):
-                scheduler_list.append(name)
+                scheduler_list.append(name[len(plugin):])
+        self.logger.debug(f"scheduler_get_all: plugin = {plugin}, schedulers = {scheduler_list}")
         return scheduler_list
 
     # ----------------------------------------------------------------------------------

--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -433,6 +433,9 @@ class Scheduler(threading.Thread):
         if name in self._scheduler:
             return self._scheduler[name]['next']
 
+    def return_all(self, from_smartplugin=False):
+        return self._scheduler
+
     def add(self, name, obj, prio=3, cron=None, cycle=None, value=None, offset=None, next=None, from_smartplugin=False):
         """
         Adds an entry to the scheduler.
@@ -806,5 +809,3 @@ class Scheduler(threading.Thread):
             #logger.exception(f"In der Logik ist ein Fehler aufgetreten:\n   Logik '{logic.name}', Datei '{tb[0]}', Zeile {tb[1]}\n   {logic_method}, Exception: '{e}'\n ")
 
         return
-
-


### PR DESCRIPTION
e.g. to easily remove all active scheduler on stop, etc.
for scheduler in self.scheduler_get_all():
            self.scheduler_remove(scheduler)

Feel free to improve/adapt the method, however I think it's convenient and useful when stopping/suspending plugins.