### PR TITLE
core: change instance handling/naming

### DIFF
--- a/lib/constants.py
+++ b/lib/constants.py
@@ -77,6 +77,7 @@ KEY_REMARK = 'remark'
 
 #global config params for plugins
 KEY_INSTANCE =         'instance'
+KEY_DEFAULT_INSTANCE = 'default_instance'
 KEY_WEBIF_PAGELENGTH = 'webif_pagelength'
 KEY_CLASS_PATH = 'class_path'
 KEY_CLASS_NAME = 'class_name'

--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -60,7 +60,7 @@ from importlib import import_module, reload
 import lib.config
 import lib.translation as translation
 from lib.model.smartplugin import SmartPlugin
-from lib.constants import (KEY_CLASS_NAME, KEY_CLASS_PATH, KEY_INSTANCE, YAML_FILE, CONF_FILE, DIR_PLUGINS, PLUGIN_PARSE_ITEM)
+from lib.constants import (KEY_CLASS_NAME, KEY_CLASS_PATH, KEY_DEFAULT_INSTANCE, KEY_INSTANCE, YAML_FILE, CONF_FILE, DIR_PLUGINS, PLUGIN_PARSE_ITEM)
 from lib.metadata import Metadata
 
 logger = logging.getLogger(__name__)
@@ -118,6 +118,22 @@ class Plugins():
         _conf = lib.config.parse_basename(configfile, configtype='plugin')
         if _conf == {}:
             return
+
+        # count plugin usage in plugin conf
+        # do this here and now because _conf isn't available later or elsewhere
+        # TODO: think about central plugin config?
+
+        # get all unique plugin names
+        # __plugins = set(_conf[p].get('plugin_name', 'unknown') for p in _conf)
+        # to keep "old" config compatibility (class_name/class_path), also check for class_name
+        __plugins = set(_conf[p].get('plugin_name', _conf[p].get('class_name', 'unknown')) for p in _conf)
+
+        # prepopulate counter dict
+        self._plugins_count = {p: 0 for p in __plugins}
+
+        # count plugin usage
+        for plugin in _conf:
+            self._plugins_count[_conf[plugin].get('plugin_name', _conf[plugin].get('class_name', 'unknown'))] += 1
 
         logger.info('Load plugins')
         self.threads_early = []
@@ -233,23 +249,40 @@ class Plugins():
         return (classname, classpath + plugin_version)
 
 
-    def _get_instancename(self, plg_conf):
+    def _get_instancename(self, plg_name: str, plg_conf: dict):
         """
-        Returns the instancename for the actual plugin
+        Returns the instance name for the actual plugin
 
-        :param plg_conf: loaded section of the plugin.yaml for the actual plugin
+        :param plg_name: section of the plugin.yaml for the current plugin
+        :type plg_name: str
+        :param plg_conf: loaded section of the plugin.yaml for the current plugin
         :type plg_conf: dict
 
         :return: instance name
         :rtype: str
         """
-        instance = ''
-        if KEY_INSTANCE in plg_conf:
-            instance = plg_conf[KEY_INSTANCE].strip()
-            if instance == 'default':
-                instance = ''
-        return instance
+        count = self._plugins_count.get(plg_conf.get('plugin_name', plg_conf.get('class_name', 'unknown')), 0)
 
+        # rewrite should retain prior instance naming, but enable
+        # "automagic instances" if nothing is explicitly given
+
+        # first priority: manual instance setting (use given instance name)
+        if KEY_INSTANCE in plg_conf and plg_conf[KEY_INSTANCE] != 'default':
+            return plg_conf[KEY_INSTANCE]
+
+        # second priority: manual default setting -- or no setting and single plugin use (use no instance name)
+        if KEY_DEFAULT_INSTANCE in plg_conf or plg_conf.get(KEY_INSTANCE, 'foo') == 'default' or count == 1:
+            return ''
+
+        # third priority: no manual settings, multiple plugins (use section name)
+        if count > 1:
+            # plugin is used multiple times and not default, return identifier
+            return plg_name
+
+        # we should not get here - we counted wrong or this is called after new plugins are loaded on the fly
+        logger.warning(f'lib.plugins._get_instancename got a plugin usage count of 0 for plugin {plg_name} ({plg_conf.get("plugin_name", "unknown")}). This should never happen.')
+        # don't set instance, this isn't sensible anyway
+        return ''
 
     def _test_duplicate_pluginconfiguration(self, plugin, classname, instance):
         """
@@ -457,7 +490,7 @@ class Plugins():
                 logger.error(f'Plugins, section {configname}: class_path is not defined')
             else:
                 args = self._get_conf_args(conf)
-                instance = self._get_instancename(conf).lower()
+                instance = self._get_instancename(configname, conf).lower()
                 try:
                     plugin_version = self.meta.pluginsettings.get('version', 'ersion unknown')
                     plugin_version = 'v' + plugin_version
@@ -494,7 +527,6 @@ class Plugins():
                             logger.warning(f"Plugin '{str(classpath).split('.')[1]}' from section '{configname}' not loaded - exception {e}")
                 except Exception as e:
                     logger.exception(f"Plugin '{str(classpath).split('.')[1]}' {plugin_version} from section '{configname}'\nException: {e}\nrunning SmartHomeNG {self._sh.version} / plugins {self._sh.plugins_version}")
-
         return False
 
 

--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -261,20 +261,26 @@ class Plugins():
         :return: instance name
         :rtype: str
         """
