### PR TITLE
lib.config: allow attributes to be recursively applied to struct items

### DIFF
--- a/doc/user/source/konfiguration/item_structs.rst
+++ b/doc/user/source/konfiguration/item_structs.rst
@@ -3,11 +3,12 @@
 
 .. role:: bluesup
 .. role:: redsup
+.. role:: greensup
 
 
-=========================
-structs (Item Strukturen)
-=========================
+============================================
+structs (Item Strukturen) :greensup:`Update`
+============================================
 
 
 Überblick
@@ -57,6 +58,38 @@ die Template Strukturen in der Reihenfolge angewendet, in der sie in der Liste a
             - mein_wetter1
             - mein_wetter2
             - ....
+
+
+Vererbte Attribute :redsup:`new`
+--------------------------------
+
+Seit SmartHomeNG 1.12 gibt es die Möglichkeit, Item-Attribute an alle Items in einer Template-Struktur zu vererben. 
+Häufige Anwendungsfälle können z.B. Item-Attribute wie **database: init**, **cache: yes** oder **enforce_updates: true** sein.
+
+Für die Vererbung müssen die Attribute als Kind-Elemente des Struktur-Namens angegeben werden:
+
+.. code-block:: yaml
+
+    aussen:
+        struct:
+            - mein_wetter1:
+                - database: init
+            - mein_wetter2:
+                - cache: true
+
+
+In diesem Fall erhalten alle Items der Struktur `mein_wetter1` das Item-Attribut **database: init**, während alle Items
+der Struktur `mein_wetter2` das Item-Attribut **cache: true** erhalten.
+
+.. note::
+
+    1. Falls das jeweilige Item-Attribut in der Template-Struktur für einzelne (oder alle) Items bereits enthalten ist,
+       wird es mit dem vererbten Attribut überschrieben.
+
+    2. Beachte den Doppelpunkt hinter dem Namen der Struktur - dies ist für die Angabe der Item-Attribute zwingend notwendig,
+       ansonsten kann die yaml-Datei nicht gelesen werden. Wenn keine Item-Attribute vererbt werden sollen, darf dort hingegen
+       - wie bisher - kein Doppelpunkt stehen.
+
 
 struct-Templates in Plugins
 ===========================
@@ -268,7 +301,7 @@ Das **individual_item** wird an die Struktur des Templates angefügt.
 Verschachtelte struct Definitionen (nested structs)
 ---------------------------------------------------
 
-Ab SmartHomeNG v1.10 könntn Strukturdefinitionen beliebig verschachtelt werden. Wie Items, die mithilfe des Attributs
+Ab SmartHomeNG v1.10 können Strukturdefinitionen beliebig verschachtelt werden. Wie Items, die mithilfe des Attributs
 **struct:** auf eine Strukturdefinition verweisen, können dies auch Strukturen selbst tun. Dabei kann das **struct*:**
 Attribut an beliebiger Stelle einer struct eingefügt werden, nicht nur auf der obersten Ebene (wie dieses bereits ab
 SmartHomeNG v1.7 möglich war).

--- a/doc/user/source/was_ist_neu.rst
+++ b/doc/user/source/was_ist_neu.rst
@@ -21,8 +21,9 @@ diesem und den vorangegangenen Releases ist den :doc:`Release Notes </release/re
       nicht mehr im Stammverzeichnis, sondern unterhalb von `etc`. Dies ist auch durch die Option
       **config_etc: true** in der `etc/smarthome.yaml` möglich.
 
-      Nur beim Aufruf mit Kommandozeilenoption **-e** wird außerdem versucht, vorhandene Konfigurationsdateien
-      nach `etc/<Verzeichnis>`` zu verschieben.
+      Gleichzeitig wird versucht, vorhandene Konfigurationsdateien nach `etc/<Verzeichnis>`` zu verschieben und -
+      beim Aufruf mit **-e** - den Eintrag **config_etc: true** in der `etc/smarthome.yaml` einzutragen, da nach
+      der Migration der Konfigurationsdateien der bisherige Aufruf nicht mehr funktionieren würde.
 
       Die Konfiguration unterhalb von `etc` soll in zukünftigen Releases Standard werden.
 
@@ -37,6 +38,10 @@ diesem und den vorangegangenen Releases ist den :doc:`Release Notes </release/re
       **legacy_instances: false** gesetzt werden.
 
       Diese Methode der Instanzbenennung soll in zukünftigen Releases Standard werden.
