### PR TITLE
smartdevice plugin: add features

### DIFF
--- a/lib/model/sdp/globals.py
+++ b/lib/model/sdp/globals.py
@@ -47,7 +47,7 @@ PLUGIN_ATTR_CMD_CLASS        = 'command_class'           # name of class to use 
 PLUGIN_ATTR_RECURSIVE        = 'recursive_custom'        # indices of custom item attributes for which to enable recursive lookup (number or list of numbers)
 PLUGIN_ATTR_SUSPEND_ITEM     = 'suspend_item'            # item to toggle suspend/resume mode
 PLUGIN_ATTR_CYCLE            = 'cycle'                   # plugin-wide cyclic update interval
-
+PLUGIN_ATTR_DELAY_INITIAL    = 'delay_initial_read'      
 # general connection attributes
 PLUGIN_ATTR_CONNECTION       = 'conn_type'               # manually set connection class, classname or type (see below)
 PLUGIN_ATTR_CONN_TIMEOUT     = 'timeout'                 # timeout for reading from network or serial
@@ -88,7 +88,7 @@ PLUGIN_ATTRS = (PLUGIN_ATTR_MODEL, PLUGIN_ATTR_CMD_CLASS, PLUGIN_ATTR_RECURSIVE,
                 PLUGIN_ATTR_CONN_RETRY_CYCLE, PLUGIN_ATTR_CONN_RETRY_SUSPD, PLUGIN_ATTR_NET_HOST, PLUGIN_ATTR_NET_PORT,
                 PLUGIN_ATTR_SERIAL_PORT, PLUGIN_ATTR_SERIAL_BAUD, PLUGIN_ATTR_SERIAL_BSIZE, PLUGIN_ATTR_SERIAL_PARITY,
                 PLUGIN_ATTR_SERIAL_STOP, PLUGIN_ATTR_PROTOCOL, PLUGIN_ATTR_MSG_TIMEOUT, PLUGIN_ATTR_MSG_REPEAT,
-                PLUGIN_ATTR_CB_ON_CONNECT, PLUGIN_ATTR_CB_ON_DISCONNECT, PLUGIN_ATTR_CB_SUSPEND)
+                PLUGIN_ATTR_CB_ON_CONNECT, PLUGIN_ATTR_CB_ON_DISCONNECT, PLUGIN_ATTR_CB_SUSPEND, PLUGIN_ATTR_DELAY_INITIAL)
 
 # connection types for PLUGIN_ATTR_CONNECTION
 CONN_NULL                    = ''                 # use base connection class without real connection functionality, for testing
@@ -173,7 +173,7 @@ COMMAND_ITEM_ATTRS = (CMD_IATTR_RG_LEVELS, CMD_IATTR_LOOKUP_ITEM, CMD_IATTR_ATTR
                       CMD_IATTR_CUSTOM1, CMD_IATTR_CUSTOM2, CMD_IATTR_CUSTOM3, CMD_IATTR_CYCLIC)
 
 # reply pattern substitution tokens, set token in {<token>}
-PATTERN_LOOKUP               = 'LOOKUP'                 # replace with lookup values    
+PATTERN_LOOKUP               = 'LOOKUP'                 # replace with lookup values
 PATTERN_VALID_LIST           = 'VALID_LIST'             # replace with valid_list items
 PATTERN_VALID_LIST_CI        = 'VALID_LIST_CI'          # replace with valid_list_ci items
 PATTERN_CUSTOM_PATTERN       = 'CUSTOM_PATTERN'         # replace with custom pattern <x>

--- a/lib/model/smartdeviceplugin.py
+++ b/lib/model/smartdeviceplugin.py
@@ -712,7 +712,7 @@ class SmartDevicePlugin(SmartPlugin):
         try:
             data_dict = self._commands.get_send_data(command, value, **kwargs)
             data_dict['command'] = command
-            if value is not None:
+            if value is not None and self._commands_read.get(command, None) is not None:
                 data_dict['returntype'] = type(value)
                 data_dict['returnvalue'] = value
             data_dict['retry'] = kwargs.get('retry') or 0

--- a/lib/model/smartdeviceplugin.py
+++ b/lib/model/smartdeviceplugin.py
@@ -711,6 +711,11 @@ class SmartDevicePlugin(SmartPlugin):
 
         try:
             data_dict = self._commands.get_send_data(command, value, **kwargs)
+            data_dict['command'] = command
+            if value is not None:
+                data_dict['returntype'] = type(value)
+                data_dict['returnvalue'] = value
+            data_dict['retry'] = kwargs.get('retry') or 0
         except Exception as e:
             self.logger.warning(f'command {command} with value {value} produced error on converting value, aborting. Error was: {e}')
             return False

--- a/lib/model/smartdeviceplugin.py
+++ b/lib/model/smartdeviceplugin.py
@@ -1087,11 +1087,11 @@ class SmartDevicePlugin(SmartPlugin):
             self._cyclic_errors = 0
             self.logger.info(f'Added cyclic worker thread {self.get_shortname()}_cyclic with {workercycle} s cycle. Shortest item update cycle found was {shortestcycle} s')
 
-    def _read_initial_values(self):
+    def _read_initial_values(self, force=False):
         """
         Read all values configured to be read/triggered at startup
         """
-        if self._initial_value_read_done:
+        if self._initial_value_read_done and force is False:
             self.logger.debug('_read_initial_values() called, but inital values were already read. Ignoring')
         else:
             if self._commands_initial:
@@ -1676,7 +1676,7 @@ class Standalone:
 
         self.yaml['item_structs'] = OrderedDict()
 
-        # this means the commands dict has 'ALL' and model names at the top level 
+        # this means the commands dict has 'ALL' and model names at the top level
         # otherwise, the top level nodes are commands or sections
         cmds_has_models = INDEX_GENERIC in top_level_entries
 

--- a/lib/model/smartdeviceplugin.py
+++ b/lib/model/smartdeviceplugin.py
@@ -341,10 +341,12 @@ class SmartDevicePlugin(SmartPlugin):
         if suspend_active:
             if self.scheduler_get(self.get_shortname() + '_cyclic'):
                 self.scheduler_remove(self.get_shortname() + '_cyclic')
+            self._on_suspend()
 
         else:
             if self._connection.connected() and not SDP_standalone:
                 self._create_cyclic_scheduler()
+                self._on_resume()
 
     def run(self):
         """
@@ -970,6 +972,14 @@ class SmartDevicePlugin(SmartPlugin):
         """
         self.logger.debug(f'sending {data_dict}')
         return self._connection.send(data_dict)
+
+    def _on_suspend(self):
+        """ Additional actions after plugin got suspended. """
+        pass
+
+    def _on_resume(self):
+        """ Additional actions after plugin got resumed. """
+        pass
 
     def on_connect(self, by=None):
         """ callback if connection is made. """


### PR DESCRIPTION
- on_suspend/resume Methods that can be overwritten by plugins (e.g. to handle additional schedulers, etc
- add some parameters to data_dict when sending for possibility to resend commands in plugins
- provide possibility to read commands even if they were read initially. This is helpful e.g. to re-read after suspend mode