+        # handle legacy instance naming - deprecated, to be removed later
+        if self._sh._legacy_instances:
+            instance = ''
+            if KEY_INSTANCE in plg_conf:
+                instance = plg_conf[KEY_INSTANCE].strip()
+                if instance == 'default':
+                    instance = ''
+            return instance
+
         count = self._plugins_count.get(plg_conf.get('plugin_name', plg_conf.get('class_name', 'unknown')), 0)
 
         # rewrite should retain prior instance naming, but enable
         # "automagic instances" if nothing is explicitly given
 
-        # first priority: manual instance setting (use given instance name)
-        if KEY_INSTANCE in plg_conf and plg_conf[KEY_INSTANCE] != 'default':
-            return plg_conf[KEY_INSTANCE]
-
-        # second priority: manual default setting -- or no setting and single plugin use (use no instance name)
+        # first priority: manual default setting -- or no setting and single plugin use (use no instance name)
+        # we retain "instance: default" as the only recognized use of "instance:" now
         if KEY_DEFAULT_INSTANCE in plg_conf or plg_conf.get(KEY_INSTANCE, 'foo') == 'default' or count == 1:
             return ''
 
-        # third priority: no manual settings, multiple plugins (use section name)
+        # second priority: no manual settings, multiple plugins (use section name)
         if count > 1:
             # plugin is used multiple times and not default, return identifier
             return plg_name

--- a/lib/smarthome.py
+++ b/lib/smarthome.py
@@ -149,7 +149,7 @@ class SmartHome():
         self.__children = []
 
         self._config_etc = False
-
+        self._legacy_instances = True
 
     def initialize_dir_vars(self):
         self._base_dir = BASE
@@ -287,6 +287,10 @@ class SmartHome():
             exit(1)
         if hasattr(self, '_module_paths'):
             sys.path.extend(self._module_paths if type(self._module_paths) is list else [self._module_paths])
+
+        #############################################################
+        # check / set legacy_instance option from config file
+        self._legacy_instances = lib.utils.Utils.to_bool(self._legacy_instances, True)
 
         #############################################################
         # check / set config_etc option from cmdline or config file

--- a/tests/mock/core.py
+++ b/tests/mock/core.py
@@ -65,6 +65,8 @@ class MockSmartHome():
 
     _restart_on_num_workers = 30
 
+    _legacy_instances = False
+
     _etc_dir = os.path.join(_base_dir, 'tests', 'resources', 'etc')
     _structs_dir = os.path.join(_base_dir, 'tests', 'resources', 'structs')
     _var_dir = os.path.join(_base_dir, 'var')

--- a/tests/resources/etc/plugin.yaml
+++ b/tests/resources/etc/plugin.yaml
@@ -3,18 +3,15 @@
 # plugin.yaml
 
 cli:
-    class_name: CLI
-    class_path: plugins.cli
+    plugin_name: cli
     ip: 0.0.0.0
     update: True
     hashed_password: 1245a9633edf47b7091f37c4d294b5be5a9936c81c5359b16d1c4833729965663f1943ef240959c53803fedef7ac19bd59c66ad7e7092d7dbf155ce45884607d
 
 wol:
-    class_name: WakeOnLan
-    class_path: plugins.wol
+    plugin_name: wol
+    instance: default
 
-wol_ww:
-    instance: bind
-    class_name: WakeOnLan
-    class_path: plugins.wol
+bind:
+    plugin_name: wol
 

--- a/tests/resources/plugin.yaml
+++ b/tests/resources/plugin.yaml
@@ -5,35 +5,29 @@ comment: '[cli]
     update = True'
 
 cli:
-    class_name: CLI
-    class_path: plugins.cli
+    plugin_name: cli
     ip: 0.0.0.0
     update: True
     hashed_password: 1245a9633edf47b7091f37c4d294b5be5a9936c81c5359b16d1c4833729965663f1943ef240959c53803fedef7ac19bd59c66ad7e7092d7dbf155ce45884607d
 
 memlog:
-    class_name: MemLog
-    class_path: plugins.memlog
+    plugin_name: memlog
     name: alert
 
 sml0:
-   class_name: Sml
-   class_path: plugins.sml
+   plugin_name: sml
    serialport: /dev/ttyUSB0
 
 sml1:
-   class_name: Sml
-   class_path: plugins.sml
+   plugin_name: sml
    serialport: /dev/ttyUSB1
 
 wol:
-    class_name: WakeOnLan
-    class_path: plugins.wol
+    plugin_name: wol
+    instance: default
 
-wol_ww:
-    instance: bind
-    class_name: WakeOnLan
-    class_path: plugins.wol
+bind:
+    plugin_name: wol
     comment: '[rest]
         class_name = RestServer
         class_path = plugins.rest
