### PR TITLE
core: modify instance processing in plugin.yaml

### DIFF
--- a/lib/constants.py
+++ b/lib/constants.py
@@ -77,6 +77,7 @@ KEY_REMARK = 'remark'
 
 #global config params for plugins
 KEY_INSTANCE =         'instance'
+KEY_DEFAULT_INSTANCE = 'default_instance'
 KEY_WEBIF_PAGELENGTH = 'webif_pagelength'
 KEY_CLASS_PATH = 'class_path'
 KEY_CLASS_NAME = 'class_name'

--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -60,7 +60,7 @@ from importlib import import_module, reload
 import lib.config
 import lib.translation as translation
 from lib.model.smartplugin import SmartPlugin
-from lib.constants import (KEY_CLASS_NAME, KEY_CLASS_PATH, KEY_INSTANCE, YAML_FILE, CONF_FILE, DIR_PLUGINS, PLUGIN_PARSE_ITEM)
+from lib.constants import (KEY_CLASS_NAME, KEY_CLASS_PATH, KEY_DEFAULT_INSTANCE, KEY_INSTANCE, YAML_FILE, CONF_FILE, DIR_PLUGINS, PLUGIN_PARSE_ITEM)
 from lib.metadata import Metadata
 
 logger = logging.getLogger(__name__)
@@ -118,6 +118,20 @@ class Plugins():
         _conf = lib.config.parse_basename(configfile, configtype='plugin')
         if _conf == {}:
             return
+
+        # count plugin usage in plugin conf
+        # do this here and now because _conf isn't available later or elsewhere
+        # TODO: think about central plugin config?
+
+        # get all unique plugin names
+        __plugins = set(_conf[p].get('plugin_name', 'unknown') for p in _conf)
+
+        # prepopulate counter dict
+        self._plugins_count = {p: 0 for p in __plugins}
+
+        # count plugin usage
+        for plugin in _conf:
+            self._plugins_count[_conf[plugin].get('plugin_name', 'unknown')] += 1
 
         logger.info('Load plugins')
         self.threads_early = []
@@ -233,23 +247,40 @@ class Plugins():
         return (classname, classpath + plugin_version)
 
 
-    def _get_instancename(self, plg_conf):
+    def _get_instancename(self, plg_name: str, plg_conf: dict):
         """
-        Returns the instancename for the actual plugin
+        Returns the instance name for the actual plugin
 
-        :param plg_conf: loaded section of the plugin.yaml for the actual plugin
+        :param plg_name: section of the plugin.yaml for the current plugin
+        :type plg_name: str
+        :param plg_conf: loaded section of the plugin.yaml for the current plugin
         :type plg_conf: dict
 
         :return: instance name
         :rtype: str
         """
-        instance = ''
-        if KEY_INSTANCE in plg_conf:
-            instance = plg_conf[KEY_INSTANCE].strip()
-            if instance == 'default':
-                instance = ''
-        return instance
+        count = self._plugins_count.get(plg_conf.get('plugin_name', 'unknown'), 0)
 