+
+    - **Vererbbare Item-Attribute**: Bei der Einbindung von Item-Template-Strukturen können Item-Attribute
+      definiert werden, die an alle Items der Struktur vererbt werden. Häufige Beispiele können z.B. 
+      die Attribute `database`, `cache` oder `enforce_updates` sein.
 
   - **Plugins**:
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -404,6 +404,10 @@ def search_for_struct_in_items(items, struct_dict, config, source_name='', paren
     :return: True, if a struct attribute was expanded
     """
 
+    def first(s):
+        """ return first item of iterable """
+        return next(iter(s), None)
+
     if source_name.startswith('test_struct'):
         logger.info(f"search_for_struct_in_items: items.keys()={list(dict(items).keys())}, source_name={source_name}, parent={parent}")
 
@@ -417,14 +421,13 @@ def search_for_struct_in_items(items, struct_dict, config, source_name='', paren
 
         if key == 'struct':
             # item is a struct
-            struct_attrs = []
-            # we check for subkeys containing attribute inheritance
-            # first, keep a compatible list...
+
+            struct_attr_list = []
 
             if isinstance(value, list) and any(isinstance(x, dict) for x in value):
 
                 # we have a list of dicts
-                struct_attrs = copy.deepcopy(value)
+                struct_attr_list = copy.deepcopy(value)
                 s = []
                 # do a thorough conversion if we have a mix of strs and dicts
                 for entry in value:
@@ -438,8 +441,8 @@ def search_for_struct_in_items(items, struct_dict, config, source_name='', paren
             elif isinstance(value, dict):
 
                 # we have a single dict
-                import json
-                struct_attrs = [copy.deepcopy(value)]
+                struct_attr_list = [copy.deepcopy(value)]
+                logger.warning(f'found struct attrs as dict in {parent}, tell developer')
                 struct_names = list(value.keys())
             else:
                 struct_names = value
@@ -449,23 +452,29 @@ def search_for_struct_in_items(items, struct_dict, config, source_name='', paren
 
             instance = items.get('instance', '')
             template = collections.OrderedDict()
-            # attr_struct_names = [list(x.keys())[0] for x in struct_attrs]
+
+            # we need a joined OrderedDict()...
+            struct_attrs = collections.OrderedDict()
+            for item in struct_attr_list:
+                if not isinstance(item, collections.OrderedDict):
+                    continue
+                try:
+                    s_name = first(item)
+                    struct_attrs.setdefault(s_name, collections.OrderedDict())
+                    for subitem in item[s_name]:
+                        struct_attrs[s_name].update(subitem)
+                except (ValueError, IndexError, KeyError) as e:
+                    # this shouldn't happen, just log something on debug.
+                    logger.debug(f'Problem joining struct attr data from {struct_attr_list} for {item}: {e}')
 
             global struct_merging_active
             struct_merging_active = True
             for struct_name in struct_names:
-                try:
-                    # get the first (only) entry out of the value for key(struct_name) in list position equal to for-loop index
-                    str_dict = struct_attrs[struct_names.index(struct_name)][struct_name][0]
-                except (ValueError, IndexError):
-                    str_dict = None
-                    # we get here if no item attributes are defined, so don't log, just ignore
-                    # logger.warning(f"Couldn't get struct attributes for struct {struct_name}: {e}")
                 wrk = struct_name.find('@')
                 if wrk > -1:
-                    add_struct_to_item_template(parent, struct_name[:wrk], template, struct_dict, struct_name[wrk + 1:], struct_attrs=str_dict)
+                    add_struct_to_item_template(parent, struct_name[:wrk], template, struct_dict, struct_name[wrk + 1:], struct_attrs=struct_attrs.get(struct_name))
                 else:
-                    add_struct_to_item_template(parent, struct_name, template, struct_dict, instance, struct_attrs=str_dict)
+                    add_struct_to_item_template(parent, struct_name, template, struct_dict, instance, struct_attrs=struct_attrs.get(struct_name))
             if template != {}:
                 config = merge(template, config, source_name, 'Item-Tree')
             struct_merging_active = False

--- a/lib/config.py
+++ b/lib/config.py
@@ -274,16 +274,18 @@ def merge_structlists(l1, l2, key=''):
         return l1 + l2
 
 
-def merge(source, destination, source_name='', dest_name='', filename='', add=None):
+def merge(source, destination, source_name='', dest_name='', filename='', add=None, top=False):
     """
     Merges an OrderedDict Tree into another one
 
     :param source: source tree to merge into another one
     :param destination: destination tree to merge into
     :param add: Data to insert into every node
+    :param top: don't add <add> if at top of tree
     :type source: OrderedDict
     :type destination: OrderedDict
     :type add: OrderedDict|None
+    :type top: bool
 
     :return: Merged configuration tree
     :rtype: OrderedDict
@@ -324,7 +326,7 @@ def merge(source, destination, source_name='', dest_name='', filename='', add=No
                     # convert to string and remove newlines from multiline attributes
                     destination[key] = str(value).replace('\n', '')
             # if "add" dict is supplied, insert into every node, overwriting existing values
-            if add:
+            if add and not top:
                 destination.update(add)
         except Exception as e:
             logger.error(f"Problem merging subtrees (key={key}), probably invalid YAML file '{source_name}' with entry '{destination}'. Error: {e}")
@@ -354,6 +356,7 @@ def nested_put(output_dict, path, value, add=None):
     :param path: path to write to
     :param value: value to write to the nested key
     :param add: data to insert into every node
+    :param top: at top of tree, don't add <add> here
     :return:
     """
     internal_dict_value = output_dict
@@ -379,7 +382,7 @@ def nested_put(output_dict, path, value, add=None):
         #     logger.warning(f"nested_put: - merge struct = {dict(value)}")
 
         # internal_last_dict_value[nested_key[len(nested_key)-1]] = value
-        merge(value, internal_last_dict_value[nested_key[len(nested_key) - 1]], 'struct-tree', 'sub-tree', add=add)
+        merge(value, internal_last_dict_value[nested_key[len(nested_key) - 1]], 'struct-tree', 'sub-tree', add=add, top=True)
 
         # if struct_merging_active:
         #     logger.warning(f"nested_put: - dest result  = {dict(internal_last_dict_value[nested_key[len(nested_key)-1]])}")
@@ -545,7 +548,7 @@ def add_struct_to_item_template(path, struct_name, template, struct_dict, instan
         # no struct/template with this name
         nf = collections.OrderedDict()
         nf['name'] = "ERROR: struct '" + struct_name + "' not found!"
-        nested_put(template, path, nf, add=struct_attrs)
+        nested_put(template, path, nf)
         logger.error(f"add_struct_to_item_template: Struct definition for '{struct_name}' not found (referenced in item {path})")
     else:
         # add struct/template to temporary item(template) tree

--- a/lib/config.py
+++ b/lib/config.py
@@ -274,14 +274,16 @@ def merge_structlists(l1, l2, key=''):
         return l1 + l2
 
 
-def merge(source, destination, source_name='', dest_name='', filename=''):
+def merge(source, destination, source_name='', dest_name='', filename='', add=None):
     """
     Merges an OrderedDict Tree into another one
 
     :param source: source tree to merge into another one
     :param destination: destination tree to merge into
+    :param add: Data to insert into every node
     :type source: OrderedDict
     :type destination: OrderedDict
+    :type add: OrderedDict|None
 
     :return: Merged configuration tree
     :rtype: OrderedDict
@@ -309,7 +311,7 @@ def merge(source, destination, source_name='', dest_name='', filename=''):
                 if node == 'None':
                     destination[key] = value
                 else:
-                    merge(value, node, source_name, dest_name)
+                    merge(value, node, source_name, dest_name, add=add)
             else:
                 if isinstance(value, list) or isinstance(destination.get(key, None), list):
                     if destination.get(key, None) is None:
@@ -321,7 +323,9 @@ def merge(source, destination, source_name='', dest_name='', filename=''):
                 else:
                     # convert to string and remove newlines from multiline attributes
                     destination[key] = str(value).replace('\n', '')
-
+            # if "add" dict is supplied, insert into every node, overwriting existing values
+            if add:
+                destination.update(add)
         except Exception as e:
             logger.error(f"Problem merging subtrees (key={key}), probably invalid YAML file '{source_name}' with entry '{destination}'. Error: {e}")
 
@@ -343,12 +347,13 @@ def nested_get(input_dict, path):
     return internal_dict_value
 
 
-def nested_put(output_dict, path, value):
+def nested_put(output_dict, path, value, add=None):
     """
 
     :param output_dict: dict structure to write to
     :param path: path to write to
     :param value: value to write to the nested key
+    :param add: data to insert into every node
     :return:
     """
     internal_dict_value = output_dict
@@ -374,7 +379,7 @@ def nested_put(output_dict, path, value):
         #     logger.warning(f"nested_put: - merge struct = {dict(value)}")
 
         # internal_last_dict_value[nested_key[len(nested_key)-1]] = value
-        merge(value, internal_last_dict_value[nested_key[len(nested_key) - 1]], 'struct-tree', 'sub-tree')
+        merge(value, internal_last_dict_value[nested_key[len(nested_key) - 1]], 'struct-tree', 'sub-tree', add=add)
 
         # if struct_merging_active:
         #     logger.warning(f"nested_put: - dest result  = {dict(internal_last_dict_value[nested_key[len(nested_key)-1]])}")
@@ -412,7 +417,32 @@ def search_for_struct_in_items(items, struct_dict, config, source_name='', paren
 
         if key == 'struct':
             # item is a struct
-            struct_names = value
+            struct_attrs = []
+            # we check for subkeys containing attribute inheritance
+            # first, keep a compatible list...
+
+            if isinstance(value, list) and any(isinstance(x, dict) for x in value):
+
+                # we have a list of dicts
+                struct_attrs = copy.deepcopy(value)
+                s = []
+                # do a thorough conversion if we have a mix of strs and dicts
+                for entry in value:
+                    if isinstance(entry, dict):
+                        s = s + list(entry.keys())
+                    elif isinstance(entry, str):
+                        s.append(entry)
+                    else:
+                        logger.warning(f'while processing {key} of {items}, list element {entry} could not be processed')
+                struct_names = s  # [k for k,v in value.items()]
+            elif isinstance(value, dict):
+
+                # we have a single dict
+                import json
+                struct_attrs = [copy.deepcopy(value)]
+                struct_names = list(value.keys())
+            else:
+                struct_names = value
             # ensure, struct_names is a list
             if isinstance(struct_names, str):
                 struct_names = [struct_names]
@@ -423,11 +453,17 @@ def search_for_struct_in_items(items, struct_dict, config, source_name='', paren
             global struct_merging_active
             struct_merging_active = True
             for struct_name in struct_names:
+                try:
+                    # get the first (only) entry out of the value for key(struct_name) in list position equal to for-loop index
+                    str_dict = struct_attrs[struct_names.index(struct_name)][struct_name][0]
+                except (ValueError, IndexError) as e:
+                    str_dict = None
+                    logger.warning(f"Couldn't get struct attributes for struct {struct_name}: {e}")
                 wrk = struct_name.find('@')
                 if wrk > -1:
-                    add_struct_to_item_template(parent, struct_name[:wrk], template, struct_dict, struct_name[wrk + 1:])
+                    add_struct_to_item_template(parent, struct_name[:wrk], template, struct_dict, struct_name[wrk + 1:], struct_attrs=str_dict)
                 else:
-                    add_struct_to_item_template(parent, struct_name, template, struct_dict, instance)
+                    add_struct_to_item_template(parent, struct_name, template, struct_dict, instance, struct_attrs=str_dict)
             if template != {}:
                 config = merge(template, config, source_name, 'Item-Tree')
             struct_merging_active = False
@@ -479,7 +515,7 @@ def set_attr_for_subtree(subtree, attr, value, indent=0):
     return
 
 
-def add_struct_to_item_template(path, struct_name, template, struct_dict, instance):
+def add_struct_to_item_template(path, struct_name, template, struct_dict, instance, struct_attrs=None):
     """
     Add the referenced struct to the items_template subtree
 
@@ -488,6 +524,7 @@ def add_struct_to_item_template(path, struct_name, template, struct_dict, instan
     :param template: Template dict to be merged into the item tree
     :param struct_dict: dict with all defined structs (from /etc/structs.yaml and from loaded plugins)
     :param instance: For multi instance plugins: instance for which the items work (is derived from item with struct attribute)
+    :param struct_attrs: OrderedDict with attributes to set for every item
 
     :return:
     """
@@ -497,7 +534,7 @@ def add_struct_to_item_template(path, struct_name, template, struct_dict, instan
         # no struct/template with this name
         nf = collections.OrderedDict()
         nf['name'] = "ERROR: struct '" + struct_name + "' not found!"
-        nested_put(template, path, nf)
+        nested_put(template, path, nf, add=struct_attrs)
         logger.error(f"add_struct_to_item_template: Struct definition for '{struct_name}' not found (referenced in item {path})")
     else:
         # add struct/template to temporary item(template) tree
@@ -512,7 +549,7 @@ def add_struct_to_item_template(path, struct_name, template, struct_dict, instan
             if Utils.to_bool(getattr(_sh, '_struct_strip_name', False)):
                 del tmp_struct['name']
                 logger.debug(f'removed "name" attribute from struct {struct_name}')
-        nested_put(template, path, tmp_struct)
+        nested_put(template, path, tmp_struct, add=struct_attrs)
 
         if instance != '' or True:
             # add instance to items added by template struct

--- a/lib/config.py
+++ b/lib/config.py
@@ -449,6 +449,7 @@ def search_for_struct_in_items(items, struct_dict, config, source_name='', paren
 
             instance = items.get('instance', '')
             template = collections.OrderedDict()
+            # attr_struct_names = [list(x.keys())[0] for x in struct_attrs]
 
             global struct_merging_active
             struct_merging_active = True
@@ -456,9 +457,10 @@ def search_for_struct_in_items(items, struct_dict, config, source_name='', paren
                 try:
                     # get the first (only) entry out of the value for key(struct_name) in list position equal to for-loop index
                     str_dict = struct_attrs[struct_names.index(struct_name)][struct_name][0]
-                except (ValueError, IndexError) as e:
+                except (ValueError, IndexError):
                     str_dict = None
-                    logger.warning(f"Couldn't get struct attributes for struct {struct_name}: {e}")
+                    # we get here if no item attributes are defined, so don't log, just ignore
+                    # logger.warning(f"Couldn't get struct attributes for struct {struct_name}: {e}")
                 wrk = struct_name.find('@')
                 if wrk > -1:
                     add_struct_to_item_template(parent, struct_name[:wrk], template, struct_dict, struct_name[wrk + 1:], struct_attrs=str_dict)


### PR DESCRIPTION
closes #723 

You can insert item structs into items:

```
item1:
    struct: foo
```

or

```
item1:
    struct:
    - foo
```

If you want to recursively add attributes (e.g. `enforce_updates: true` or `database: init` or `visu_acl: ro`...) to all items imported from a struct, you would have to explicitly and manually define every item.

With this PR, you can do this as follows:

```
item1:
    struct:
    - foo:
       - enforce_updates: true
```

Note that:
1. even for one struct, you need to notate a list with dashes,
2. after the struct name, you have to add a colon `:` to make this a dict in yaml. Omitting the colon will prevent shng from being able to parse the yaml file.

You can add multiple struct (in the usual list format), and you can add multiple attributes (also in list format as shown). And of course you can add different attributes each time you include the same dict...

```
i_fn:
    struct: 
    -   my.attr.sf:
        - value: 'abc'
    -   my.attr.sn:
        - value: 2

i_f:
    struct:
    -   my.attr.sf:
        - value: 'xyz'

i_n:
    struct:
    -   my.attr.sn:
        - value: '1'
```

Adding nested dict structs **is** possible, but might lead to unforeseen consequences, as nested attributes introduce subitems to all items...

```
i_n:
    struct:
    -   my.attr.sn:
        - subitem:
               value: '1'
```

would add item `subitem` with value 1 (and implicit type `foo`) to every item in the struct...