### PR TITLE
logging: introduce EnglishLocale formatter 

### DIFF
--- a/doc/user/source/referenz/logging/logging_formatter.rst
+++ b/doc/user/source/referenz/logging/logging_formatter.rst
@@ -6,9 +6,9 @@
 .. role:: redsup
 
 
-=================
-Logging Formatter
-=================
+===================================
+Logging Formatter :bluesup:`Update`
+===================================
 
 Mit **Logging Formattern** wird festgelegt, wie die Informationen aufbereitet werden sollen, wenn sie in ein
 Log geschrieben werden.
@@ -40,9 +40,25 @@ werden:
             format: '%(asctime)s %(levelname)-8s %(name)-19s %(message)s'
             datefmt: '%Y-%m-%d  %H:%M:%S %Z'
 
+Möchte man den Zeitstempel anders gestalten, ist dies einfach über den Parameter `datefmt` zu bewerkstelligen.
+Das folgende Beispiel formatiert den Zeitstempel als `Mai 29 12:59:51`. Die Sprache für den Monatsnamen
+hängt dabei von der Systemlokalisierung ab. Möchte man unabhängig von der Lokalisierung die Monate jedenfalls
+auf English geloggt haben (z.B. für eine automatisierte Analyse), ist die `EnglishLocale` Klasse zu nutzen,
+wie im Beispiel `shng_english_month` zu sehen.
+
+.. code-block:: yaml
+
+    formatters:
+        shng_local_month:
+            format: '%(asctime)s %(levelname)-8s %(name)-17s %(message)s'
+            datefmt: '%b %d %H:%M:%S'
+
+        shng_english_month:
+            (): lib.log.EnglishLocale
+            format: '%(asctime)s %(levelname)-8s %(name)-17s %(message)s'
+            datefmt: '%b %d %H:%M:%S'
 
 Eine vollständige Liste der Attribute eines Log-Records kann in der Python Dokumentation unter
 `logging - Logging facility for Python <https://docs.python.org/3/library/logging.html>`_ nachgelesen werden.
 
 |
-

--- a/etc/logging.yaml.default
+++ b/etc/logging.yaml.default
@@ -7,6 +7,15 @@ formatters:
 
     # The following sections define the output formats to be used in the different logs
     #
+    shng_local_month:
+        format: '%(asctime)s %(levelname)-8s %(name)-17s %(message)s'
+        datefmt: '%b %d %H:%M:%S'
+
+    shng_english_month:
+        (): lib.log.EnglishLocale
+        format: '%(asctime)s %(levelname)-8s %(name)-17s %(message)s'
+        datefmt: '%b %d %H:%M:%S'
+
     shng_simple:
         format: '%(asctime)s %(levelname)-8s %(name)-19s %(message)s'
         datefmt: '%Y-%m-%d  %H:%M:%S'

--- a/lib/log.py
+++ b/lib/log.py
@@ -29,6 +29,7 @@ import os
 import datetime
 import pickle
 import re
+import locale
 from pathlib import Path
 
 import collections
@@ -662,6 +663,19 @@ class DateTimeRotatingFileHandler(logging.StreamHandler):
 """
 In the following part of the code, logging handlers are defined
 """
+
+class EnglishLocale(logging.Formatter):
+    """
+    Use English month names for logging
+    """
+    def formatTime(self, record, datefmt=None):
+        current_locale = locale.setlocale(locale.LC_TIME)
+        try:
+            locale.setlocale(locale.LC_TIME, 'C')  # Forces English (Jan, Feb, etc.)
+            return time.strftime(datefmt, self.converter(record.created)) if datefmt else super().formatTime(record, datefmt)
+        finally:
+            locale.setlocale(locale.LC_TIME, current_locale)
+
 
 class ShngTimedRotatingFileHandler(logging.handlers.TimedRotatingFileHandler):
     """


### PR DESCRIPTION
(to name months in English even if locale is set differently). This is useful for log analysis or processing using promtail, loki, etc.