+        # rewrite should retain prior instance naming, but enable
+        # "automagic instances" if nothing is explicitly given
+
+        # first priority: manual instance setting (use given instance name)
+        if KEY_INSTANCE in plg_conf and plg_conf[KEY_INSTANCE] != 'default':
+            return plg_conf[KEY_INSTANCE]
+
+        # second priority: manual default setting -- or no setting and single plugin use (use no instance name)
+        if KEY_DEFAULT_INSTANCE in plg_conf or plg_conf.get(KEY_INSTANCE, 'foo') == 'default' or count == 1:
+            return ''
+
+        # third priority: no manual settings, multiple plugins (use section name)
+        if count > 1:
+            # plugin is used multiple times and not default, return identifier
+            return plg_name
+
+        # we should not get here - we counted wrong or this is called after new plugins are loaded on the fly
+        logger.warning(f'lib.plugins._get_instancename got a plugin usage count of 0 for plugin {plg_name} ({plg_conf.get("plugin_name", "unknown")}). This should never happen.')
+        # don't set instance, this isn't sensible anyway
+        return ''
 
     def _test_duplicate_pluginconfiguration(self, plugin, classname, instance):
         """
@@ -457,7 +488,7 @@ class Plugins():
                 logger.error(f'Plugins, section {configname}: class_path is not defined')
             else:
                 args = self._get_conf_args(conf)
-                instance = self._get_instancename(conf).lower()
+                instance = self._get_instancename(configname, conf).lower()
                 try:
                     plugin_version = self.meta.pluginsettings.get('version', 'ersion unknown')
                     plugin_version = 'v' + plugin_version
@@ -494,7 +525,6 @@ class Plugins():
                             logger.warning(f"Plugin '{str(classpath).split('.')[1]}' from section '{configname}' not loaded - exception {e}")
                 except Exception as e:
                     logger.exception(f"Plugin '{str(classpath).split('.')[1]}' {plugin_version} from section '{configname}'\nException: {e}\nrunning SmartHomeNG {self._sh.version} / plugins {self._sh.plugins_version}")
-
         return False
 
 

--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -124,14 +124,16 @@ class Plugins():
         # TODO: think about central plugin config?
 
         # get all unique plugin names
-        __plugins = set(_conf[p].get('plugin_name', 'unknown') for p in _conf)
+        # __plugins = set(_conf[p].get('plugin_name', 'unknown') for p in _conf)
+        # to keep "old" config compatibility (class_name/class_path), also check for class_name
+        __plugins = set(_conf[p].get('plugin_name', _conf[p].get('class_name', 'unknown')) for p in _conf)
 
         # prepopulate counter dict
         self._plugins_count = {p: 0 for p in __plugins}
 
         # count plugin usage
         for plugin in _conf:
-            self._plugins_count[_conf[plugin].get('plugin_name', 'unknown')] += 1
+            self._plugins_count[_conf[plugin].get('plugin_name', _conf[plugin].get('class_name', 'unknown'))] += 1
 
         logger.info('Load plugins')
         self.threads_early = []
@@ -259,7 +261,7 @@ class Plugins():
         :return: instance name
         :rtype: str
         """
-        count = self._plugins_count.get(plg_conf.get('plugin_name', 'unknown'), 0)
+        count = self._plugins_count.get(plg_conf.get('plugin_name', plg_conf.get('class_name', 'unknown')), 0)
 
         # rewrite should retain prior instance naming, but enable
         # "automagic instances" if nothing is explicitly given


### PR DESCRIPTION
Ich hab mich mal an die instance-Thematik gesetzt.

Richtlinie fürs erste: nonbreaking... (dafür die mit (*) markierten Pfade)

wenn 
- Instanz ausdrücklich gesetzt: "<instanz>" übernehmen (*)
- Instanz auf "default" gesetzt:  "" übernehmen (*)
- default_instance: true gesetzt: "" übernehmen
- keine Instanz angegeben und Plugin nur einmal eingebunden: "" übernehmen
- keine Instanz angegeben und Plugin mehrfach eingebunden: <plugin_identifier> übernehmen

Später würden dann die ersten beiden Pfade (und damit die Angabe `instance: foo`) entfallen.

Alles andere ist b.a.w. unverändert, d.h.

- Items ohne Instanz-Angabe beziehen sich auf die default-Instanz
- Items mit Instanz-Angabe beziehen sich auf die jeweilige Instanz

Ich konnte den ersten von drei Tests fixen, weil die plugins-Teste class_name und class_path verwenden (den Zopf könnte man irgendwann auch abschneiden... oder?)

Die beiden plugins-Tests, die noch fehlschlagen, schaue ich mir noch im Detail an. 

Nonbreaking heißt, dass
1. bestehende Konfigurationen ohne Anpassung weiter funktionieren,
2. in allen Fällen, in denen keine Instanzen deklariert werden, die neue Benennung schon implizit genutzt wird,
3. damit später nur geringe Anpassungen notwendig werden (in der plugins.yaml die Sektionsnamen durch den Instanznamen ersetzen)


Mich würde erstmal interessieren, ob dieser Weg für uns gemeinsam vorwärts führt.