@@ -48,7 +42,5 @@ wol_ww:
         update = True'
 
 knx:
-  class_name: KNX
-  class_path: plugins.knx
+  plugin_name: knx
   host: hostname
-  instance: default

--- a/tests/resources/plugin_items.yaml
+++ b/tests/resources/plugin_items.yaml
@@ -22,7 +22,7 @@ item3:
 
         item3b1:
             type: bool
-            #wol_mac: 11:22:33:44:55:66
+            wol_mac: 11:22:33:44:55:66
 
             item3b1a:
                 type: bool

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -20,15 +20,15 @@ class TestPlugin(unittest.TestCase):
         self.assertIsNone(self.plugins.get_pluginthread("wol1"))
 
     def test_plugin_name(self):
-        wolplug = self.plugins.get_pluginthread("wol_ww")
-        self.assertEqual(wolplug.name, "wol_ww")
+        wolplug = self.plugins.get_pluginthread("bind")
+        self.assertEqual(wolplug.name, "bind")
 
     def test_plugin_implementation(self):
-        wolplug = self.plugins.get_pluginthread("wol_ww")
+        wolplug = self.plugins.get_pluginthread("bind")
         self.assertEqual(wolplug.plugin, wolplug.get_implementation())
 
     def test_plugin_ident(self):
-        wolplug = self.plugins.get_pluginthread("wol_ww")
+        wolplug = self.plugins.get_pluginthread("bind")
         self.assertIsNone(wolplug.ident)
         self.plugins.start()
         self.assertEqual(wolplug.ident, wolplug.get_ident())
@@ -40,12 +40,12 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(cliplug.plugin.get_instance_name(),"")
 
     def test_plugin_instance_set(self):
-        cliplug = self.plugins.get_pluginthread("wol_ww")
+        cliplug = self.plugins.get_pluginthread("bind")
         self.assertEqual(cliplug.plugin.get_instance_name(),"bind")
 
 
     def test_plugin_multi_instance_capable_true(self):
-        wolplug = self.plugins.get_pluginthread("wol_ww")
+        wolplug = self.plugins.get_pluginthread("bind")
         self.assertTrue(isinstance(wolplug.plugin, SmartPlugin))
         self.assertTrue(wolplug.plugin.is_multi_instance_capable())
 
@@ -72,7 +72,7 @@ class TestPlugin(unittest.TestCase):
         self.assertFalse(wolplug.plugin.has_iattr(config_mock, "key3"))
 
     def test_plugin_instance_set_has_iattr(self):
-        wolplug = self.plugins.get_pluginthread("wol_ww")
+        wolplug = self.plugins.get_pluginthread("bind")
 
         config_mock = {'key3@bind', 'value3'}
         self.assertTrue(wolplug.plugin.has_iattr(config_mock, "key3"))
@@ -92,7 +92,7 @@ class TestPlugin(unittest.TestCase):
         self.assertIsNone(wolplug.plugin.get_iattr_value(config_mock, "key3"))
 
     def test_plugin_instance_set_get_iattr_value(self):
-        wolplug = self.plugins.get_pluginthread("wol_ww")
+        wolplug = self.plugins.get_pluginthread("bind")
 
         config_mock = {'key3@*' : 'value3'}
         self.assertEqual(wolplug.plugin.get_iattr_value(config_mock, "key3"), "value3")
@@ -119,7 +119,7 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(len(it.get_method_triggers()),0)
 
     def test_plugin_instance_wol(self):
-        wolplug = self.plugins.get_pluginthread("wol_ww")
+        wolplug = self.plugins.get_pluginthread("bind")
         self.sh.scheduler.add(wolplug.name, wolplug.plugin.update_item, prio=5, cycle=300, offset=2)
         wolplug.plugin.wake_on_lan("11:22:33:44:55:66")
 


### PR DESCRIPTION
First up, this is - for now - optional, default is the old behaviour.

By setting `"legacy_instances: false"` in `etc/smarthome.yaml`, you can activate the new behaviour:

As we already have a unique identifier for each plugin - the "section name" in `etc/plugin.yaml` - it seems natural to use this as the instance name. This results in practically never having to manually set instance names.

For single instance plugins, the instance name stays the same - '' or no instance.
For multiple instance plugins, every plugin's instance name becomes the respective section name.
For one of these plugins, you can set `instance: default` to set the instance name to '' (like before) - any other use of "instance" will be ignored.

If you want to quickly exchange one plugin for another (e.g. private repos from PR testing), just rename the plugin.yaml section without having to care for any other place in the config.

If you want to swap items between two instances of the same plugin, swap the plugin.yaml section names.

You can also alternate "defaulting" one of the instances - however, items which have the "defaulted" instance name set will not be bound to a plugin for the time.


The idea is starting off with a nonbreaking configuration option which can later become default.
Documentation will be updated soon.

This PR more or less closes #292 (deciding how items are bound to instance names will stay open, also, if an item can be bound to multiple instances of the same of different plugins...)