### PR TITLE
module mqtt: add compatibility to paho_mqtt v2

### DIFF
--- a/modules/mqtt/module.yaml
+++ b/modules/mqtt/module.yaml
@@ -2,7 +2,7 @@
 module:
     # Global plugin attributes
     classname: Mqtt
-    version: 1.7.6
+    version: 1.8.0
     sh_minversion: 1.6a
 #   sh_maxversion:              # maximum shNG version to use this plugin (leave empty if latest)
     description:


### PR DESCRIPTION
works with paho_mqtt v1 (tested: 1.6.1) and v2 (tested: 2.1.0), discriminates between v1 and v2, configuration not needed. Should be non-breaking and backwards-compatible.

Will need adjusting for paho_mqtt v3 someday.

No problems here with both versions, would like independent testing.

fixes #632 