### PR TITLE
docu: unify filename/folder usage, focus on current version

### DIFF
--- a/doc/user/source/admin/dienste.rst
+++ b/doc/user/source/admin/dienste.rst
@@ -48,7 +48,7 @@ Auf diesem Tab können folgende Funktionen ausgelöst werden:
   wird die in dem Zip Archiv gesicherte Konfiguration wiederhergestellt. Als Vorsichtsmaßnahme wird vor Beginn der
   Wiederherstellung ein Backup der aktuellen Konfiguration vorgenommen. Dieses verbleibt auf dem SmartHomeNG Server
   um im Notfall die aktuelle Konfiguration wiederherstellen zu können, falls die hochgeladene Datei nicht die gewünschte
-  Konfiguration enthielt. Dieses Backup wird im Verzeichnis ../var/backup abgelegt und trägt den Dateinamen
+  Konfiguration enthielt. Dieses Backup wird im Verzeichnis var/backup abgelegt und trägt den Dateinamen
   shng_config_backup_before_restore_<Jahr>-<Monat>-<Tag>-<Stunde>-<Minuten>.zip
 
 
@@ -116,7 +116,7 @@ Der CONF-YAML Konverter dient dazu, Snippets die im alten CONF Format vorliegen 
 Cache Prüfung
 =============
 
-Auf diesem Tab kann der SmartHomeNG Item-Cache überprüft werden. Dazu werden alle im Directory ../var/cache vorhandenen
+Auf diesem Tab kann der SmartHomeNG Item-Cache überprüft werden. Dazu werden alle im Directory var/cache vorhandenen
 Dateien angezeigt, zu denen es kein Item gibt oder zu denen es zwar ein Item gibt, bei dem jedoch das cache Attribut
 nicht gesetzt ist.
 

--- a/doc/user/source/admin/dienste.rst
+++ b/doc/user/source/admin/dienste.rst
@@ -28,13 +28,12 @@ Auf diesem Tab können folgende Funktionen ausgelöst werden:
 
 * **Backup**: Herunterladen der Konfigurationsdaten von SmartHomeNG als Zip Archiv
 
-  Das Zip-Archiv enthält die yaml Konfigurationsdateien aus dem /etc Verzeichnis (logging.yaml, logic.yaml,
-  module.yaml, plugin.yaml, smarthome.yaml und struct.yaml). Weiterhin sind alle yaml Dateien der Verzeichnisse
-  /items und /scenes enthalten. Außerdem enthält das Archiv den Python Code der Logiken aus dem Verzeichnis /logics.
-  Ab SmartHomeNG v1.7 werden auch die Zertifikats- und Key Dateien (\*.cer, \*.key) für tls/https aus dem /etc
-  Verzeichnis mit gesichert.
+  Das Zip-Archiv enthält die yaml Konfigurationsdateien aus dem ``/etc`` Verzeichnis (``logging.yaml``, ``logic.yaml``,
+  ``module.yaml``, ``plugin.yaml``, ``smarthome.yaml`` und ``struct.yaml``). Weiterhin sind alle yaml Dateien der Verzeichnisse
+  ``items`` und ``scenes`` enthalten. Außerdem enthält das Archiv den Python Code der Logiken aus dem Verzeichnis ``logics``.
+  Ab SmartHomeNG v1.7 werden auch die Zertifikats- und Key Dateien (``\*.cer``, ``\*.key``) für tls/https aus dem ``etc`` Verzeichnis mit gesichert.
 
-  Das heruntergeladene Archiv trägt den Namen shng_config_backup_<Jahr>-<Monat>-<Tag>-<Stunde>-<Minuten>.zip
+  Das heruntergeladene Archiv trägt den Namen ``shng_config_backup_<Jahr>-<Monat>-<Tag>-<Stunde>-<Minuten>.zip``
 
   Links neben dem **Herunterladen** Button wird Datum/Uhrzeit des letzten Backups angezeigt.
 
@@ -49,7 +48,7 @@ Auf diesem Tab können folgende Funktionen ausgelöst werden:
   Wiederherstellung ein Backup der aktuellen Konfiguration vorgenommen. Dieses verbleibt auf dem SmartHomeNG Server
   um im Notfall die aktuelle Konfiguration wiederherstellen zu können, falls die hochgeladene Datei nicht die gewünschte
   Konfiguration enthielt. Dieses Backup wird im Verzeichnis var/backup abgelegt und trägt den Dateinamen
-  shng_config_backup_before_restore_<Jahr>-<Monat>-<Tag>-<Stunde>-<Minuten>.zip
+  ``shng_config_backup_before_restore_<Jahr>-<Monat>-<Tag>-<Stunde>-<Minuten>.zip``
 
 
 .. image:: assets/services.jpg
@@ -116,7 +115,7 @@ Der CONF-YAML Konverter dient dazu, Snippets die im alten CONF Format vorliegen 
 Cache Prüfung
 =============
 
-Auf diesem Tab kann der SmartHomeNG Item-Cache überprüft werden. Dazu werden alle im Directory var/cache vorhandenen
+Auf diesem Tab kann der SmartHomeNG Item-Cache überprüft werden. Dazu werden alle im Directory ``var/cache`` vorhandenen
 Dateien angezeigt, zu denen es kein Item gibt oder zu denen es zwar ein Item gibt, bei dem jedoch das cache Attribut
 nicht gesetzt ist.
 

--- a/doc/user/source/admin/items.rst
+++ b/doc/user/source/admin/items.rst
@@ -76,7 +76,7 @@ Struktur Templates
 ==================
 
 Hier werden alle zur Verfügung stehenden Struktur Templates angezeigt. Das sind die Struktur Templates die von Plugins
-definiert werden, die aktuell in SmartHomeNG konfiguriert sind und die in ../etc/structs.yaml konfigurierten Strukturen.
+definiert werden, die aktuell in SmartHomeNG konfiguriert sind und die in etc/structs.yaml konfigurierten Strukturen.
 Strukturen aus Plugins sind daran zu erkennen, dass der Name der Item Struktur mit dem Namen des Plugins beginnt, an den
 sich mit einem Punkt getrennt der eigentliche Name der Struktur anschließt.
 
@@ -87,7 +87,7 @@ sich mit einem Punkt getrennt der eigentliche Name der Struktur anschließt.
 Struktur Konfiguration
 ======================
 
-Hier können eigene Struktur Templates konfiguriert werden, die in der Datei ../etc/structs.yaml gespeichert werden.
+Hier können eigene Struktur Templates konfiguriert werden, die in der Datei etc/structs.yaml gespeichert werden.
 
 .. image:: assets/items-struct-configuration.jpg
    :class: screenshot

--- a/doc/user/source/admin/items.rst
+++ b/doc/user/source/admin/items.rst
@@ -76,7 +76,7 @@ Struktur Templates
 ==================
 
 Hier werden alle zur Verfügung stehenden Struktur Templates angezeigt. Das sind die Struktur Templates die von Plugins
-definiert werden, die aktuell in SmartHomeNG konfiguriert sind und die in etc/structs.yaml konfigurierten Strukturen.
+definiert werden, die aktuell in SmartHomeNG konfiguriert sind und die in ``etc/structs.yaml`` konfigurierten Strukturen.
 Strukturen aus Plugins sind daran zu erkennen, dass der Name der Item Struktur mit dem Namen des Plugins beginnt, an den
 sich mit einem Punkt getrennt der eigentliche Name der Struktur anschließt.
 
@@ -87,7 +87,7 @@ sich mit einem Punkt getrennt der eigentliche Name der Struktur anschließt.
 Struktur Konfiguration
 ======================
 
-Hier können eigene Struktur Templates konfiguriert werden, die in der Datei etc/structs.yaml gespeichert werden.
+Hier können eigene Struktur Templates konfiguriert werden, die in der Datei ``etc/structs.yaml`` gespeichert werden.
 
 .. image:: assets/items-struct-configuration.jpg
    :class: screenshot

--- a/doc/user/source/admin/logiken.rst
+++ b/doc/user/source/admin/logiken.rst
@@ -37,7 +37,7 @@ Auf einem 2. Tab kann eine Liste der Systemlogiken eingesehen werden.
 
 .. index:: Logiken; Editor
 
-Ab **SmartHomeNG v1.10** können die Logiken in dieser Ansicht gruppiert werden. Wenn mindestens eine Logik einer Gruppe
+Logiken können in dieser Ansicht gruppiert werden. Wenn mindestens eine Logik einer Gruppe
 zugeordnet wird, ändert sich die Ansicht von einer flachen Liste, in eine Liste aufklappbarer Gruppen.
 
 .. image:: assets/logics-grouped.jpg
@@ -57,12 +57,10 @@ der Liste der Logiken oder durch den Button **Neue Logik** gestartet.
 Code Editor
 -----------
 
-Das Tab mit dem Code Editor ermöglicht den Python Code der Logik zu erfassen/zu ändern.
+Das Tab mit dem Code Editor ermöglicht, den Python Code der Logik zu erfassen/zu ändern und die Logik zu aktivieren, zu deaktivieren oder neu zu laden.
 
 .. image:: assets/logics-codeeditor.jpg
    :class: screenshot
-
-Ab **SmartHomeNG v1.10** sind Buttons zum Aktivieren/Deaktivieren und zum neu Laden der Logik hinzugekommen.
 
 
 Parameter Editor
@@ -73,9 +71,6 @@ für die Logik konfiguriert werden.
 
 .. image:: assets/logics-parametereditor.jpg
    :class: screenshot
-
-Ab **SmartHomeNG v1.10** sind Felder für die Beschreibung der Logik und zur Zuordnung zu einer bzw. mehreren Gruppen
-hinzu gekommen.
 
 Beschreibung
 ~~~~~~~~~~~~

--- a/doc/user/source/admin/logs.rst
+++ b/doc/user/source/admin/logs.rst
@@ -64,7 +64,7 @@ Aus der Liste geht hervor, über welchen Log-Handler die Einträge in welches Lo
 Konfiguration/Logging).
 
 Auf dem Screenshot ist zu sehen, wie das Logging einzelner Logiken unterschiedlich konfiguriert ist. Es gibt einen
-Logger **logics**, der WARNINGS (oder höher) aus allen Logiken in das Logfile **smarthome-details.log** schreibt.
+Logger **logics**, der WARNINGS (oder höher) aus allen Logiken in das Logfile ``smarthome-details.log`` schreibt.
 Abweichend davon, ist ein Logger für die Logik **a_testlogic2** definiert, der INFOs (oder höher) loggt und zwar über
 den Standardhandler für Logiken (es ist in der Konfiguration kein Handler angegeben).
 
@@ -79,7 +79,7 @@ Logging Konfiguration
 =====================
 
 Unter **Konfiguration** kann das Logging vollständig konfiguriert werden. Hierzu wird die Konfigurationsdatei
-**logging.yaml** direkt editiert. Änderungen an der Konfiguration werden erst wirksam, wenn SmartHomeNG neu gestartet
+``logging.yaml`` direkt editiert. Änderungen an der Konfiguration werden erst wirksam, wenn SmartHomeNG neu gestartet
 wird.
 
 

--- a/doc/user/source/admin/plugins.rst
+++ b/doc/user/source/admin/plugins.rst
@@ -50,7 +50,7 @@ durchführen zu müssen.
 Liste der konfigurierten Plugins
 ================================
 
-Die Liste der konfigurierten Plugins zeigt alle Konfigurationen an, die in ../etc/plugin.yaml gespeichert sind. Der
+Die Liste der konfigurierten Plugins zeigt alle Konfigurationen an, die in etc/plugin.yaml gespeichert sind. Der
 Schiebeschalter links in jeder Zeile zeigt ob das Plugin aktiviert ist. Falls nicht, ist es nicht geladen bzw. wird bei
 einem Neustart nicht geladen.
 

--- a/doc/user/source/admin/plugins.rst
+++ b/doc/user/source/admin/plugins.rst
@@ -50,7 +50,7 @@ durchführen zu müssen.
 Liste der konfigurierten Plugins
 ================================
 
-Die Liste der konfigurierten Plugins zeigt alle Konfigurationen an, die in etc/plugin.yaml gespeichert sind. Der
+Die Liste der konfigurierten Plugins zeigt alle Konfigurationen an, die in ``etc/plugin.yaml`` gespeichert sind. Der
 Schiebeschalter links in jeder Zeile zeigt ob das Plugin aktiviert ist. Falls nicht, ist es nicht geladen bzw. wird bei
 einem Neustart nicht geladen.
 

--- a/doc/user/source/admin/system.rst
+++ b/doc/user/source/admin/system.rst
@@ -98,7 +98,7 @@ Allgemein
 =========
 
 In diesem Tab werden die allgemeinen Einstellungen für SmartHomeNG konfiguriert. Es handelt sich hierbei um die Einstellungen,
-die in der Konfigurationsdatei etc/smarthome.yaml abgelegt sind.
+die in der Konfigurationsdatei ``etc/smarthome.yaml`` abgelegt sind.
 
 .. image:: assets/system-common.jpg
    :class: screenshot
@@ -129,7 +129,7 @@ Admin Modul
 ===========
 
 In diesem Tab werden die Einstellungen für das Admin Modul konfiguriert. Es handelt sich hierbei um die Einstellungen,
-die in der Konfigurationsdatei etc/module.yaml im Abschnitt ``admin:`` abgelegt sind.
+die in der Konfigurationsdatei ``etc/module.yaml`` im Abschnitt **admin:** abgelegt sind.
 
 .. image:: assets/system-admin.jpg
    :class: screenshot
@@ -155,7 +155,7 @@ MQTT Modul
 ==========
 
 In diesem Tab werden die Einstellungen für Nutzung des MQTT Protokolls konfiguriert. Es handelt sich hierbei um die
-Einstellungen, die in der Konfigurationsdatei etc/module.yaml im Abschnitt ``mqtt:`` abgelegt sind.
+Einstellungen, die in der Konfigurationsdatei ``etc/module.yaml`` im Abschnitt **mqtt:** abgelegt sind.
 
 .. image:: assets/system-mqtt.jpg
    :class: screenshot

--- a/doc/user/source/admin/system.rst
+++ b/doc/user/source/admin/system.rst
@@ -98,7 +98,7 @@ Allgemein
 =========
 
 In diesem Tab werden die allgemeinen Einstellungen für SmartHomeNG konfiguriert. Es handelt sich hierbei um die Einstellungen,
-die in der Konfigurationsdatei ../etc/smarthome.yaml abgelegt sind.
+die in der Konfigurationsdatei etc/smarthome.yaml abgelegt sind.
 
 .. image:: assets/system-common.jpg
    :class: screenshot
@@ -115,7 +115,7 @@ Http Modul
 Im Tab für das http Modul werden die Einstellungen für das http Modul konfiguriert. Die Anmeldeinformation wird sowohl
 vom http Modul (Basic Auth), als auch vom Admin Modul (JWT Token) genutzt. Passworte werden hierbei nur als Hash in die
 Konfiguration geschrieben und NICHT im Klartext. Ein vergessenes Passwort kann daher nicht wieder sichtbar gemacht werden.
-Es handelt sich hierbei um die Einstellungen, die in der Konfigurationsdatei ../etc/module.yaml im Abschnitt http: abgelegt
+Es handelt sich hierbei um die Einstellungen, die in der Konfigurationsdatei etc/module.yaml im Abschnitt http: abgelegt
 sind.
 
 .. image:: assets/system-http.jpg
@@ -129,7 +129,7 @@ Admin Modul
 ===========
 
 In diesem Tab werden die Einstellungen für das Admin Modul konfiguriert. Es handelt sich hierbei um die Einstellungen,
-die in der Konfigurationsdatei ../etc/module.yaml im Abschnitt ``admin:`` abgelegt sind.
+die in der Konfigurationsdatei etc/module.yaml im Abschnitt ``admin:`` abgelegt sind.
 
 .. image:: assets/system-admin.jpg
    :class: screenshot
@@ -138,14 +138,14 @@ Falls ein Username und ein Password konfiguriert sind, steuern die folgenden zwe
 Anmeldung. Die Anmeldung wird über ein Token gesteuert, welches auch bei Beendigung des Browsers erhalen bleibt. Es
 wird bei Klick auf den Abmelden Button gelöscht oder es verfällt nach Ablauf der Gültigkeitsdauer.
 
-Der Parameter **login_experiation** legt die Gültigkeitsdauer (in Stunden) des bei der Anmeldung ausgestellten Tokens
+Der Parameter **login_expiration** legt die Gültigkeitsdauer (in Stunden) des bei der Anmeldung ausgestellten Tokens
 fest. Falls eine kurze Gültigkeit gewünscht ist, können auch Werte kleiner 1 angegeben werden. (0.5 bedeutet z.B. eine
 Gültigkeit von 30 Minuten).
 
 Der Parameter **login_autorenew** legt fest, ob bei Nutzung des Administrations-Interfaces die Gültigkeit des Tokens
 verlängert wird oder nicht. Wenn **login_autorenew** auf **true** gesetzt ist, wird bei einer Nutzung des
 Administrations-Interfaces nach Ablauf der halben Gültigkeits-Dauer das Token erneuert, so dass es wieder die volle
-mit **login_experiation** festgelegte Dauer gültig ist.
+mit **login_expiration** festgelegte Dauer gültig ist.
 
 
 .. index:: Konfiguration; mqtt Modul
@@ -155,7 +155,7 @@ MQTT Modul
 ==========
 
 In diesem Tab werden die Einstellungen für Nutzung des MQTT Protokolls konfiguriert. Es handelt sich hierbei um die
-Einstellungen, die in der Konfigurationsdatei ../etc/module.yaml im Abschnitt ``mqtt:`` abgelegt sind.
+Einstellungen, die in der Konfigurationsdatei etc/module.yaml im Abschnitt ``mqtt:`` abgelegt sind.
 
 .. image:: assets/system-mqtt.jpg
    :class: screenshot

--- a/doc/user/source/beispiele/items/items_tipps_und_tricks.rst
+++ b/doc/user/source/beispiele/items/items_tipps_und_tricks.rst
@@ -126,7 +126,7 @@ dennoch leicht erhellt wird.
 
 Welches der beiden Items man nutzen will, bleibt jedem selbst überlassen. Schließlich ist der Status des
 jeweiligen Items bereits eindeutig. Wichtig dafür ist natürlich, dass die richtigen Geo-Koordinaten und die
-Zeitzone in der Datei **../etc/smarthome.yaml** hinterlegt sind sowie die aktuelle Uhrzeit auf dem Rechner
+Zeitzone in der Datei ``etc/smarthome.yaml`` hinterlegt sind sowie die aktuelle Uhrzeit auf dem Rechner
 eingestellt ist.
 
 Um Tag/Nacht-Items zu erstellen, bringt SmarthomeNG bereits alles mit. Man kann einfach auf die SmarthomeNG

--- a/doc/user/source/beispiele/plugins/plugin_aus_develop.rst
+++ b/doc/user/source/beispiele/plugins/plugin_aus_develop.rst
@@ -82,11 +82,11 @@ Dazu gibt es im Prinzip drei Wege, das Plugin zu installieren:
         **Gewünschtes Plugin installieren:**
 
         Um zum Beispiel ein Plugin mit dem Namen **xyz** aus dem develop Branch zu installieren, sollte (falls es existiert)
-        zuerst das Verzeichnis **xyz_dev** im ``plugins`` Verzeichnis gelöscht werden, damit keine Seiteneffekte durch
+        zuerst das Verzeichnis ``xyz_dev`` im ``plugins`` Verzeichnis gelöscht werden, damit keine Seiteneffekte durch
         bestehende Dateien auftreten.
 
-        Anschließend kann das Verzeichnis **xyz** (mit allen Bestandteilen/Unterordnern) aus dem beim Entpacken entstandenen
-        Verzeichnis ``plugins-develop`` in das ``plugins`` Verzeichnis der SmartHomeNG Installation unter dem Namen **xyz_dev**
+        Anschließend kann das Verzeichnis ``xyz`` (mit allen Bestandteilen/Unterordnern) aus dem beim Entpacken entstandenen
+        Verzeichnis ``plugins-develop`` in das ``plugins`` Verzeichnis der SmartHomeNG Installation unter dem Namen ``xyz_dev``
         kopiert werden.
 
         Nun kann das Archiv ``develop.zip`` und das Verzeichnis ``plugins-develop`` gelöscht werden.

--- a/doc/user/source/beispiele/structs/1_structs.rst
+++ b/doc/user/source/beispiele/structs/1_structs.rst
@@ -9,7 +9,7 @@
 structs (Item Strukturen)
 =========================
 
-Durch folgende Einträge in der Datei **../structs/global_structs.yaml** werden diverse Templates bereit gestellt,
+Durch folgende Einträge in der Datei ``etc/structs/global_structs.yaml`` werden diverse Templates bereit gestellt,
 auf die von Items referenziert werden kann. Es gibt hier auch keine erkennbare Unterscheidung zwischen
 Structs und Sub-Structs, alle Deklarationen sind gleichwertig und können nach Belieben verschachtelt werden.
 

--- a/doc/user/source/beispiele/umzug.rst
+++ b/doc/user/source/beispiele/umzug.rst
@@ -225,7 +225,7 @@ Verzeichnisse können Unterverzeichnisse enthalten und müssen daher rekursiv ko
 Nicht kopiert werden müssen die Verzeichnisse ``backup`` und ``restore``, sowie die Dateien ``pip_list.txt``
 und ``systeminfo.yaml``, die direkt im ``var`` Verzeichnis liegen.
 
-Wenn die alte SmarthomeNG Installation (das Verzeichnis /usr/local/smarthome) auf dem neuen System
+Wenn die alte SmarthomeNG Installation (das Verzeichnis ``/usr/local/smarthome``) auf dem neuen System
 als /mnt/shng_old gemountet wurde, sollten die jeweiligen Verzeichnisse unterhalb des var Verzeichnisses
 mit den folgenden Befehlen kopiert werden (hier am Beispiel des cache Verzeichnisse):
 

--- a/doc/user/source/beispiele/umzug.rst
+++ b/doc/user/source/beispiele/umzug.rst
@@ -202,7 +202,7 @@ Mit Hilfe der Admin GUI ein Backup der Konfiguration von SmartHomeNG erstellen.
 Kopieren weiterer Daten
 -----------------------
 
-Im folgenden werden weitere Daten, die im ``../var`` Verzeichnis von SmartHmeNG gespeichert sind, auf das neue System
+Im folgenden werden weitere Daten, die im ``var`` Verzeichnis von SmartHmeNG gespeichert sind, auf das neue System
 übertragen.
 
 Für die folgen Schritte ist es **wichtig**, dass SmartHomeNG weder auf dem alten System, noch auf dem neuen
@@ -219,11 +219,11 @@ Im folgenden ist das kopieren des Verzeichnisse beschrieben, die fast bei jeder 
 kopiert werden müssen.
 
 Hinzu kommen Verzeichnisse, die von weiteren selterner genutzten Plugins
-im ``../var`` Verzeichnis angelegt wurden (z.B. **bo_netlink**, **esphome**, **panasonic_ac**). Diese
+im ``var`` Verzeichnis angelegt wurden (z.B. ``bo_netlink``, ``esphome``, ``panasonic_ac``). Diese
 Verzeichnisse können Unterverzeichnisse enthalten und müssen daher rekursiv kopiert werden.
 
-Nicht kopiert werden müssen die Verzeichnisse **backup** und **restore**, sowie die Dateien **pip_list.txt**
-und **systeminfo.yaml**, die direkt im ``../var`` Verzeichnis liegen.
+Nicht kopiert werden müssen die Verzeichnisse ``backup`` und ``restore``, sowie die Dateien ``pip_list.txt``
+und ``systeminfo.yaml``, die direkt im ``var`` Verzeichnis liegen.
 
 Wenn die alte SmarthomeNG Installation (das Verzeichnis /usr/local/smarthome) auf dem neuen System
 als /mnt/shng_old gemountet wurde, sollten die jeweiligen Verzeichnisse unterhalb des var Verzeichnisses

--- a/doc/user/source/entwickler_doku.rst.off
+++ b/doc/user/source/entwickler_doku.rst.off
@@ -3,8 +3,8 @@
 Entwickler Dokumentation (Englisch)
 ###################################
 
-Wenn jemand Plugins entwickeln möchte oder Interesse an der Mitarbeit bei der allgemeinen
-Weiterentwicklung von SmartHomeNG hat, benötigt er weitergehende Informationen.
+Die früher gepflegte Entwicklerdokumentation wurde in Gänze in die
+Anwenderdokumentation aufgenommen und wird dort auf Deutsch weitergepflegt.
 
-Diese für Entwickler interessante Dokumentation steht ausschließlich in englischer Sprache
-zur Verfügung und ist hier zu finden: `https://www.smarthomeNG.de/developer/ <../developer/>`_
+Einzelne Anteile können nach wie vor auf Englisch sein, sofern diese direkt aus
+dem Programmcode übernommen wurden.

--- a/doc/user/source/entwicklung/build_doc.rst
+++ b/doc/user/source/entwicklung/build_doc.rst
@@ -48,7 +48,7 @@ Der eigentliche Bau der Dokumentation erfolgt mit dem folgenden Befehl:
    ./build_doc.sh
 
 
-Dieses Skript erzeugt einen Unterordner **work** in welchem der eigentliche Build Prozess abläuft und die
+Dieses Skript erzeugt einen Unterordner ``work`` in welchem der eigentliche Build Prozess abläuft und die
 Ergebnisse gespeichert werden.
 
 Nachdem das Skript beendet ist, ist die Anwender Dokumentation im Ordner
@@ -73,9 +73,6 @@ werden soll.
 Wenn das Build Skript ein zweiter mal gestartet wird, wird die Dokumentation aus den Dateien gebaut, die bereits
 bei einem vorangegangenen Bau aus github ausgecheckt wurden. Wenn die Dateien erneut ausgecheckt werden sollen, muss
 das Skript build_doc.sh mit der Option **-f** aufgerufen werden. (-f = force checkout)
-
-Falls nur eine Dokumentation gebaut werden soll (**user** oder **developer**), muss das Skript mit den
-Optionen **-u** oder --*d** aufgerufen werden.
 
 Falls die Dokumentation aus dem **master** Branch gebaut werden soll, muss die Option **-m** angegeben werden.
 Das sollte mit der Option **force checkout** kombiniert werden, um sicherzustellen, dass die richtigen Dateien

--- a/doc/user/source/entwicklung/core/core_shng.rst
+++ b/doc/user/source/entwicklung/core/core_shng.rst
@@ -1,14 +1,14 @@
 Der Core von SmartHomeNG
 ========================
 
-Der Core von SmartHomeNG besteht aus einem Haupt-Objekt welches in ``bin/smarthome.py`` definiert ist und einer
-Reihe von Programm Modulen, die exklusiv für die Nutzung durch den Core Hilfs-Objekte implementieren.
-Die Programm Module sind in dem Ordner ``lib`` abgelegt und im Unterpunkt **Programm Modulen** beschrieben.
+Der Core von SmartHomeNG besteht aus einem Haupt-Objekt, welches in ``bin/smarthome.py`` definiert ist und einer
+Reihe von Programm-Modulen, die exklusiv für die Nutzung durch den Core Hilfs-Objekte implementieren.
+Die Programm-Module sind in dem Ordner ``lib`` abgelegt und im Unterpunkt **Programm Module** beschrieben.
 
 smarthome.py
 ------------
 
-Das Haupt-Objekt von SmartHomeNG ist im folgenden beschrieben:
+Das Haupt-Objekt von SmartHomeNG ist im Folgenden beschrieben:
 
 .. module:: lib.smarthome
 

--- a/doc/user/source/entwicklung/core/core_shng.rst
+++ b/doc/user/source/entwicklung/core/core_shng.rst
@@ -3,7 +3,7 @@ Der Core von SmartHomeNG
 
 Der Core von SmartHomeNG besteht aus einem Haupt-Objekt welches in ``bin/smarthome.py`` definiert ist und einer
 Reihe von Programm Modulen, die exklusiv für die Nutzung durch den Core Hilfs-Objekte implementieren.
-Die Programm Module sind in dem Ordner ``../lib`` abgelegt und im Unterpunkt **Programm Modulen** beschrieben.
+Die Programm Module sind in dem Ordner ``lib`` abgelegt und im Unterpunkt **Programm Modulen** beschrieben.
 
 smarthome.py
 ------------

--- a/doc/user/source/entwicklung/logiken/logiken.rst
+++ b/doc/user/source/entwicklung/logiken/logiken.rst
@@ -15,7 +15,7 @@ Eine Logik besteht aus einem Python Skript sowie einer Reihe von Parametern die 
 steuern. Eine Logik kann während der Laufzeit von SmartHomeNG geladen und entladen werden. Dadurch sind Veränderungen
 ein einer Logik möglich, ohne SmartHomeNG neu starten zu müssen.
 
-Wird ein zusätzliches Python Modul in einer Logik benötigt, so kann eine ``requirements.txt`` im Verzeichnis ``logics`` erstellt 
+Wird ein zusätzliches Python Modul in einer Logik benötigt, so kann eine ``requirements.txt`` im Verzeichnis ``etc/logics`` erstellt 
 und in dieser Datei Namen und Versionen für die Installation via PIP notiert werden.
 In diesem Fall muss SmartHomeNG auf jeden Fall neu gestartet werden da die Überprüfung nur beim Start von SmartHomeNG erfolgt.
 
@@ -23,9 +23,9 @@ In diesem Fall muss SmartHomeNG auf jeden Fall neu gestartet werden da die Über
 Einführung
 ==========
 
-Das eigentliche Python Skript einer Logik muss im Verzeichnis ``../logics`` der SmartHomeNG Installation abgelegt
+Das eigentliche Python Skript einer Logik muss im Verzeichnis ``etc/logics`` der SmartHomeNG Installation abgelegt
 werden. Damit die Logik getriggert und ausgeführt wird, muss sie zusätzlich in der Konfigurationsdatei
-``../etc/logic.yaml`` konfiguriert werden. Hier wird festgelegt, unter welchen Bedingungen eine bestimmte Logik
+``etc/logic.yaml`` konfiguriert werden. Hier wird festgelegt, unter welchen Bedingungen eine bestimmte Logik
 auszuführen ist.
 
 Wenn eine Logik mit der Admin GUI erstellt wurde, ist sie nach dem ersten erfolgreichen Laden pausiert (disabled).
@@ -163,18 +163,18 @@ Beispiele
 
 Die folgende Beispielkonfiguration definiert 4 Logiken:
 
-* Die erste Logik mit Namen ``InitSmartHomeNG`` befindet sich in der Datei ``logics/initsmarthomeng.py``.
+* Die erste Logik mit Namen ``InitSmartHomeNG`` befindet sich in der Datei ``etc/logics/initsmarthomeng.py``.
   Das Attribut ``crontab: init`` weist SmartHomeNG an diese Logik direkt nach dem Start auszuführen.
-* Die zweite Logik mit dem Namen ``Hourly`` befindet sich in der Datei ``logics/time.py``
+* Die zweite Logik mit dem Namen ``Hourly`` befindet sich in der Datei ``etc/logics/time.py``
   und das Attribut ``cycle: 3600`` weist SmartHomeNG an die Logik alle 3600 Sekunden (jede Stunde) auszuführen.
-* Die dritte Logik mit Namen ``Gate`` befindet sich in der Datei ``logics/gate.py`` und das Attribut
+* Die dritte Logik mit Namen ``Gate`` befindet sich in der Datei ``etc/logics/gate.py`` und das Attribut
   ``watch_item: gate.alarm`` weist SmartHomeNG an die Logik auszuführen, wenn der Wert des Items gate.alarm sich ändert.
-* Die vierte Logik mit Namen ``disks`` befindet sich in der Datei ``logics/disks.py``. Der crontab Eintrag weist SmartHomeNG an
+* Die vierte Logik mit Namen ``disks`` befindet sich in der Datei ``etc/logics/disks.py``. Der crontab Eintrag weist SmartHomeNG an
   diese Logik alle 5 Minuten auszuführen. Der Parameter ``usage_warning`` ist ein benutzerdefinierter Parameter, der
   in der Logik verwendet wird, um einen Schwellwert zu definieren.
 
 .. code-block:: yaml
-   :caption:  etc/logic.yaml
+   :caption: etc/logic.yaml
 
    InitSmarthomeNG:
        filename: initsmarthomeng.py

--- a/doc/user/source/entwicklung/module/module.rst
+++ b/doc/user/source/entwicklung/module/module.rst
@@ -13,7 +13,7 @@ Ladbare Code Module (SmartHomeNG Module) stellen zusätzliche Funktionalitäten 
 von Plugins und Logiken genutzt werden können. Sie implementieren Funktionalitäten, die nicht unbedingt benötigt
 werden und deshalb nicht direkt im Core implementiert und zwangsweise geladen werden.
 
-Module werden in der Datei ``../etc/modules.yaml`` oder in der Admin GUI konfiguriert. Die Parameter sind in
+Module werden in der Datei ``etc/modules.yaml`` oder in der Admin GUI konfiguriert. Die Parameter sind in
 der jeweiligen README.md beschrieben.
 
 Bisher existieren die folgenden Module:
@@ -33,18 +33,18 @@ Ein Modul besteht aus mindestens zwei Dateien:
 - dem Programm Code: __init__.py
 - den Metadaten: module.yaml
 
-Beide Dateien lliegen in einem Unterordnet des Ordners ``../modules`` und dieser Unterordnet trägt den Namen des
+Beide Dateien lliegen in einem Unterordnet des Ordners ``modules`` und dieser Unterordnet trägt den Namen des
 Mooduls.
 
 Metadaten
 =========
 
-Die **Metadaten** Datei trägt den Namen ``../modules/<name of the module>/module.yaml``. Sie hat zwei
+Die **Metadaten** Datei trägt den Namen ``modules/<name of the module>/module.yaml``. Sie hat zwei
 Haupt Abschnitte:
 
 
 - ``module:`` - Globale Metadaten des Moduls
-- ``parameters:`` - Definition der Parameter welche in ``../etc/module.yaml`` zur Konfiguration des Moduls
+- ``parameters:`` - Definition der Parameter welche in ``etc/module.yaml`` zur Konfiguration des Moduls
   genutzt werden können.
 
 .. include:: /referenz/metadata/module_global.rst
@@ -53,5 +53,5 @@ Haupt Abschnitte:
 
 
 Falls ein Modul ein Python Package nutzt, welches nicht in der Standardinstallation von Python enthalten ist,
-muss diese Anforderung in der Datei ``../modules/<name of the module>/requirements.txt`` dokumentiert werden.
+muss diese Anforderung in der Datei ``modules/<name of the module>/requirements.txt`` dokumentiert werden.
 

--- a/doc/user/source/entwicklung/module/module.rst
+++ b/doc/user/source/entwicklung/module/module.rst
@@ -33,8 +33,8 @@ Ein Modul besteht aus mindestens zwei Dateien:
 - dem Programm Code: __init__.py
 - den Metadaten: module.yaml
 
-Beide Dateien lliegen in einem Unterordnet des Ordners ``modules`` und dieser Unterordnet trägt den Namen des
-Mooduls.
+Beide Dateien liegen in einem Unterordner des Ordners ``modules`` und dieser Unterordner trägt den Namen des
+Moduls.
 
 Metadaten
 =========

--- a/doc/user/source/entwicklung/plugins/entwicklungsrichtlinien.rst
+++ b/doc/user/source/entwicklung/plugins/entwicklungsrichtlinien.rst
@@ -143,7 +143,7 @@ Basic Rules
 Fork erstellen
 --------------
 
-    * Gehen Sie aif GitHub zum `SmartHome Repo <https://github.com/smarthomeNG/smarthome/>`_ und melden Sie sich mit
+    * Gehen Sie auf GitHub zum `SmartHome Repo <https://github.com/smarthomeNG/smarthome/>`_ und melden Sie sich mit
       Ihrem Benutzernamen/Passwort an
     * Klicken Sie rechts oben auf „Fork“.
     * Wechseln Sie zu Ihrem Terminal und geben Sie „git clone https://USER:PASSWORD@github.com/USER/smarthome“ ein

--- a/doc/user/source/entwicklung/plugins/entwicklungsrichtlinien.rst
+++ b/doc/user/source/entwicklung/plugins/entwicklungsrichtlinien.rst
@@ -122,13 +122,13 @@ Testen und Dokumentieren
 
 Bitte den Code des Plugins ausgiebig testen und dokumentieren!
 
-In Ihrem Plugin-Verzeichnis sollte sich eine Datei **user_doc.rst** (aus dem Verzeichnis „sample_plugin“) befinden.
+In Ihrem Plugin-Verzeichnis sollte sich eine Datei ``user_doc.rst`` (aus dem Verzeichnis „sample_plugin“) befinden.
 Bitte diese Datei mit die notwendigen Informationen befüllen. ``viplugins/myplugin/user_doc.rst``
 
 Methoden und Funktionen sollten mit einem Docstring versehen werden, der den Zweck der Methode/Funktion, die
 Aufrufparameter und den Rückgabewert beschreibt.
 
-Weiterhin ist es sinnvoll **Unittests** für das Plugin zu erstellen.
+Weiterhin ist es sinnvoll, **Unittests** für das Plugin zu erstellen.
 
 
 Basic Rules
@@ -168,7 +168,7 @@ Mitglieder des Core Teams von SmartHomeNG können dann den Pull-Request prüfen 
 .git/config (description is deprecated, has to be updated)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Falls Probleme beim pushen auf GitHub bestehen, bitte die **config**-Datei im **.git** Verzeichnis überprüfen.
+Falls Probleme beim pushen auf GitHub bestehen, bitte die ``config``-Datei im ``.git`` Verzeichnis überprüfen.
 Sie sollte zum Beispiel folgendermaßen aussehen:
 
 .. code-block:: ini
@@ -187,7 +187,7 @@ Sie sollte zum Beispiel folgendermaßen aussehen:
 
 Falls der Code für GitHub verifizierbar signiert werden soll, muss noch die gpg Signierung auf GitHub und in der
 Entwicklungsumgebung konfiguriert sein. In dem Fall gibt es noch die beiden folgenden Abschnitte in der git
-**config**-Datei:
+``config``-Datei:
 
 .. code-block:: ini
 

--- a/doc/user/source/entwicklung/plugins/kurzanleitung/plugin_in5minutes.rst
+++ b/doc/user/source/entwicklung/plugins/kurzanleitung/plugin_in5minutes.rst
@@ -8,7 +8,7 @@ Plugins sind Erweiterungen von SmartHomeNG mit zusätzlichen Funktionen. Sie sin
 Um ein neues Plugin hinzuzufügen, wird der Plugin-Code und ein entsprechender Eintrag in der Konfigurationsdatei ``plugin.yaml`` benötigt.
 
 Eine gute Basis für ein eigenes Plugin ist das Beispielplugin, welches komplett
-mit allen notwendigen Dateien auf github unter https://github.com/smarthomeng/smarthome im ``/dev``-Ordner zur Verfügung steht.
+mit allen notwendigen Dateien auf github unter https://github.com/smarthomeng/smarthome im ``dev``-Ordner zur Verfügung steht.
 
 
 Beschreibung des Plugins
@@ -17,7 +17,7 @@ Beschreibung des Plugins
 Übersicht
 ---------
 
-Das Plugin wird in einem eigenen Ordner unterhalb des ``/plugins``-Ordner abgelegt. Der Name des Ordners entspricht dem Namen des Plugins in **Kleinschreibung**.
+Das Plugin wird in einem eigenen Ordner unterhalb des ``plugins``-Ordner abgelegt. Der Name des Ordners entspricht dem Namen des Plugins in **Kleinschreibung**.
 
 Derzeit besteht ein Plugin mindestens aus drei Dateien, die alle im Plugin Ordner liegen. Dies sind:
 

--- a/doc/user/source/entwicklung/plugins/kurzanleitung/plugin_metadata.rst
+++ b/doc/user/source/entwicklung/plugins/kurzanleitung/plugin_metadata.rst
@@ -71,7 +71,7 @@ Die Metadaten werden weiterhin vorgesehen
 
 .. hint::
 
-    Zum Validieren der Metadaten in plugin.yaml kann das Tool /tools/plugin_metadata_checker.py genutzt werden. Dies
+    Zum Validieren der Metadaten in ``plugin.yaml`` kann das Tool ``tools/plugin_metadata_checker.py`` genutzt werden. Dies
     prüft die Metadaten auf Vollständigkeit und Fehlerfreiheit.
 
 

--- a/doc/user/source/entwicklung/plugins/kurzanleitung/samplemqttplugin.rst
+++ b/doc/user/source/entwicklung/plugins/kurzanleitung/samplemqttplugin.rst
@@ -72,9 +72,9 @@ Die folgende Datei skizziert den Mindestumfang für die Plugin-Dokumentation.
 
 .. hint::
 
-   Das in früheren Versionen verwendete **README**-Format für die Dokumentation von Plugins ist veraltet.
-   Ein Großteil der Dokumentation ist in die Metadaten-Dokumentation in **plugin.yaml** übergegangen.
-   Die restliche Dokumentation sollte nur noch im **user_doc**-Format erfolgen.
+   Das in früheren Versionen verwendete ``README.md``-Format für die Dokumentation von Plugins ist veraltet.
+   Ein Großteil der Dokumentation ist in die Metadaten-Dokumentation in ``plugin.yaml`` übergegangen.
+   Die restliche Dokumentation sollte nur noch im ``user_doc.rst``-Format erfolgen.
 
-   Soweit möglich, sollten bestehende **README** im Rahmen von Aktualisierungen in entsprechende **user_doc** überführt werden.
+   Soweit möglich, sollten bestehende ``README.md`` im Rahmen von Aktualisierungen in entsprechende ``user_doc.rst`` überführt werden.
 

--- a/doc/user/source/entwicklung/plugins/kurzanleitung/sampleplugin.rst
+++ b/doc/user/source/entwicklung/plugins/kurzanleitung/sampleplugin.rst
@@ -71,8 +71,8 @@ Die folgende Datei skizziert den Mindestumfang für die Plugin-Dokumentation.
 
 .. hint::
 
-   Das in früheren Versionen verwendete **README**-Format für die Dokumentation von Plugins ist veraltet.
-   Ein Großteil der Dokumentation ist in die Metadaten-Dokumentation in **plugin.yaml** übergegangen. 
-   Die restliche Dokumentation sollte nur noch im **user_doc**-Format erfolgen.
+   Das in früheren Versionen verwendete ``README.md``-Format für die Dokumentation von Plugins ist veraltet.
+   Ein Großteil der Dokumentation ist in die Metadaten-Dokumentation in ``plugin.yaml`` übergegangen. 
+   Die restliche Dokumentation sollte nur noch im ``user_doc.rst``-Format erfolgen.
 
-   Soweit möglich, sollten bestehende **README** im Rahmen von Aktualisierungen in entsprechende **user_doc** überführt werden.
+   Soweit möglich, sollten bestehende ``README.md`` im Rahmen von Aktualisierungen in entsprechende ``user_doc.rst`` überführt werden.

--- a/doc/user/source/entwicklung/plugins/kurzanleitung/webinterface.rst
+++ b/doc/user/source/entwicklung/plugins/kurzanleitung/webinterface.rst
@@ -38,8 +38,7 @@ Tooltips
 ========
 
 *popper.min.js* kann genutzt werden, um (aktuell pro Seite maximal zehn) "stabile"
-und ansprechende Tooltips zu integrieren. Ab *SmarthomeNG 1.10* sind alle nötigen
-Dateien hierbei schon automatisch integriert. Um Buttons mit Tooltips auszustatten,
+und ansprechende Tooltips zu integrieren. Um Buttons mit Tooltips auszustatten,
 muss ihnen die CSS Klasse ``button-tooltip`` zugewiesen werden. Außerdem sind
 folgende Codezeilen in der index.html Datei notwendig:
 
@@ -62,8 +61,7 @@ Cookies
 =======
 
 Um Einstellungen im Webinterface dauerhaft zu speichern, sollten die entsprechenden
-Werte als Browser-Cookie gespeichert werden. Eine einfache Möglichkeit dazu wird
-seit *SmarthomeNG 1.10* angeboten. Zum Speichern von Cookies steht die Funktion
+Werte als Browser-Cookie gespeichert werden. Zum Speichern von Cookies steht die Funktion
 ``setCookie(<Cookiename>, <Cookiewert>, <Dauer der Speicherung>, <Pluginname>)`` bereit, für das Laden ``getCookie(<Cookiename>)``. Cookies können gelöscht werden, indem 0 als Dauer angegebene wird.
 
 Im Folgenden Beispiel wird beim Laden der Seite das Cookie
@@ -94,8 +92,8 @@ genau so referenziert werden.
 Icons
 =====
 
-Im Ordner ``/gstatic/img`` sind diverse globale Icons hinterlegt. Seit *SmarthomeNG 1.10*
-stehen Icons für Sortierfunktionen zur Verfügung. Diese heißen wie folgt:
+Im Ordner ``/gstatic/img`` sind diverse globale Icons hinterlegt. 
+Für Sortierfunktionen stehen die folgenden Icons zur Verfügung:
 
   - sort-alpha-asc.svg
   - sort-alpha-desc.svg

--- a/doc/user/source/entwicklung/plugins/kurzanleitung/webinterface_filling_webinterface.rst
+++ b/doc/user/source/entwicklung/plugins/kurzanleitung/webinterface_filling_webinterface.rst
@@ -148,4 +148,4 @@ Die folgenden Schritte dienen dazu, das Webinterface mit Leben zu füllen:
         </script>
 
 
-   6. Das Logo oben links auf der Seite wird automatisch durch das Logo des konfigurierten Plugin-Typs ersetzt. Wenn das Webinterface ein eigenes Logo mitbringen soll, muss das entsprechende Bild im Verzeichnis ``webif/static/img`` mit dem Namen ``plugin_logo`` abgelegt sein. Die zulässigen Dateiformate sind **.png**, **.jpg** oder **.svg**. Dabei sollte die Größe der Bilddatei die Größe des angezeigten Logos (derzeit ca. 180x150 Pixel) nicht überschreiten, um unnötige Datenübertragungen zu vermeiden.
+   6. Das Logo oben links auf der Seite wird automatisch durch das Logo des konfigurierten Plugin-Typs ersetzt. Wenn das Webinterface ein eigenes Logo mitbringen soll, muss das entsprechende Bild im Verzeichnis ``webif/static/img`` mit dem Namen ``plugin_logo`` abgelegt sein. Die zulässigen Dateiformate sind ``.png``, ``.jpg`` oder ``.svg``. Dabei sollte die Größe der Bilddatei die Größe des angezeigten Logos (derzeit ca. 180x150 Pixel) nicht überschreiten, um unnötige Datenübertragungen zu vermeiden.

--- a/doc/user/source/entwicklung/plugins/vorueberlegungen.rst
+++ b/doc/user/source/entwicklung/plugins/vorueberlegungen.rst
@@ -74,9 +74,8 @@ Beispiele für Web/Cloud Plugins sind: **alexa4p3**, **ical**, **jsonread** oder
 Plugin Vorlagen
 ===============
 
-Um ein neues Plugin zu erstellen, ist es am besten die Vorlage zu verwenden, die unter /dev/sample_plugin zu finden ist.
-Falls das Plugin über MQTT kommunizieren soll, ist es besser, die Vorlage zu verwenden, die unter /dev/sample_mqttplugin
-zu finden ist.
+Um ein neues Plugin zu erstellen, ist es am besten die Vorlage zu verwenden, die unter ``dev/sample_plugin`` zu finden ist.
+Falls das Plugin über MQTT kommunizieren soll, ist es besser, die Vorlage zu verwenden, die unter ``dev/sample_mqttplugin`` zu finden ist.
 
 Falls über MQTT kommuniziert werden soll, wäre es für einfache Aufgabenstellungen auch zu überlegen, kein eigenes Plugin
 zu schreiben, sondern das generische mqtt Plugin zu nutzen.

--- a/doc/user/source/entwicklung/virtual_env.rst
+++ b/doc/user/source/entwicklung/virtual_env.rst
@@ -20,7 +20,7 @@ Danach werden aktuell (Stand November 2020) empfohlen:
 
 .. hint::
 
-    Seit SmartHomeNG v1.10 wird der Betrieb von SmartHomeNG in virtuellen standardmäßig unterstützt und empfohlen
+    Der Betrieb von SmartHomeNG in virtuellen Environments wird unterstützt und standardmäßig empfohlen
     (siehe auch :doc:`Komplettanleitung </installation/komplettanleitung/03_smarthomeng>`).
 
     Eine ausführlichere Beschreibung zur Unterstützung virtueller Environments in SmartHomeNG ist in der

--- a/doc/user/source/fehlersuche_checkliste.rst
+++ b/doc/user/source/fehlersuche_checkliste.rst
@@ -17,7 +17,7 @@ sollen, dann müsst ihr Informationen beisteuern:
 * Debug Ausgabe anhängen, mindestens bis das Problem ersichtlich geloggt wird. (Dazu SmartHome.py mit
   der Option **-d** starten)
 * Error und Warnings soweit möglich bereits vorher beseitigen
-* evtl. die etc/plugin.conf und die items mit denen Euer Problem zusammenhängt
+* evtl. die ``etc/plugin.conf`` und die items mit denen Euer Problem zusammenhängt
 * Wichtig ist auch u.U. die verwendete Hardware (VM oder Raspi 1, 2, 3) das Betriebssystem
   (Raspbian, Ubuntu x.y, Debian x.y) und ob eibd oder knxd genutzt werden.
 
@@ -87,7 +87,7 @@ zu einer sehr großen Anzahl von Log Einträgen und ist deshalb recht unübersic
 .. note::
 
     Vorzuziehen ist eine gezielte Aktivierung der DBUG Ausgaben für einzelne Komponenten oder Plugins. Dieses geschieht
-    über die Logging Konfiguration in /etc/logging.yaml bzw. über die GUI des Admin Interfaces.
+    über die Logging Konfiguration in ``/etc/logging.yaml`` bzw. über die GUI des Admin Interfaces.
 
 
 .. code::

--- a/doc/user/source/fehlersuche_checkliste.rst
+++ b/doc/user/source/fehlersuche_checkliste.rst
@@ -43,7 +43,7 @@ Es sollte eine Zeile augegeben werden, die etwa so aussieht:
     smartho+ 28373     1  1 12:45 ?        00:00:02 python3 bin/smarthome.py
 
 Die Zeile zeigt an, dass unter dem User **smarthome** (hier zu smartho+ abgekürzt) unter der PID **28373** seit **12:45**
-Uhr SmartHomeNG (**python3 bin/smarthome.py**) ausgeführt wird.
+Uhr SmartHomeNG (``y``) ausgeführt wird.
 
 
 ------
@@ -120,7 +120,7 @@ Nun sollte so etwas ähnliches gezeigt werden:
    smarthome@sh13:~$
 
 Im obigen Fall handelt es sich beim laufenden eibd um eine Installation, die auf eine KNX
-Schnittstelle zugreift. Wichtig ist hier, das die Zeile **/usr/bin/eibd** auftaucht. Wenn
+Schnittstelle zugreift. Wichtig ist hier, das die Zeile ``/usr/bin/eibd`` auftaucht. Wenn
 das der Fall ist, dann läuft der eibd.
 
 Ob der eibd auch schalten kann stellt man fest mit

--- a/doc/user/source/ideen_kommendes_release.rst
+++ b/doc/user/source/ideen_kommendes_release.rst
@@ -92,7 +92,7 @@ neue Version von SmartHomeNG installiert wird.
 * Nach erfolgtem Lauf ein Flag in eine Datei speichern (dass die Daten dem Release … entsprechen)
 * Mehrere Routinen nacheinander aufrufen, falls jemand beim Update Versionen überspringt
 * Neustart nach jeder Routine notwendig?
-* Routinen könnten in lib/update abgelegt werden
+* Routinen könnten in ``lib/update`` abgelegt werden
 * Wo sollten die Flags gespeichert werden?
 
 |

--- a/doc/user/source/ideen_kommendes_release.rst
+++ b/doc/user/source/ideen_kommendes_release.rst
@@ -1,6 +1,6 @@
-=========================
-Ideen für das Release 1.9
-=========================
+===========================
+Ideen für das Release 1.13+
+===========================
 
 
 .. contents:: Inhaltsübersicht
@@ -15,39 +15,10 @@ Ideen für neue Funktionalitäten im Core
 
 |
 
-Struct Nesting
---------------
-
-Möglichkeiten des Nesting von structs erweitern.
-
-|
-
-lib.network
------------
-
-|
-
-daemonize überarbeiten
-----------------------
-
-die Systemlogik für "daemonize" bzw. "im Vordergrund bleiben" ist kaputt.
-Spätestens die Methoden stop und restart können damit so nicht umgehen.
-Dazu hatte ich (Morg) schon ein issue aufgemacht.
-(Besonders "spaßig": smarthome mit -f oder -i starten und im AdminUI auf Restart Core klicken... hrhr)
-
-|
-
 Logiken: Zusätzlichen Trigger „shutdown“
 ----------------------------------------
 
 Zusätzlichen Trigger, um Logiken beim herunterfahren von SmartHomeNG triggern zu können.
-
-|
-
-Items: User Attribute implementieren
-------------------------------------
-
-Attribute, die User nutzen wollen, die aber in keinem Plugin definiert sind.
 
 |
 
@@ -98,7 +69,7 @@ lib.color
 ---------
 
 Library zur Umrechnung zwischen Farbräumen. Zur Nutzung in Logiken und evals z.B.
-bei Nutzung von Hue.
+bei Nutzung von Hue. Ggf. auf vorhandene Methoden aus Plugin zigbee2mqtt zurückgreifen.
 
 |
 
@@ -121,7 +92,7 @@ neue Version von SmartHomeNG installiert wird.
 * Nach erfolgtem Lauf ein Flag in eine Datei speichern (dass die Daten dem Release … entsprechen)
 * Mehrere Routinen nacheinander aufrufen, falls jemand beim Update Versionen überspringt
 * Neustart nach jeder Routine notwendig?
-* Routinen könnten in ../lib/update abgelegt werden
+* Routinen könnten in lib/update abgelegt werden
 * Wo sollten die Flags gespeichert werden?
 
 |
@@ -138,6 +109,15 @@ Admin GUI
 =========
 
 Ideen für neue Funktionalitäten in der Admin GUI
+
+|
+
+Plugins live laden, entladen, neu laden
+---------------------------------------
+
+* Die Methoden sind im Core schon vorbereitet und können mit kompatiblen
+  Plugins genutzt werden. Die "Ansteuerung" über das AdminUI muss implementiert
+  werden.
 
 |
 

--- a/doc/user/source/index.rst
+++ b/doc/user/source/index.rst
@@ -35,6 +35,15 @@ Diese Dokumentation reflektiert das aktuelle Release:
 Hilfe zu SmartHomeNG gibt es im `Supportforum im KNX-User-Forum <https://knx-user-forum.de/forum/supportforen/smarthome-py>`_
 oder im `Chat auf gitter.im <https://app.gitter.im/#/room/#smarthomeNG_smarthome:gitter.im>`_ .
 
+.. hint::
+
+   Mit Release der Version 1.12 wurden die folgenden Konventionen in der Dokumentation eingeführt:
+
+   - Datei- und Ordnernamen werden relativ zum SmartHomeNG-Stammverzeichnis (standardmäßig ``/usr/local/smarthome/``) angegeben
+   - Dateien und Ordner, die Nutzerkonfigurationen enthalten, werden unterhalb von ``etc`` referenziert. Dies entspricht
+     dem zukünftigen Standard, der mit der Kommandozeilenoption **-e** / **--config-etc** oder mit der Option
+     **config_etc: true**  in der ``etc/smarthome.yaml`` aktiviert werden kann.
+
 .. note::
 
    **Anmerkungen** und **Änderungswünsche** zu dieser Dokumentation bitte auf

--- a/doc/user/source/installation/komplettanleitung/01_debian.rst
+++ b/doc/user/source/installation/komplettanleitung/01_debian.rst
@@ -9,7 +9,7 @@ Debian Linux installieren
 =========================
 
 Die genaue Schritt für Schritt Installation des Betriebsystems wird hier nicht beschrieben, das hier ist der falsche
-Ort dafür. Jedoch werden als Referenz die Paketauswahlen während der Installation hier beschrieben.
+Ort dafür. Jedoch werden als Referenz die Paketauswahl während der Installation hier beschrieben.
 
 Am kompaktesten ist die Netinstall ISO-Datei. Zur Installation auf einem externen Rechner (z.B. NUC o.ä.) kann die
 ISO-Datei am einfachsten mit dem Tool `Balena Etcher <https://etcher.balena.io>`__ auf einen USB-Stick übertragen werden.
@@ -19,7 +19,7 @@ Es können auch andere Tools wie z.B. `Linux Live USB Creator <http://www.linuxl
 oder `UNetbootin <https://unetbootin.github.io/>`__ dazu genutzt werden.
 
 Diese Komplettanleitung wurde auf einer virtuellen Maschine unter VMWare mit einem
-Debian bullseye 11.3 und Debian Bookworm 12.4 getestet.
+Debian trixie 13.4 getestet.
 
 Andere Linux Derivate können abweichen, man sollte dann mit den Unterschieden umgehen
 können.

--- a/doc/user/source/installation/komplettanleitung/03_smarthomeng.rst
+++ b/doc/user/source/installation/komplettanleitung/03_smarthomeng.rst
@@ -32,179 +32,88 @@ Zunächst müssen einige zusätzliche Pakete installiert werden:
 SmartHomeNG Quellcode laden
 ===========================
 
-.. tab-set::
+  SmartHomeNG Dateien vom github holen:
 
-    .. tab-item:: SmartHomeNG ab v1.10
+  Die folgenden Kommandos mit dem User Account (smarthome) durchführen
+  unter dem später SmartHomeNG laufen soll, **nicht als root**.
 
-        SmartHomeNG Dateien vom github holen:
+  .. important::
 
-        Die folgenden Kommandos mit dem User Account (smarthome) durchführen
-        unter dem später SmartHomeNG laufen soll, **nicht als root**.
+      **WICHTIG**: Das Skript ``tools/postinstall`` setzt die Dateiberechtigungen. Anschließend prüft es, welche
+      Python Version(en) auf dem System installiert sind und erstellt mit einer geeigneten Python Version ein
+      virtuelles Environment in dem SmartHomeNG später laufen soll.
 
-        .. important::
+  .. code-block:: bash
 
-            **WICHTIG**: Das Skript ``tools/postinstall`` setzt die Dateiberechtigungen. Anschließend prüft es, welche
-            Python Version(en) auf dem System installiert sind und erstellt mit einer geeigneten Python Version ein
-            virtuelles Environment in dem SmartHomeNG später laufen soll.
+     cd /usr/local
+     sudo mkdir smarthome
+     sudo chown -R smarthome:smarthome /usr/local/smarthome
 
-        .. code-block:: bash
+     cd smarthome
+     git clone https://github.com/smarthomeNG/smarthome.git .
+     git clone https://github.com/smarthomeNG/plugins.git plugins
 
-           cd /usr/local
-           sudo mkdir smarthome
-           sudo chown -R smarthome:smarthome /usr/local/smarthome
+     bash tools/postinstall
 
-           cd smarthome
-           git clone https://github.com/smarthomeNG/smarthome.git .
-           git clone https://github.com/smarthomeNG/plugins.git plugins
+  .. important::
 
-           bash tools/postinstall
+      bash tools/postinstall **NICHT** mit sudo aufrufen
 
-        .. important::
+  Bitte auf den **Punkt** am Ende des ersten **git clone** Kommandos achten!
 
-            bash tools/postinstall **NICHT** mit sudo aufrufen
+  Das Skript postinstall erzeugt ein virtuelles Environment **py_shng**.
 
-        Bitte auf den **Punkt** am Ende des ersten **git clone** Kommandos achten!
+  Nach dem Aufruf des postinstall Skripts bitte **ausloggen** und **erneut einloggen**. Damit wird die Umgebung
+  für den User richtig gesetzt und das virtuelle Python Environment wird aktiviert.
 
-        Das Skript postinstall erzeugt ein virtuelles Environment **py_shng**.
-
-        Nach dem Aufruf des postinstall Skripts bitte **ausloggen** und **erneut einloggen**. Damit wird die Umgebung
-        für den User richtig gesetzt und das virtuelle Python Environment wird aktiviert.
-
-        Ausführlichere Informationen zu den virtuellen Python Environments sind im Abschnitt Referenz unter
-        :doc:`Python Environment/Virtuelle Python Environments </referenz/python/virtual_environments>` zu finden.
-
-
-        .. attention::
-
-            Bei der Installation von debian 12 (bookworm) wird Python 3.11 installiert. SmartHomeNG v1.10 ist zwar
-            prinzipiell unter Python 3.11 lauffähig, es sind jedoch nicht alle Plugins unter Python 3.11 getetet,
-            weshalb SmartHomeNG v1.10 offiziell nur Python Versionen bis 3.10 unterstützt.
-
-            Soll eine andere Python Version als 3.11 genutzt werden, sollte diese Python Version vor dem Aufruf des
-            Skripts tools/postinstall installiert werden, damit das Standard Virtual Environment, welches beim Start
-            des Rechners aktiviert wird, für die gewünschte Python Version erstellt wird.
-
-            Eine Beschreibung, wie zusätzliche Python Versionen installiert werden, ist unter
-            :doc:`Python Environment/Python Version Installieren </referenz/python/python_installation>` zu finden.
-
-
-
-    .. tab-item:: SmartHomeNG vor v1.10
-
-        SmartHomeNG Dateien vom github holen:
-
-        Die folgenden Kommandos mit dem User Account (smarthome) durchführen
-        unter dem später SmartHomeNG laufen soll, **nicht als root**.
-
-        .. code-block:: bash
-
-           cd /usr/local
-           sudo mkdir smarthome
-           sudo chown -R smarthome:smarthome /usr/local/smarthome
-
-           cd smarthome
-           git clone https://github.com/smarthomeNG/smarthome.git .
-           git clone https://github.com/smarthomeNG/plugins.git plugins
-
-           bash tools/setpermissions
-
-        Bitte auf den **Punkt** am Ende des ersten **git clone** Kommandos achten!
+  Ausführlichere Informationen zu den virtuellen Python Environments sind im Abschnitt Referenz unter
+  :doc:`Python Environment/Virtuelle Python Environments </referenz/python/virtual_environments>` zu finden.
 
 |
 
 Weitere Python Bibliotheken installieren
 ========================================
 
-.. tab-set::
+SmartHomeNG installiert benötigte Pakete selbst.
 
-   .. tab-item:: SmartHomeNG ab v1.7
+Wenn SmartHomeNG in einer Python Umgebung gestartet wird, in der nicht der minimale Set an Packages installiert ist,
+wird dieser installiert und die Informationen werden auf der Konsole ausgegeben (da das Logging dann noch nicht
+konfiguriert werden kann). Anschließend startet SmartHomeNG neu. Das sieht folgendermaßen aus.
 
-      SmartHomeNG kann benötigte Pakete selbst nachinstallieren.
+.. code-block:: bash
 
-      Wenn SmartHomeNG in einer Python Umgebung gestartet wird, in der nicht der minimale Set an Packages installiert ist,
-      wird dieser installiert und die Informationen werden auf der Konsole ausgegeben (da das Logging dann noch nicht
-      konfiguriert werden kann). Anschließend startet SmartHomeNG neu. Das sieht folgendermaßen aus.
+   $ python3 bin/smarthome.py
 
-      .. code-block:: bash
+   test_requirements: 'ephem' not installed. Minimum v3.7 needed
+   test_requirements: 'holidays' not installed. Minimum v0.9.11 needed
+   test_requirements: 'psutil' not installed, any version needed
+   test_requirements: 'python-dateutil' not installed. Minimum v2.5.3 needed
+   test_requirements: 'requests' not installed. Minimum v2.20.0 needed
+   test_requirements: 'ruamel.yaml' not installed. Minimum v0.13.7 needed
 
-         $ python3 bin/smarthome.py
+   Installing core requirements for the current user, please wait...
+   Running in a virtualenv environment,
+   installing core requirements only to current virtualenv, please wait...
 
-         test_requirements: 'ephem' not installed. Minimum v3.7 needed
-         test_requirements: 'holidays' not installed. Minimum v0.9.11 needed
-         test_requirements: 'psutil' not installed, any version needed
-         test_requirements: 'python-dateutil' not installed. Minimum v2.5.3 needed
-         test_requirements: 'requests' not installed. Minimum v2.20.0 needed
-         test_requirements: 'ruamel.yaml' not installed. Minimum v0.13.7 needed
+   core requirements installed
 
-         Installing core requirements for the current user, please wait...
-         Running in a virtualenv environment,
-         installing core requirements only to current virtualenv, please wait...
+   Starting SmartHomeNG again...
+   Daemon PID 4024
 
-         core requirements installed
+   $
 
-         Starting SmartHomeNG again...
-         Daemon PID 4024
+Danach kann der Core von SmartHomeNG vollständig initialisiert werden und Ausgaben erfolgen in smarthome-warnings.log
 
-         $
+Anschließend prüft SmartHomeNG, ob die benötigten Pakete für die ladbaren Module und für die konfigurierten Plugins
+installiert sind. Falls nicht, werden diese jeweils installiert und SmartHomeNG startet sich erneut.
 
-      Danach kann der Core von SmartHomeNG vollständig initialisiert werden und Ausgaben erfolgen in smarthome-warnings.log
+.. note::
 
-      Anschließend prüft SmartHomeNG, ob die benötigten Pakete für die ladbaren Module und für die konfigurierten Plugins
-      installiert sind. Falls nicht, werden diese jeweils installiert und SmartHomeNG startet sich erneut.
+   Dieser Mechanismus sorgt auch dafür, dass Pakete die von später konfigurierten Plugins benötigt werden,
+   automatisch nachinstalliert werden.
 
-      .. note::
-
-         Dieser Mechanismus sorgt auch dafür, dass Pakete die von später konfigurierten Plugins benötigt werden,
-         automatisch nachinstalliert werden.
-
-      Nach der Installation der benötigten Pakete dauert es noch einige Zeit, bis SmartHomeNG reagiert, da beim ersten
-      Start die CPU Geschwindigkeit des Rechners bestimmt wird.
-
-
-   .. tab-item:: SmartHomeNG vor v1.7
-
-      Für den ersten Start müssen noch einige Python Packages nachgeladen werden.
-      Im Unterordner ``requirements`` befindet sich dafür eine Datei ``base.txt``.
-      In dieser Datei stehen die von SmartHomeNG grundlegend benötigten Bibliotheken.
-      Diese können wie folgt installiert werden:
-
-      .. code-block:: bash
-
-         cd /usr/local/smarthome
-         python3 -m pip install -r requirements/base.txt --user
-
-      .. attention::
-
-          In früheren Beschreibungen wurde die globale Installation von Python Packages mit dem **sudo** Kommando
-          beschrieben:
-
-             sudo pip3 install -r requirements/base.txt
-
-          Dieses funktioniert unter Debian Buster **NICHT** mehr. Zumindest unter Buster **muss** die Installation
-          für den entsprechenden User mit **--user** erfolgen (wie oben beschrieben).
-
-
-      .. note::
-
-          Falls mehrere Python3 Versionen installiert sind, kann es zu Problemen kommen, da pip die Bibliotheken immer nur
-          in eine der installierten Python 3 Versionen installiert.
-
-          Um sicherzustellen, dass die Bibliotheken in die Python3 Version installiert werden, muss pip aus genau dieser
-          Python3 Umgebung aufgerufen werden.
-
-          Um das sicherzustellen, ist statt
-
-          .. code-block:: bash
-
-              pip3 install -r requirements/base.txt --user
-
-          der folgende Befehl auszuführen:
-
-          .. code-block:: bash
-
-              <python used to start SmartHomeNG> -m pip3 install -r requirements/base.txt --user
-
-      Jetzt ist SmartHomeNG installiert und kann konfiguriert werden.
+Nach der Installation der benötigten Pakete dauert es noch einige Zeit, bis SmartHomeNG reagiert, da beim ersten
+Start die CPU Geschwindigkeit des Rechners bestimmt wird.
 
 
 Erstmaliger Start von SmartHomeNG
@@ -246,7 +155,7 @@ Es sollte eine Zeile ausgegeben werden, die etwa so aussieht:
     smartho+ 28373     1  1 12:45 ?        00:00:02 python3 bin/smarthome.py
 
 Die Zeile zeigt an, dass unter dem User **smarthome** (hier zu smartho+ abgekürzt) unter der PID **28373** seit **12:45**
-Uhr SmartHomeNG (**python3 bin/smarthome.py**) ausgeführt wird.
+Uhr SmartHomeNG (``python3 bin/smarthome.py``) ausgeführt wird.
 
 Erfolgt keine Ausgabe, so läuft SmartHomeNG nicht. In diesem Fall bitte den Angaben im Abschnitt :doc:`../../fehlersuche`
 nachlesen.
@@ -311,20 +220,20 @@ Anpassung der Konfigurationsdateien vorgenommen werden. Dieses ist hier im folge
 Beschreibung findet sich im Abschnitt :doc:`../../konfiguration/konfiguration` .
 
 Mit der Grundinstallation werden einige Konfigurationsdateien mitgeliefert die den gleichen Namen tragen wie die
-benötigten Dateien aber zusätzlich noch die Endung **.default**. Wenn SmartHomeNG beim Start eine benötigte
-Konfigurationsdatei sucht, aber noch keine vorhanden ist, so wird eine Kopie von der mitgelieferten **.default**
+benötigten Dateien aber zusätzlich noch die Endung ``.default``. Wenn SmartHomeNG beim Start eine benötigte
+Konfigurationsdatei sucht, aber noch keine vorhanden ist, so wird eine Kopie von der mitgelieferten ``.default``
 Datei erstellt und diese weiter verwendet. Gelingt dies nicht, so bricht SmartHomeNG beim Start ab.
 
 Es werden für einen Systemstart folgende Konfigurationsdateien benötigt:
 
-- **smarthome.yaml**
-- **holidays.yaml**
-- **plugin.yaml**
-- **logging.yaml**
-- **logic.yaml**
-- **module.yaml**
+- ``smarthome.yaml``
+- ``holidays.yaml``
+- ``plugin.yaml``
+- ``logging.yaml``
+- ``logic.yaml``
+- ``module.yaml``
 
-Der Inhalt von **.yaml** Dateien ist speziell formatierter Text und sollte nur mit einem Editor
+Der Inhalt von ``.yaml`` Dateien ist speziell formatierter Text und sollte nur mit einem Editor
 bearbeitet werden, der Dateien im UTF-8 Format (ohne BOM) schreiben kann.
 (z.B. **nano**, **Notepad++**)
 
@@ -335,7 +244,7 @@ und bestimmten die Position eines Elementes in der Objekthierarchie.
 
    Damit die Änderungen, die mit einem Editor durchgeführt wurden, wirksam werden, muss SmartHomeNG
    unbedingt neu gestartet werden.
-   (Eine Ausnahme bildet hier nur die **logic.yaml**, da es möglich ist, mit
+   (Eine Ausnahme bildet hier nur die ``logic.yaml``, da es möglich ist, mit
    dem Logikeditor im Admin Interface diese Logiken zur Laufzeit neu
    zu laden.)
 
@@ -344,7 +253,7 @@ Im folgenden werden diese Dateien und deren Inhalt genauer beschrieben.
 smarthome.yaml
 --------------
 
-In der **smarthome.yaml** stehen die allgemeinen Konfigurationseinstellungen der SmartHomeNG Installation, wie z.B. die
+In der ``smarthome.yaml`` stehen die allgemeinen Konfigurationseinstellungen der SmartHomeNG Installation, wie z.B. die
 Koordinaten des Standortes. Die Koordinaten werden benötigt, um unter anderem Sonnenaufgang und Sonnenuntergang zu berechnen.
 Die Koordinaten für einen Standort kann man z.B. auf http://www.mapcoordinates.net/de ermitteln.
 
@@ -381,7 +290,7 @@ anzupassen. Alternativ kann diese Anpassung später über das Admin Interface du
 logging.yaml
 ------------
 
-In der **logging.yaml** finden sich die Anweisungen wie Ereignisse, die während des Programmablaufes von
+In der ``logging.yaml`` finden sich die Anweisungen wie Ereignisse, die während des Programmablaufes von
 SmartHomeNG auftreten und geloggt also notiert werden sollen.
 
 Diese recht umfangreiche Datei sollte zunächst nicht geändert werden. Später kann sie angepasst werden, um
@@ -417,9 +326,9 @@ melden und sich beenden.
    Wichtig ist es nach CRITICAL, ERROR und WARNING zu schauen und zu versuchen, diese zu vermeiden.
    Meldungen der Level INFO und DEBUG sind normal und brauchen erstmal nicht weiter beachtet zu werden.
 
-   Deshalb schreibt SmartHomeNG standardmäßig zwei Logs (**smarthome-warnings.log** und **smarthome-details.log**).
+   Deshalb schreibt SmartHomeNG standardmäßig zwei Logs (``smarthome-warnings.log`` und ``smarthome-details.log``).
    Das erste Log ist so konfiguriert, dass es aus allen konfigurierten Logs nur die Einträge folgender Log-Level
-   enthält: CRITICAL, ERROR und WARNING. **smarthome-details.log** enthält dem gegenüber Log Einträge bis zum Level DEBUG.
+   enthält: CRITICAL, ERROR und WARNING. ``smarthome-details.log`` enthält dem gegenüber Log Einträge bis zum Level DEBUG.
 
 
 In der zweiten Datei finden sich zusätzliche Informationen, die für die Erstkonfiguration, die hier beschrieben wird, nicht
@@ -432,9 +341,9 @@ anzupassen.
 plugin.yaml
 -----------
 
-In der **plugin.yaml** stehen die Plugins, die verwendet werden sollen, sowie ihre Konfigurationsparameter.
+In der ``plugin.yaml`` stehen die Plugins, die verwendet werden sollen, sowie ihre Konfigurationsparameter.
 
-Wenn keine Datei **plugin.yaml** existiert, wird beim ersten Start von SmartHomeNG die mitgelieferte Datei **plugin.yaml.default**
+Wenn keine Datei ``plugin.yaml`` existiert, wird beim ersten Start von SmartHomeNG die mitgelieferte Datei ``plugin.yaml.default``
 kopiert. In dieser Datei ist ein minimaler Set von Plugins konfiguriert, so dass z.B. per Browser oder mit der smartVISU auf die
 SmartHomeNG Instanz zugegriffen werden kann.
 
@@ -482,7 +391,7 @@ Jedes Plugin kann weitere Abhängigkeiten von Bibliotheken mit sich bringen. Die
 
 .. note::
 
-   Beim Start von SmartHomeNG wird die Datei **requirements/all.txt** erstellt.
+   Beim Start von SmartHomeNG wird die Datei ``requirements/all.txt`` erstellt.
 
    Es kann allerdings dann zu einem Abbruch des Starts von SmartHomeNG kommen, da beim Start automatisch nur die beiden
    Requirements-Dateien erstellt werden. Die benötigten Python Packages werden dabei nicht automatisch installiert.
@@ -495,7 +404,7 @@ logic.yaml
 ----------
 
 SmartHomeNG kann benutzerdefinierte Python-Anweisungen ausführen.
-Diese werden in eigenen Python Dateien im Verzeichnis **logics** abgelegt.
+Diese werden in eigenen Python Dateien im Verzeichnis ``etc/logics`` abgelegt.
 In der Konfigurationsdatei ist beispielsweise beschrieben welche Skriptdateien für
 SmartHomeNG bekannt sein sollen,
 wann sie ausgeführt werden sollen und ob sie aktiv sind oder nicht.

--- a/doc/user/source/installation/komplettanleitung/05_knxd.rst
+++ b/doc/user/source/installation/komplettanleitung/05_knxd.rst
@@ -36,7 +36,7 @@ knxd konfigurieren
 
 Als nächstes muss die Konfiguration des knxd für die zu verwendende
 Schnittstelle angepasst werden. Dazu wird bei Systemen mit systemd die
-Datei **/etc/knxd.conf** bearbeitet:
+Datei ``/etc/knxd.conf`` bearbeitet:
 
 .. code-block:: bash
 
@@ -179,7 +179,7 @@ SmartHomeNG Plugin konfigurieren
 ================================
 
 Damit das KNX-Plugin von SmartHomeNG genutzt werden kann, muss in der
-**../etc/plugin.yaml** noch folgendes eingefügt werden:
+``etc/plugin.yaml`` noch folgendes eingefügt werden:
 
 .. code-block:: yaml
 

--- a/doc/user/source/installation/komplettanleitung/06_onewire.rst
+++ b/doc/user/source/installation/komplettanleitung/06_onewire.rst
@@ -115,7 +115,7 @@ SmartHomeNG Plugin konfigurieren
 Die Konfiguration des Plugins erfolgt über das Admin Interface (Siehe Abschnitt Konfiguration).
 
 Alternativ kann die Konfiguration des Onewire-Plugin natürlich auch über die Konfigurationsdatei
-**../etc/plugin.yaml** erfolgen. Dazu muss dort noch folgendes eingefügt werden:
+``etc/plugin.yaml`` erfolgen. Dazu muss dort noch folgendes eingefügt werden:
 
 .. code-block:: yaml
 

--- a/doc/user/source/installation/komplettanleitung/08_shng_daemon.rst
+++ b/doc/user/source/installation/komplettanleitung/08_shng_daemon.rst
@@ -66,7 +66,7 @@ und folgenden Text hineinkopieren:
 Nutzung eines virtuellen Environments
 =====================================
 
-Bei der Installation von SmartHomeNG v1.10 (oder neuer) wird vom postinstall-Skript ein virtuelles Python
+Bei der Installation von SmartHomeNG wird vom postinstall-Skript ein virtuelles Python
 Environment angelegt. Wenn dieses virtuelle Environment im Zusammenhang mit dem Dienst genutzt werden soll, muss
 der Python Interpreter aus diesem virtuellen Environment genutzt werden um SmartHomeNG zu betreiben.
 Dazu muss der folgende Text in die Datei /etc/systemd/system/smarthome.service eingefügt werden:

--- a/doc/user/source/installation/komplettanleitung/komplettanleitung.rst
+++ b/doc/user/source/installation/komplettanleitung/komplettanleitung.rst
@@ -8,7 +8,7 @@
 Komplettanleitung
 =================
 
-Diese Anleitung beschreibt eine komplette Installation von **SmartHomeNG v1.10** auf
+Diese Anleitung beschreibt eine komplette Installation von **SmartHomeNG v1.12** auf
 einem Linuxsystem mit Debian 12 (bookworm).
 
 Zusätzlich wird die Installation folgender weiterer Pakete beschrieben:

--- a/doc/user/source/installation/komplettanleitung/komplettanleitung.rst
+++ b/doc/user/source/installation/komplettanleitung/komplettanleitung.rst
@@ -9,7 +9,7 @@ Komplettanleitung
 =================
 
 Diese Anleitung beschreibt eine komplette Installation von **SmartHomeNG v1.12** auf
-einem Linuxsystem mit Debian 12 (bookworm).
+einem Linuxsystem mit Debian 13 (trixie).
 
 Zusätzlich wird die Installation folgender weiterer Pakete beschrieben:
 

--- a/doc/user/source/installation/update_upgrade.rst
+++ b/doc/user/source/installation/update_upgrade.rst
@@ -296,47 +296,73 @@ geschaut werden.
 Eine falsche Konfiguration kann nach dem Neustart auch via Admin Interface angepasst werden.
 Wenn keine weiteren Fehler auftreten können die Items übernommen werden.
 
-Items
-~~~~~~
+Konfiguration
+~~~~~~~~~~~~~
 
-Die empfohlene Vorgehensweise für die Übernahme der Items besteht aus den Schritten
+Je nach Struktur der Konfiguration ist deren Übernahme etwas mehr oder weniger aufwändig.
 
-- kopieren der Dateien mit den Definitionen der Items aus der alten Installation ``/usr/local/smarthome.old/items/``
-  in das Verzeichnis ``/usr/local/smarthome/items/`` der neuen Installation.
-- starten des Konvertierungstools:
+Wenn schon die Konfiguration mit **-e**, **--config-etc** oder der Einstellung **config_etc: true** in der ``etc/smarthome.yaml`` vorgenommen wurde, ist es simpel. Ansonsten muss etwas mehr Aufwand getrieben werden.
 
-  .. code-block:: bash
+.. tab-set::
 
-      /usr/local/smarthome$ python3 tools/conf_to_yaml_converter.py
+   .. tab-item:: Konfiguration in `etc`
 
-  Bei erfolgreichem Durchlauf des Konverters ist jetzt für jede ``*.conf`` Datei eine passende ``*.yaml`` Datei erstellt worden.
-  Wenn das überprüft wurde können die ``*.conf`` Dateien nun aus ``/usr/local/smarthome/items/`` gelöscht werden.
+      Das alte ``etc``-Verzeichnis kann im Normalfall 1:1 in den neuen Verzeichnisbaum übernommen
+      werden. Da von SmartHomeNG dort keine Dateien mehr mitgeliefert werden, können auch alte
+      Backup- und Default-Dateien (z.B. ``etc/smarthome.yaml.default`` und ``etc/smarthome.yaml.bak``)
+      bedenkenlos gelöscht werden.
 
-Nun sollte wiederum ein Neustart von SmartHomeNG durchgeführt und die Logdateien auf Fehler kontrolliert werden.
-Das kann entweder über das Admin Interface geschehen oder es muss in
-``/usr/local/smarthome/var/log/smarthome-warnings.log`` geschaut werden.
+      Es empfiehlt sich, eine Kopie des gesamten ``etc``-Verzeichnisses samt Unterverzeichnissen aufzuheben, bis die neue Installation fehlerfrei läuft.
 
-Logiken
-~~~~~~~~
+      Sofern noch einzelne Konfigurationen im alten **conf**-Format vorliegen, sollte das Konvertertool
+      gestartet werden (siehe Anleitung im nächsten Abschnitt).
 
-Die empfohlene Vorgehensweise für die Übernahme der Logiken besteht aus den Schritten
+   .. tab-item:: Konfiguration in einzelnen Verzeichnissen
 
-- kopieren der Dateien mit den Definitionen der Logiken aus der alten Installation ``/usr/local/smarthome.old/logics/``
-  in das Verzeichnis ``/usr/local/smarthome/logics/`` der neuen Installation.
+      **Items**
+      
+      Die empfohlene Vorgehensweise für die Übernahme der Items besteht aus den Schritten
 
-- über das Admin Interface unter Dienste --> CONF-YAML Konverter den Inhalt der ``/usr/local/smarthome.old/etc/logics.conf``
-  in yaml Format umwandeln und das Ergebnis an die Datei ``/usr/local/smarthome/etc/logics.yaml`` anhängen bzw. einarbeiten.
-  Dabei muss natürlich selbst auf Doppelungen und die Einrückebene geachtet werden.
+      - kopieren der Dateien mit den Definitionen der Items aus der alten Installation ``/usr/local/smarthome.old/items/``
+        in das Verzeichnis ``/usr/local/smarthome/items/`` der neuen Installation.
+      - starten des Konvertierungstools:
 
-Nun sollte wiederum ein Neustart von SmartHomeNG durchgeführt und die Logdateien auf Fehler kontrolliert werden.
-Das kann entweder über das Admin Interface geschehen oder es muss in ``/usr/local/smarthome/var/log/smarthome-warnings.log``
-geschaut werden.
+        .. code-block:: bash
+
+            /usr/local/smarthome$ python3 tools/conf_to_yaml_converter.py
+
+        Bei erfolgreichem Durchlauf des Konverters ist jetzt für jede ``*.conf`` Datei eine passende ``*.yaml`` Datei erstellt worden.
+        Wenn das überprüft wurde können die ``*.conf`` Dateien nun aus ``/usr/local/smarthome/items/`` gelöscht werden.
+
+      Nun sollte wiederum ein Neustart von SmartHomeNG durchgeführt und die Logdateien auf Fehler kontrolliert werden.
+      Das kann entweder über das Admin Interface geschehen oder es muss in
+      ``/usr/local/smarthome/var/log/smarthome-warnings.log`` geschaut werden.
+
+      **Logiken**
+
+      Die empfohlene Vorgehensweise für die Übernahme der Logiken besteht aus den Schritten
+
+      - kopieren der Dateien mit den Definitionen der Logiken aus der alten Installation ``/usr/local/smarthome.old/logics/``
+        in das Verzeichnis ``/usr/local/smarthome/logics/`` der neuen Installation.
+
+      - über das Admin Interface unter Dienste --> CONF-YAML Konverter den Inhalt der ``/usr/local/smarthome.old/etc/logics.conf``
+        in yaml Format umwandeln und das Ergebnis an die Datei ``/usr/local/smarthome/etc/logics.yaml`` anhängen bzw. einarbeiten.
+        Dabei muss natürlich selbst auf Doppelungen und die Einrückebene geachtet werden.
+
+      Nun sollte wiederum ein Neustart von SmartHomeNG durchgeführt und die Logdateien auf Fehler kontrolliert werden.
+      Das kann entweder über das Admin Interface geschehen oder es muss in ``/usr/local/smarthome/var/log/smarthome-warnings.log``
+      geschaut werden.
+
+      **Szenen, Userfunctions und Strukturen**
+
+      Analog zu den Logiken werden auch die Verzeichnisse ``scenes``, ``functions`` und ``structs`` migriert.
+
 
 Konvertierung von \*.conf-Dateien
 ==================================
 
 Möchte man vom alten ``*.conf`` Format der Konfigurationsdateien
-(die ab Version 2.0 nicht weiter unterstützt werden) auf das neue
+(die ab Version 1.12 nicht weiter unterstützt werden) auf das neue
 ``*.yaml`` Format umschwenken, so kann der im Verzeichnis ``tools``
 bereitgestellte Konverter ``conf_to_yaml_converter.py`` genutzt werden
 um das automatisch zu tun.

--- a/doc/user/source/installation/update_upgrade.rst
+++ b/doc/user/source/installation/update_upgrade.rst
@@ -231,7 +231,7 @@ von der Kommandozeile aus machen:
 
 
 Jetzt heißt es genau zu schauen, was an **WARNING** oder **ERROR** gemeldet wird. Logfiles findet man im
-Verzeichnis ``../var/log`` (in der Standardinstallation unter ``/usr/local/smarthome/var/log``).
+Verzeichnis ``var/log`` (in der Standardinstallation unter ``/usr/local/smarthome/var/log``).
 Von da aus kann man sie mit einem Editor in Ruhe anschauen und auf Fehler durchsuchen.
 
 Wenn dann die Konfiguration stimmt, kann man natürlich den automatischen
@@ -337,7 +337,7 @@ Konvertierung von \*.conf-Dateien
 
 Möchte man vom alten ``*.conf`` Format der Konfigurationsdateien
 (die ab Version 2.0 nicht weiter unterstützt werden) auf das neue
-``*.yaml`` Format umschwenken, so kann der im Verzeichnis ``../tools``
+``*.yaml`` Format umschwenken, so kann der im Verzeichnis ``tools``
 bereitgestellte Konverter ``conf_to_yaml_converter.py`` genutzt werden
 um das automatisch zu tun.
 

--- a/doc/user/source/konfiguration/admin_gui/admin_gui_system.rst
+++ b/doc/user/source/konfiguration/admin_gui/admin_gui_system.rst
@@ -49,6 +49,6 @@ Für Details zur Definition benutzerspezifischer Feiertage bitte den Abschnitt *
 dieser Dokumentation konsultieren.
 
 Dieser Abschnitt wird vervollständigt, nachdem das Administations-Interface einen Dialog zur Konfiguration der Feiertage
-erhalten hat. Bis dahin müssen die Feiertage direkt in der Konfigurationsdatei **etc/holidays.yaml** konfiguriert werden.
+erhalten hat. Bis dahin müssen die Feiertage direkt in der Konfigurationsdatei ``etc/holidays.yaml`` konfiguriert werden.
 
 

--- a/doc/user/source/konfiguration/item_structs.rst
+++ b/doc/user/source/konfiguration/item_structs.rst
@@ -25,14 +25,14 @@ Prinzipiell gibt es 2 Anwendungsfälle:
 
 Demzufolge können die Item-Struktur-Templates an zwei verschiedenen Stellen definiert werden:
 
- - der Nutzer kann die Strukturen in Dateien im Verzeichnis etc/structs in beliebigen Dateien definieren
+ - der Nutzer kann die Strukturen in Dateien im Verzeichnis ``etc/structs`` in beliebigen Dateien definieren
  - Autoren von Plugins können die Strukturen in den Metadaten des Plugins definieren. Beim Start von SmartHomeNG stehen
    die dann die Strukturen aller konfigurierten Plugins zur Verfügung.
 
 
 Um eine doppelte Namensvergabe zu vermeiden, wird bei der Nutzung den structs, die in Plugins definiert wurden, der
 Name des Plugins vorangestellt; bei structs, die vom Nutzer definiert wurden, wird "my." und der Name der Datei vorangestellt. Wenn z.B. die struct **weather** genutzt werden soll, die im Plugin **darksky**
-definiert wurde, so muss als Referenz **darksky.weather** angegeben werden. Für die struct **weather*, die vom Nutzer in der Datei etc/structs/lightsky.yaml definiert wurde, muss **my.lightsky.weather** als Referenz
+definiert wurde, so muss als Referenz **darksky.weather** angegeben werden. Für die struct **weather*, die vom Nutzer in der Datei ``etc/structs/lightsky.yaml`` definiert wurde, muss **my.lightsky.weather** als Referenz
 angegeben werden.
 
 Eine Übersicht der zur Verfügung stehenden structs kann in der Admin GUI unter **Items/Struktur** Templates eingesehen werden.

--- a/doc/user/source/konfiguration/item_structs.rst
+++ b/doc/user/source/konfiguration/item_structs.rst
@@ -14,7 +14,7 @@ structs (Item Strukturen) :greensup:`Update`
 Überblick :greensup:`Update`
 ============================
 
-Seit SmartHomeNG v1.6 werden Item-Struktur-Templates unterstützt, mit denen sich wiederholende Itemstrukturen einfach realisieren lassen.
+SmartHomeNG unterstützt Item-Struktur-Templates, mit denen sich wiederholende Itemstrukturen einfach realisieren lassen.
 Die Anwendung erfolgt mit Hilfe des **struct**-Attributes mit dem jeweiligen Namen des Item-Templates. Dies wird bei dem Item definiert,
 unter dem die definierte Struktur (Teil-Item-Baum) eingefügt werden soll.
 
@@ -25,25 +25,15 @@ Prinzipiell gibt es 2 Anwendungsfälle:
 
 Demzufolge können die Item-Struktur-Templates an zwei verschiedenen Stellen definiert werden:
 
- - der Nutzer kann die Strukturen in der Konfigurationsdatei ../structs/global_structs.yaml definieren
+ - der Nutzer kann die Strukturen in Dateien im Verzeichnis etc/structs in beliebigen Dateien definieren
  - Autoren von Plugins können die Strukturen in den Metadaten des Plugins definieren. Beim Start von SmartHomeNG stehen
    die dann die Strukturen aller konfigurierten Plugins zur Verfügung.
 
-.. note::
-
-    Ab SmartHomeNG v1.9 können Item-Struktur-Template Definitionen auf mehrere Dateien verteilt werden.
-
-    Ab SmartHomeNG v1.10 werden die Item-Struktur-Template Definitionen nicht mehr in ../etc gespeichert sondern
-    in dem neu hinzugekommenen Verzeichnis ../structs.
-
-    Außer der Datei **global_structs.yaml** (die der bisherigen Datei **struct.yaml** im Verzeichnis ../etc entspricht)
-    können weitere Dateien angelegt werden. Im ../etc Verzeichnis musste deren Name muss mit **struct_** beginnen.
-    Das ist im ../structs Verzeichnis nicht mehr der Fall) Der Dateiname wird dabei der struct Namen als Prefix
-    vorangestellt, um Namensdopplungen vorzubeugen.
 
 Um eine doppelte Namensvergabe zu vermeiden, wird bei der Nutzung den structs, die in Plugins definiert wurden, der
-Name des Plugins vorangestellt. Wenn z.B. die struct **weather** genutzt werden soll, die im Plugin **darksky**
-definiert wurde, so muss als Referenz **darksky.weather** angegeben werden.
+Name des Plugins vorangestellt; bei structs, die vom Nutzer definiert wurden, wird "my." und der Name der Datei vorangestellt. Wenn z.B. die struct **weather** genutzt werden soll, die im Plugin **darksky**
+definiert wurde, so muss als Referenz **darksky.weather** angegeben werden. Für die struct **weather*, die vom Nutzer in der Datei etc/structs/lightsky.yaml definiert wurde, muss **my.lightsky.weather** als Referenz
+angegeben werden.
 
 Eine Übersicht der zur Verfügung stehenden structs kann in der Admin GUI unter **Items/Struktur** Templates eingesehen werden.
 
@@ -208,14 +198,14 @@ selbst definierte struct-Templates
 Anwendung
 ---------
 
-Eigens definierte Item-Struktur-Templates werden in der Konfigurationsdatei **../structs/global_structs.yaml** abgelegt.
+Eigens definierte Item-Struktur-Templates werden in der Konfigurationsdatei ``etc/structs/global_structs.yaml`` abgelegt.
 
 Hierbei gibt die oberste Ebene den Namen der Templates an. Darunter können Item-Strukturen definiert werden, wie man es
 auch in der Item Definition in den items.yaml Dateien machen würde. Das folgende Beispiel zeigt die Definition von zwei
 Strukturen (**individual_struct_01** und **individual_struct_02**):
 
 .. code-block:: yaml
-    :caption: structs/global_structs.yaml
+    :caption: etc/structs/global_structs.yaml
 
     individual_struct_01:
         name: Name der erste eigenen Item Struktur
@@ -250,7 +240,7 @@ Strukturen (**individual_struct_01** und **individual_struct_02**):
 Wenn jetzt in der Item Definition diese Strukturen referenziert werden:
 
 .. code-block:: yaml
-    :caption: items/items.yaml
+    :caption: etc/items/items.yaml
 
     my_tree:
         my_complex_data:
@@ -266,7 +256,7 @@ Wenn jetzt in der Item Definition diese Strukturen referenziert werden:
 entsteht im Item-Tree die selbe Struktur, als wenn man folgendes direkt in die item.yaml eingetragen hätte:
 
 .. code-block:: yaml
-    :caption: items/items.yaml
+    :caption: etc/items/items.yaml
 
     my_tree:
         my_complex_data:
@@ -301,10 +291,9 @@ Das **individual_item** wird an die Struktur des Templates angefügt.
 Verschachtelte struct Definitionen (nested structs)
 ---------------------------------------------------
 
-Ab SmartHomeNG v1.10 können Strukturdefinitionen beliebig verschachtelt werden. Wie Items, die mithilfe des Attributs
+Strukturdefinitionen können beliebig verschachtelt werden. Wie Items, die mithilfe des Attributs
 **struct:** auf eine Strukturdefinition verweisen, können dies auch Strukturen selbst tun. Dabei kann das **struct*:**
-Attribut an beliebiger Stelle einer struct eingefügt werden, nicht nur auf der obersten Ebene (wie dieses bereits ab
-SmartHomeNG v1.7 möglich war).
+Attribut an beliebiger Stelle einer struct eingefügt werden.
 
 SmartHomeNG löst alle Unterstrukturreferenzen vor dem Laden des Item Trees auf, um das Laden der Item Definitionen
 zu beschleunigen.
@@ -382,21 +371,21 @@ Attributdefinitionen eingelesen werden.
 Verwendung mehrerer Definitionsdateien
 ======================================
 
-Wenn structs in der Datei **../structs/global_structs.yaml** definiert werden, ist der Name der geladenen struct
+Wenn structs in der Datei ``etc/structs/global_structs.yaml`` definiert werden, ist der Name der geladenen struct
 zur Laufzeit identisch mit dem Namen, der in der Datei definiert wurde.
 
-Wenn eine Datei in einer Datei nach dem Namensschema **../structs/\<name\>.yaml** definiert wird, wird dem Namen
+Wenn eine Datei in einer Datei nach dem Namensschema ``etc/structs/\<name\>.yaml`` definiert wird, wird dem Namen
 der struct ein Präfix vorangestellt, um Namensdoppelungen zu vermeiden. Der Präfix ist der Dateiname. Wenn also eine
 struct mit dem Namem **individual_struct** in der Datei mit dem Namen
-../structs/**test**.yaml definiert wird, wird als Präfix für die Herkunft **test** vorangestellt. Der struct Name wäre
+``etc/structs/test.yaml`` definiert wird, wird als Präfix für die Herkunft **test** vorangestellt. Der struct Name wäre
 also **test.individual_struct**.
 
 Das könnte jedoch zu Namenskonflikten führen, falls hierbei der Name eines Plugins verwendet wird.
-Falls z.B. eine struct in einer Datei ../structs/**stateengine**.yaml definiert wird, könnte es zu Namenskonflikten mit
+Falls z.B. eine struct in einer Datei ``etc/structs/stateengine.yaml`` definiert wird, könnte es zu Namenskonflikten mit
 den structs kommen, die durch das **stateengine Plugin** definiert sind. Deshalb wird ein weiterer Präfix **my** dem
 struct Namen vorangestellt, um Namenskonflikte mit structs aus Plugins auszuschließen.
 
-Die struct **individual_struct** in der Datei mit dem Namen ../structs/**test**.yaml definiert wurde,
+Die struct **individual_struct** in der Datei mit dem Namen ``etc/structs/test.yaml`` definiert wurde,
 trägt zur Laufzeit also den Namen **my.test.individual_struct**. Unter diesem Namen wird sie in der Admin GUI
 angezeigt und muss auch so in Item Definitionen referenziert werden.
 

--- a/doc/user/source/konfiguration/items/initiale_itemkonfiguration.rst
+++ b/doc/user/source/konfiguration/items/initiale_itemkonfiguration.rst
@@ -16,7 +16,7 @@ Ein kleines Beispiel: Eine Lampe soll über KNX ein- und
 ausgeschaltet werden. Dazu braucht es zwei Schritte:
 
 1)  Das **KNX Plugin** muss installiert und aktiviert werden.
-    Das geschieht in der Datei ``./etc/plugins.yaml``.
+    Das geschieht in der Datei ``etc/plugins.yaml``.
     Typischerweise sieht der entsprechende Eintrag dann so aus:
 
     .. code-block:: yaml
@@ -26,8 +26,8 @@ ausgeschaltet werden. Dazu braucht es zwei Schritte:
           host: 127.0.0.1
 
 2)  Die Lampe muss nun als **Item** im SmartHomeNG angelegt werden.
-    Dazu wird eine Datei mit beliebigem Namen im Verzeichnis ``./items``
-    mit der Endung ``.yaml`` angelegt. z.B. die Datei ``./items/Lampen.yaml``.
+    Dazu wird eine Datei mit beliebigem Namen im Verzeichnis ``etc/items``
+    mit der Endung ``.yaml`` angelegt. z.B. die Datei ``etc/items/Lampen.yaml``.
     In dieser Datei wird das Item angelegt indem den Name des Items gefolgt von
     einem Doppelpunkt notiert wird. Der Inhalt der Datei wäre also:
 
@@ -130,7 +130,7 @@ Ein solches Schema hat den Vorteil, dass man mit
 beispielsweise um eine Logik auszulösen.
 
 Möchte man nun das Beispiel erweitern um z.B. mit der SmartVISU die Lampe zu schalten,
-muss man zunächst das Plugin **visu_websocket** in der ``./etc/plugin.yaml``
+muss man zunächst das Plugin **visu_websocket** in der ``etc/plugin.yaml``
 durch folgenden Eintrag aktivieren:
 
 .. code-block:: yaml
@@ -184,7 +184,7 @@ D.h. man kann die Lampe nun via KNX, SmartVISU oder Dashbutton ein- und
 ausschalten.
 
 Wie man grundsätzlich die verschiedenen Plugins in der
-``./etc/plugin.yaml`` konfiguriert, steht im Abschnitt **Konfiguration/Plugins**
+``etc/plugin.yaml`` konfiguriert, steht im Abschnitt **Konfiguration/Plugins**
 der Doku. Auch wie die Attribute in den Items
 gesetzt werden müssen, ist für jedes Plugin in der Doku der **Plugins**
 zu finden.

--- a/doc/user/source/konfiguration/items/ueberblick.rst
+++ b/doc/user/source/konfiguration/items/ueberblick.rst
@@ -67,11 +67,10 @@ Attribute eines Items werden in der Konfigurationsdatei in der Form
 
 
 angegeben. Normalerweise sind Attribut-Werte einzeilig. Es wird alles bis zum Zeilenende oder bis
-zum Beginn eines Kommentars (`#`) angenommen. (Seit dem Release 1.3 werden auch mehrzeilige Attribute
-unterstützt.)
+zum Beginn eines Kommentars (`#`) angenommen. 
 
 Informationen zum :doc:`Dateiformat </konfiguration/konfigurationsdateien/konfigdateien>`
-finden Sie :doc:`hier </konfiguration/konfigurationsdateien/konfigdateien>` unter
+finden sich :doc:`hier </konfiguration/konfigurationsdateien/konfigdateien>` unter
 **Aufbau der Konfigurationsdateien**.
 
 

--- a/doc/user/source/konfiguration/items/ueberblick.rst
+++ b/doc/user/source/konfiguration/items/ueberblick.rst
@@ -46,7 +46,7 @@ Namensvergabe
 Bei der Wahl von Itemnamen ist folgendes zu beachten:
 
 Plugin-Instanzen und Items der obersten Ebene (Top-Level) teilen sich den Namensraum. Es sollte
-vermieden werden, Top-Level Items einen Namen zu geben, der in **../etc/plugin.yaml** (bzw. **../etc/plugin.conf**)
+vermieden werden, Top-Level Items einen Namen zu geben, der in ``etc/plugin.yaml`` (bzw. ``etc/plugin.conf``)
 bereits für eine Plugin-Instanz gewählt wurde. Dieses kann zu unvorhergesehenen Problemen führen.
 
 z.B.: Wenn ein Plugin Funktionen implementiert hat, wird dies beim Aufruf dieser Funktionen zu
@@ -70,14 +70,9 @@ angegeben. Normalerweise sind Attribut-Werte einzeilig. Es wird alles bis zum Ze
 zum Beginn eines Kommentars (`#`) angenommen. (Seit dem Release 1.3 werden auch mehrzeilige Attribute
 unterstützt.)
 
-.. hint::
-
-   **Ab SmartHomeNG v1.3** wird ein neues Dateiformat für Konfigurationsdateien
-   unterstützt. Das bisherige Format der Konfigurationsdateien wird vorerst weiter unterstützt.
-
-   Informationen zum :doc:`alten und neuen Dateiformat </konfiguration/konfigurationsdateien/konfigdateien>`
-   finden Sie :doc:`hier </konfiguration/konfigurationsdateien/konfigdateien>` unter
-   **Aufbau der Konfigurationsdateien**.
+Informationen zum :doc:`Dateiformat </konfiguration/konfigurationsdateien/konfigdateien>`
+finden Sie :doc:`hier </konfiguration/konfigurationsdateien/konfigdateien>` unter
+**Aufbau der Konfigurationsdateien**.
 
 
 Properties und Funktionen

--- a/doc/user/source/konfiguration/konfiguration_backup_restore.rst
+++ b/doc/user/source/konfiguration/konfiguration_backup_restore.rst
@@ -20,12 +20,12 @@ Die Konfiguration von SmartHomeNG kann in ein zip-Archiv gesichert werden und au
 werden. Dieses kann sowohl von der Kommandozeile aus, als auch über das Administrationsinterface erfolgen.
 
 Von der Kommandozeile wird ein Backup erstellt, indem SmartHomeNG mit der Option **-cb** bzw. **--create_backup**
-gestartet wird. Das zip-Archiv mit dem Backup wird im Verzeichnis **/var/backup** abgelegt und hat den Namen
-**shng_config_backup.zip**.
+gestartet wird. Das zip-Archiv mit dem Backup wird im Verzeichnis ``/var/backup`` abgelegt und hat den Namen
+``shng_config_backup.zip``.
 
 Wenn beim Backup der Dateiname den Zeitpunkt des Backups enthalten soll, muss SmartHomeNG mit der Option **-cbt** bzw.
 **--create_backup_t** aufgerufen werden. Dann wird der Dateiname um Datum und Zeit der Erstellung des Backups ergänzt.
-Der Dateiname hat dann die Form **shng_config_backup_YYYY-MM-TT_hh-mm-ss.zip**.
+Der Dateiname hat dann die Form ``shng_config_backup_YYYY-MM-TT_hh-mm-ss.zip``.
 
 Die Sicherung von der Kommandozeile aus kann durchgeführt werden, während eine Instanz von SmartHomeNG läuft. Es ist
 nicht notwendig ein laufendes SmartHomeNG vorher zu beenden.
@@ -34,7 +34,7 @@ nicht notwendig ein laufendes SmartHomeNG vorher zu beenden.
 
    Es werden keine Konfigurationsdateien des alten .CONF Formats gesichert, sondern ausschließlich YAML Dateien.
 
-Ab SmartHomeNG v1.12 werden nun, falls vorhanden, die privaten Plugins (Plugins, deren Name mit **priv_** beginnt)
+Ab SmartHomeNG v1.12 werden nun, falls vorhanden, die privaten Plugins (Plugins, deren Name mit ``priv_`` beginnt)
 und die privaten Tools (das Verzeichnis priv_tools) mit gesichert und beim Wiederherstellen aus der Zip Datei zurück
 kopiert.
 
@@ -50,7 +50,7 @@ Wiederherstellen
 ----------------
 
 Zum Wiederherstellen eines Konfigurations-Backups von der Kommandozeile, muss das Backup-Archiv in das Verzeichnis
-**/var/restore** gelegt werden. Es darf einen beliebigen Namen tragen und muss die einzige Datei in diesem Verzeichnis
+``/var/restore`` gelegt werden. Es darf einen beliebigen Namen tragen und muss die einzige Datei in diesem Verzeichnis
 sein. Anschließend muss SmartHomeNG mit der Option **-rb** bzw. **--restore_backup** gestartet werden.
 
 Die Wiederherstellung von der Kommandozeile aus kann durchgeführt werden, während eine Instanz von SmartHomeNG läuft.

--- a/doc/user/source/konfiguration/konfiguration_ueberblick.rst
+++ b/doc/user/source/konfiguration/konfiguration_ueberblick.rst
@@ -80,7 +80,7 @@ Die Verzeichnisse sind im Hauptverzeichnis von SmartHomeNG zu finden, für gewö
 +---------------+-----------------------------------------------------------------------------------------------------------------------------+
 | ``doc``       | Wird einmal die Dokumentation enthalten                                                                                     |
 +---------------+-----------------------------------------------------------------------------------------------------------------------------+
-| ``etc``       | enthält mindestens **smarthome.yaml**, **plugin.yaml** und **logic.yaml**.                                                  |
+| ``etc``       | enthält mindestens ``smarthome.yaml``, ``plugin.yaml`` und ``logic.yaml``.                                                  |
 |               | In diesen Dateien befindet sich die Konfiguration des Grundsystems                                                          |
 +---------------+-----------------------------------------------------------------------------------------------------------------------------+
 | ``examples``  | Beispiele für Items                                                                                                         |
@@ -124,21 +124,21 @@ Durch Setzen der Kommandozeilenoption ``-e`` bzw. ``--config_etc`` kann das glei
 Wenn dies von der Kommandozeile aus aktiviert wird, versucht SmartHomeNG zusätzliche, vorhandene  Konfigurationen in den oben mit (*) gekennzeichneten Verzeichnissen in die entsprechenden Ordner unterhalb von `etc` zu verschieben. Wenn dies gelingt, werden die ursprünglichen (leeren) Verzeichnisse gelöscht und SmartHomeNG startet normal.
 Wenn dabei Fehler auftauchen, wird eine entsprechende Meldung ausgegeben, und da die Konfiguration möglicherweise nicht korrekt übernommen wurde, wird der Start abgebrochen.
 
-Dateien im Verzeichnis *../etc*
--------------------------------
+Dateien im Verzeichnis ``etc``
+------------------------------
 
-Während der Installation sind im Unterverzeichnis **etc** bereits drei Dateien erstellt worden:
-**smarthome.yaml**, **plugin.yaml** und **logic.yaml**.
+Während der Installation sind im Unterverzeichnis ``etc`` bereits drei Dateien erstellt worden:
+``smarthome.yaml``, ``plugin.yaml`` und ``logic.yaml``.
 
 
 smarthome.yaml
 ^^^^^^^^^^^^^^
 
-In der Datei **smarthome.yaml** wird notiert, wo sich die Installation befindet und welche
+In der Datei ``smarthome.yaml`` wird notiert, wo sich die Installation befindet und welche
 Zeitzone als Basis genommen werden soll:
 
 .. code-block:: yaml
-   :caption: ../etc/smarthome.yaml
+   :caption: etc/smarthome.yaml
 
    # smarthome.yaml
    lat: '50.123'
@@ -167,10 +167,10 @@ Seite :doc:`/referenz/items/standard_attribute/autotimer`
 plugin.yaml
 ^^^^^^^^^^^
 
-Die Datei **plugin.yaml** enthält die Konfigurationsanweisungen für alle Plugins, die benutzt werden sollen.
+Die Datei ``plugin.yaml`` enthält die Konfigurationsanweisungen für alle Plugins, die benutzt werden sollen.
 
 .. code-block:: yaml
-   :caption: ../etc/plugin.yaml
+   :caption: etc/plugin.yaml
 
    # plugin.yaml
    knx:
@@ -189,29 +189,6 @@ Die Datei **plugin.yaml** enthält die Konfigurationsanweisungen für alle Plugi
    sql:
        plugin_name: sqlite_visu2_8
 
-
-Seit Version 1.2 (Master Branch) gibt es ein neues Plugin (Backend) für SmartHomeNG. Dabei kann
-man über einen Browser das gleiche (und mehr) erreichen, wie früher über das CLI-Plugin.
-
-Allerdings ist das Plugin inzwischen veraltet und wird in einer der kommenden Versionen von SmartHomeNG entfernt, da
-es inzwischen ein erheblich leistungsfähigeres Administrationsinterface für SmartHomeNG gibt.
-
-Das Backend Plugin bindet man folgendermaßen ein:
-
-.. code-block:: yaml
-   :caption: Auszug aus ../etc/plugin.yaml
-
-   BackendServer:
-       plugin_name: backend
-       updates_allowed: True
-       user: admin
-       password: xxxx
-       language: de
-       threads: 8
-       #ip: 0.0.0.0
-       #port: 8383
-
-
 Die weitere Einrichtung und Konfiguration von Plugins ist unter `Plugins <plugins.html>`_ beschrieben.
 
 
@@ -224,7 +201,7 @@ Die weitere Einrichtung und Konfiguration von Plugins ist unter `Plugins <plugin
    version of the plugin, you have to specify the parameter `plugin_version` in the configuration
    section of the plugin.
 
-   To find out, if a plugin comes with an older version (or versions), take a look at the plugin's
+   To find out if a plugin comes with an older version (or versions), take a look at the plugin's
    directory. if you find a subdirectory with the name starting with ``_pv_`` the plugin comes with
    an older (previous) version. The rest of the folder name specifies the version number. If you
    find a subfolder ``_pv_1_3_0``, it contains the v1.3.0 of the plugin. To load that version, just
@@ -235,13 +212,13 @@ Die weitere Einrichtung und Konfiguration von Plugins ist unter `Plugins <plugin
 logic.yaml
 ^^^^^^^^^^
 
-In der Datei **logic.yaml** werden die Logiken eingetragen. Der Name jeder Logik kommt
+In der Datei ``logic.yaml`` werden die Logiken eingetragen. Der Name jeder Logik kommt
 zwischen zwei eckige Klammern, der Eintrag **filename** verweist auf die Python-Datei die dann aufgerufen
 wird, wenn die Logik abgearbeitet werden soll. **crontab** schreibt fest, dass die Logik zu bestimmten
 Zeiten ausgeführt werden soll. watch_item bestimmt, welche Items die Logik aufrufen können:
 
 .. code-block:: yaml
-   :caption: ../etc/logic.yaml
+   :caption: etc/logic.yaml
 
    # logic.yaml
    InitSmarthomeNG:
@@ -269,11 +246,8 @@ Für die weitere Konfiguration von Logiken geht es unter :doc:`logiken` weiter.
 Weitere Dateien
 ^^^^^^^^^^^^^^^
 
-Zusätzlich sind ab der Version 1.2 auch noch **logging.yaml**, **plugin.yaml.default** und
-**smarthome.yaml.default** zu finden. Während sich der Inhalt der **.default** Dateien als
-Beispieldatei selbst erklärt, ist die **logging.yaml** noch erklärungsbedürftig:
-Im gesamten Programmcode sind Anweisungen verteilt, die bestimmte Programmzustände loggen,
-also mit notieren.
+Weiterhin existiert noch ``logging.yaml``. Im gesamten Programmcode sind Anweisungen
+verteilt, die bestimmte Programmzustände loggen, also protokollieren.
 
 Im einfachsten Fall sind das einfache Meldungen die z.B. den Start eines
 Plugins melden oder aber das setzen eines Items durch die Visu oder aber das Ausführen einer
@@ -281,7 +255,7 @@ Datenbank Komprimierung. Es sind aber auch Meldungen dabei, die über Fehler ber
 ein Item das über die Visu aktualisiert werden soll, gar nicht existiert oder wenn zum Beispiel
 ein Plugin einen Fehler bei der Abfrage von Daten eines Stromzählers meldet.
 
-Mit der **logging.yaml** kann man ziemlich fein steuern von welchen Modulen man welche Meldungen
+Mit der ``logging.yaml`` kann man ziemlich fein steuern von welchen Modulen man welche Meldungen
 bekommen möchte. Sucht man beispielsweise einen hartnäckigen Fehler in einem neuen Plugin **Foo**,
 dann kann man das Logging für alle anderen Plugins gezielt reduzieren so das man sich aufs Wesentliche
 konzentrieren kann.
@@ -289,14 +263,14 @@ konzentrieren kann.
 Weitere Informationen gibt es unter `Konfiguration - Logging <logging.html>`_
 
 
-Dateien im Verzeichnis *../functions*
--------------------------------------
+Dateien im Verzeichnis ``etc/functions``
+----------------------------------------
 
 Hier werden benutzerdefinierte Funktionen (Userfunctions) gespeichert.
 
 
-Dateien im Verzeichnis *../items*
----------------------------------
+Dateien im Verzeichnis ``etc/items``
+------------------------------------
 
 Hier finden sich die Dateien mit den Items. Es ist egal, wie viele Dateien hier abgelegt wurden.
 Alle Dateien die die Endung .yaml besitzen, werden beim Start von SmartHomeNG gelesen und in die

--- a/doc/user/source/konfiguration/konfiguration_ueberblick.rst
+++ b/doc/user/source/konfiguration/konfiguration_ueberblick.rst
@@ -109,19 +109,19 @@ Die Verzeichnisse sind im Hauptverzeichnis von SmartHomeNG zu finden, für gewö
 
 Mit (*) gekennzeichnete Verzeichnisse enthalten die vom Benutzer zu erstellenden/zu ändernden Daten (Konfiguration).
 
-Durch Setzen der Konfigurationsoption ``config_etc: true`` in der `etc/smarthome.yaml` wird SmartHomeNG angewiesen, diese Verzeichnisse nicht im Hauptverzeichnis
+Durch Setzen der Konfigurationsoption ``config_etc: true`` in der ``etc/smarthome.yaml`` wird SmartHomeNG angewiesen, diese Verzeichnisse nicht im Hauptverzeichnis
 von SmartHomeNG (z.B. `/usr/local/smarthome/`) zu suchen, sondern im Unterverzeichnis `etc`. So wären Item-Dateien beispielsweise nicht in
-`/usr/local/smarthome/items/`, sondern in `/usr/local/smarthome/etc/items/` abzulegen. 
+`/usr/local/smarthome/items/`, sondern in ``/usr/local/smarthome/etc/items/`` abzulegen. 
 
 Der Vorteil der Option ist, dass sich alle vom Benutzer zu ändernden Daten innerhalb eines Verzeichnisses (mit Unterverzeichnissen) befinden (`etc/`) und
 dieses damit einfach nach eigenen Wünschen verwaltet werden kann. Weiterhin wird mit dieser Option die Nutzung der Verzeichnisstruktur stärker
-an die im Unix-Bereich übliche Aufteilung angepasst - in `etc/` befinden sich Konfigurationsdateien (die der Benutzer ändert), in `var/`
+an die im Unix-Bereich übliche Aufteilung angepasst - in ``etc/`` befinden sich Konfigurationsdateien (die der Benutzer ändert), in `var/`
 befinden sich Dateien, die durch SmartHomeNG geändert werden, und die restlichen Dateien sind statisch, d.h. im Programmablauf unverändert.
 
 Da bestehende Referenzen aber auf die seit Beginn von SmartHomeNG festgelegten Pfade verweisen, ist diese Konfiguration optional und kein Standard.
 
-Durch Setzen der Kommandozeilenoption ``-e`` bzw. ``--config_etc`` kann das gleiche Verhalten erzwungen werden, auch wenn die Konfiguration in `etc/smarthome.yaml` nicht gesetzt ist.
-Wenn dies von der Kommandozeile aus aktiviert wird, versucht SmartHomeNG zusätzliche, vorhandene  Konfigurationen in den oben mit (*) gekennzeichneten Verzeichnissen in die entsprechenden Ordner unterhalb von `etc` zu verschieben. Wenn dies gelingt, werden die ursprünglichen (leeren) Verzeichnisse gelöscht und SmartHomeNG startet normal.
+Durch Setzen der Kommandozeilenoption ``-e`` bzw. ``--config_etc`` kann das gleiche Verhalten erzwungen werden, auch wenn die Konfiguration in ``etc/smarthome.yaml`` nicht gesetzt ist.
+Wenn dies von der Kommandozeile aus aktiviert wird, versucht SmartHomeNG zusätzliche, vorhandene  Konfigurationen in den oben mit (*) gekennzeichneten Verzeichnissen in die entsprechenden Ordner unterhalb von ``etc`` zu verschieben. Wenn dies gelingt, werden die ursprünglichen (leeren) Verzeichnisse gelöscht und SmartHomeNG startet normal.
 Wenn dabei Fehler auftauchen, wird eine entsprechende Meldung ausgegeben, und da die Konfiguration möglicherweise nicht korrekt übernommen wurde, wird der Start abgebrochen.
 
 Dateien im Verzeichnis ``etc``

--- a/doc/user/source/konfiguration/konfigurationsdateien/items.rst
+++ b/doc/user/source/konfiguration/konfigurationsdateien/items.rst
@@ -7,14 +7,14 @@ items/\*.yaml
 .. _`item configuration files`:
 
 
----------------------------------------------
-Item Definitionen im Verzeichnis **../items**
----------------------------------------------
+----------------------------------------------
+Item Definitionen im Verzeichnis ``etc/items``
+----------------------------------------------
 
 Die Items repräsentieren das Herz der Konfiguration von SmartHomeNG. Auf ein Item kann von jeder Logik,
 jedem Plugin und jedem eval-Ausdruck zugegriffen werden.
 
-Im Verzeichnis **../items** kann eine beliebige Anzahl von Konfigurationsdateien erzeugt werden und jede
+Im Verzeichnis ``etc/items`` kann eine beliebige Anzahl von Konfigurationsdateien erzeugt werden und jede
 Konfigurationsdatei kann eine beliebige Anzahl von Item Definitionen enthalten. Das Verzeichnis enthält yaml
 Dateien (oder Dateien im alten .conf Format) mit den Definitionen der Items, die durch SmartHomeNG genutzt
 werden sollen. Der Name der yaml Datei kann beliebig sein, solange die Extension `.yaml` ist.

--- a/doc/user/source/konfiguration/konfigurationsdateien/konfigdateien.rst
+++ b/doc/user/source/konfiguration/konfigurationsdateien/konfigdateien.rst
@@ -6,7 +6,7 @@
 Konfiguration über Dateien
 ==========================
 
-Für die Konfiguration sind die Verzeichnisse ***../etc***, ***../items***, ***../scenes*** und ***../logics*** wichtig.
+Für die Konfiguration sind die Verzeichnisse ``etc``, ``etc/items``, ``etc/scenes`` und ``etc/logics`` wichtig.
 In diesen Verzeichnissen wird die Konfiguration gespeichert und gepflegt. Im folgenden sind
 die Konfigurationsdateien beschrieben, die in diesen Verzeichnissen gespeichert werdeen.
 
@@ -18,8 +18,8 @@ Verzeichnisse
 Im folgenden sind die Verzeichnisse beschrieben, in denen Konfigurationsdateien abgelegt werden.
 
 
-Verzeichnis *../etc*
---------------------
+Verzeichnis *etc*
+-----------------
 
 In diesem Verzeichnis werden die allgemeineren Konfigurationsdateien abgelegt. Im einzelnen sind das folgende
 Dateien:
@@ -33,18 +33,18 @@ Dateien:
 - struct.yaml
 
 
-Verzeichnis *../items*
-----------------------
+Verzeichnis *etc/items*
+-----------------------
 
 In diesem Verzeichnis werden eine oder mehrere Dateien abgelegt, welche die Item Definitionen enthalten. Der
-Name der Dateien ist dabei beliebig. Sie müssen nur gültige YAML Dateien sein und die Endung **.yaml**
+Name der Dateien ist dabei beliebig. Sie müssen nur gültige YAML Dateien sein und die Endung ``.yaml``
 tragen.
 
 - \*.yaml
 
 
-Verzeichnis *../logics*
------------------------
+Verzeichnis *etc/logics*
+------------------------
 
 In diesem Verzeichnis werden die Python Code Dateien der Logiken abgelegt. Zusätzlich legt das Blockly Plugin
 hier auch die Blockly Definitionen ab, die von dem Plugin in Python Code übersetzt werden.
@@ -53,8 +53,8 @@ hier auch die Blockly Definitionen ab, die von dem Plugin in Python Code überse
 - \*.blockly
 
 
-Verzeichnis *../scenes*
------------------------
+Verzeichnis *etc/scenes*
+------------------------
 
 In diesem Verzeichnis werden Szenen Definitionen gespeichert. Außerdem legt SmartHomeNG hier für Szenen, bei
 denen das Lernen von Werten erlaubt ist, eine Datei mit den gelernten Werten zu der Szenendefinition ab.
@@ -74,8 +74,6 @@ Diese Seite beschäftigt sich mit dem grundlegenden Format der
 Konfigurationsdateien. Für die vollständigen
 Konfigurationsmöglichkeiten, bitte auf den jeweiligen Wiki Seiten
 nachsehen.
-
-Das YAML Format wird seit SmartHomeNG **Release 1.3** unterstützt.
 
 Dieser Abschnitt beschäftigt sich nur mit den Teilen der
 Markup-Language, die für SmartHomeNG relevant sind. Bei einem
@@ -111,10 +109,8 @@ Und die Beschreibungen für **Items** sehen so aus:
                key4: value4
 
 Wichtig ist dabei folgendes: - In YAML Dateien sind keine TABs erlaubt.
-Es müssen Leerzeichen verwendet werden. - Im Gegensatz zu
-Item\ **.conf** Dateien, bei denen die Struktur durch die Anzahl eckiger
-Klammern um den Sektions(Item)-Namen bestimmt wird, wird die Struktur
-einer YAML Datei durch Einrückungen bestimmt. - Der Doppelpunkt, der
+Es müssen Leerzeichen verwendet werden, die Struktur
+einer YAML Datei wird durch Einrückungen bestimmt. Der Doppelpunkt, der
 einem Sektions-/Key-Namen folgt, kann direkt nach diesem Namen folgen.
 Er **muss** jedoch von einem Leerzeichen gefolgt werden
 

--- a/doc/user/source/konfiguration/konfigurationsdateien/logic.rst
+++ b/doc/user/source/konfiguration/konfigurationsdateien/logic.rst
@@ -7,9 +7,9 @@ logic.yaml
 ==========
 
 Logiken in SmartHomeNG sind Python Skripte (wie der Core von SmartHomeNG auch). Diese Skripte
-werden im Verzeichnis **../logics** abgelegt. Um SmartHomeNG wissen zu lassen, wann eine
+werden im Verzeichnis ``etc/logics`` abgelegt. Um SmartHomeNG wissen zu lassen, wann eine
 Logik gestartet werden soll und welches Python Skript dann genutzt werden soll, muss jede Logik
-in der Datei **../etc/logic.yaml** konfiguriert werden:
+in der Datei ``etc/logic.yaml`` konfiguriert werden:
 
 .. code-block:: yaml
    :caption: logic.yaml

--- a/doc/user/source/konfiguration/konfigurationsdateien/logics.rst
+++ b/doc/user/source/konfiguration/konfigurationsdateien/logics.rst
@@ -9,24 +9,24 @@ logics/\*.py
 ---------
 
 Logiken werden in SmartHomeNG durch einfache Python Skripte bereitgestellt. Damit SmartHomeNG
-die Skripte findet, müssen sie unter **../logics** abgelegt sein. Zusätzlich
-müssen diese Logiken in der Datei **logic.yaml** im Verzeichnis  **../etc**
+die Skripte findet, müssen sie unter ``etc/logics`` abgelegt sein. Zusätzlich
+müssen diese Logiken in der Datei ``logic.yaml`` im Verzeichnis  ``etc``
 konfiguriert werden.
 
 
----------------------------------------
-Logik Code im Verzeichnis **../logics**
----------------------------------------
+----------------------------------------
+Logik Code im Verzeichnis ``etc/logics``
+----------------------------------------
 
 Dieses Verzeichnis enthält die Logiken, welche von SmartHomeNG verwendet werden. Diese Logiken
 schreibst Du bei Bedarf selbst.
 
 Eine Logik ist grundsätzlich ein Python Skript. Es gibt jedoch einige zusätzliche Konventionen.
-Wann und wie die Logik ausgeführt wird, wird in **../etc/logics.yaml** konfiguriert.
+Wann und wie die Logik ausgeführt wird, wird in ``etc/logics.yaml`` konfiguriert.
 
 Falls das Blockly Plugin zum schreiben einer Logik genutzt wird, hat eine Logik zwei Dateien.
-Eine Datei enthält den Blockly Code (Dateiendung **.blockly**) und die andere Datei enthält den
-generierten Python Code (Dateiendung **.py**).
+Eine Datei enthält den Blockly Code (Dateiendung ``.blockly``) und die andere Datei enthält den
+generierten Python Code (Dateiendung ``.py``).
 
 .. note::
 

--- a/doc/user/source/konfiguration/konfigurationsdateien/module.rst
+++ b/doc/user/source/konfiguration/konfigurationsdateien/module.rst
@@ -12,7 +12,7 @@ Programmcode des Cores aufgenommen worden, sondern als ladbare Module ausgeführ
 es möglich SmartHomeNG auch auf leistungsschwachen Systemen einzusetzen. Man muss nur auf den
 Einsatz der ladbaren Module verzichten.
 
-Die ladbaren Module werden in der Datei **../etc/module.yaml** konfiguriert.
+Die ladbaren Module werden in der Datei ``etc/module.yaml`` konfiguriert.
 
 Die Datei sollte folgendermaßen aussehen:
 

--- a/doc/user/source/konfiguration/konfigurationsdateien/plugin.rst
+++ b/doc/user/source/konfiguration/konfigurationsdateien/plugin.rst
@@ -9,15 +9,15 @@ plugin.yaml
 ===========
 
 Plugins erweitern die Kern-Funktionalität von SmartHomeNG.
-Das **../plugins** Verzeichnis enthält ein Unterverzeichnis für jedes verfügbare Plugin.
-In der Konfigurationsdatei **../etc/plugin.yaml** wird die Konfiguration für jedes Plugin hinterlegt,
+Das ``plugins`` Verzeichnis enthält ein Unterverzeichnis für jedes verfügbare Plugin.
+In der Konfigurationsdatei ``etc/plugin.yaml`` wird die Konfiguration für jedes Plugin hinterlegt,
 dass genutzt werden soll.
 
 Das Beispiel unten konfiguriert das KNX-Plugin, so dass es Telegramme an einen **eibd** oder einen
 **knxd** Daemon sendet bzw. von dort empfängt. **eibd** und **knxd** sind Software Gateways zum KNX Bus.
 
 In diesem Fall ist der Name der Plugin Instanz **knx** und das Plugin wird im Verzeichnis **knx** im
-Verzeichnis **../plugins** gesucht.
+Verzeichnis ``plugins`` gesucht.
 
 
 .. literalinclude:: ../../../../../templates/plugin.yaml.default
@@ -41,22 +41,13 @@ im Abschnitt **Konfiguration/Plugins** zu finden.
 Referenzierung eines Plugins in der Konfiguration
 -------------------------------------------------
 
-Seit v1.4 ist es Standard, das Plugin über den einzigen Parameter ``plugin_name`` zu spezifizieren.
-Dabei ist der Wert der Wert des früheren Parameters ``class_path`` ohne den Präfix ``plugins.``,
-also der Name des Plugin Verzeichnisses. Da alle Plugins im Verzeichnis **../plugins** liegen, ist
-**plugins.** redundante Information.
-
-Bis zu SmartHomeNG v1.3 wurde ein Plugin in der Konfiguration über zwei Parameter ``class_name``
-und ``class_path`` referenziert.
-
-Wenn das Plugin eine Metadaten Definition enthält (was fast alle Plugins tun), so gibt es keine
-Notwendigkeit den Parameter ``class_name`` anzugeben. Diese Information wird dann den Metadaten
-entnommen.
+Das Plugin wird über den einzigen Parameter ``plugin_name`` spezifiziert. Der Wert ist der
+Name des Plugin-Verzeichnisses unterhalb von ``plugins``
 
 .. note::
 
-    Sollte es notwendig werden ein Plugin außerhalb des Verzeichnisses **../plugins** zu speichern,
-    kann dieses Plugin (wie bisher) über ``class_path:`` referenziert werden.
+    Sollte es notwendig werden ein Plugin außerhalb des Verzeichnisses ``../plugins`` zu speichern,
+    kann dieses Plugin (wie früher) über ``class_path:`` referenziert werden.
 
 
 Nutzung einer älteren Version eines Plugins
@@ -64,13 +55,13 @@ Nutzung einer älteren Version eines Plugins
 
 Falls Du nicht die neueste Version von SmartHomeNG nutzt, kann es vorkommen, dass Du eine ältere
 Version eines Plugins nutzen möchtest. Einige Plugins enthalten in Unterverzeichnissen ältere
-Versionen. Um diese zu nutzen, muss in **../etc/plugin.yaml** in der Konfiguration der Parameter
+Versionen. Um diese zu nutzen, muss in ``etc/plugin.yaml`` in der Konfiguration der Parameter
 ``plugin_version:`` angegeben werden.
 
 Um herauszufinden, ob ein Plugin mit einer (oder mehreren) älteren Version(en) installiert ist,
 hilft ein Blick in das Plugin Verzeichnis. Falls es dort Unterverzeichnisses gibt, deren Name mit
 `_pv_` beginnt, sind ältere Versionen vorhanden. Der Rest des jeweiligen Verzeichnisnamens gibt
-an, welche Version sich in dem Verzeichnis befindet. Wenn Du ein Unterverzeichnis **_pv_1_3_0**
+an, welche Version sich in dem Verzeichnis befindet. Wenn Du ein Unterverzeichnis ``_pv_1_3_0``
 findest, enthält es die Version v1.3.0 des Plugins. Um diese Version, statt der aktuellen Version
 zu laden, musst Du nur den Eintrag ``plugin_version: 1.3.0`` zur Plugin Konfiguration hinzufügen.
 

--- a/doc/user/source/konfiguration/konfigurationsdateien/scenes.rst
+++ b/doc/user/source/konfiguration/konfigurationsdateien/scenes.rst
@@ -6,10 +6,10 @@ scenes/\*.yaml
 .. _`scene configuration files`:
 
 
-Szenen Definitionen im Verzeichnis **../scenes**
-================================================
+Szenen Definitionen im Verzeichnis ``etc/scenes``
+=================================================
 
-Im Verzeichnis **../scenes** kann eine beliebige Anzahl von Konfigurationsdateien für Szenen
+Im Verzeichnis ``etc/scenes`` kann eine beliebige Anzahl von Konfigurationsdateien für Szenen
 erzeugt werden. Jede Konfigurationsdatei kann dabei nur die Konfiguration einer Szene enthalten.
 Das Verzeichnis enthält yaml Dateien (oder Dateien im alten .conf Format) mit den Definitionen
 der Szenen, die durch SmartHomeNG genutzt werden sollen. Der Name der yaml Datei kann beliebig sein,
@@ -169,9 +169,9 @@ Dafür muss ein Szenen-Item angelegt werden:
            szenen:
                type: scene
 
-Um festzulegen wie die Szenen aussehen sollen, muss im Verzeichnis **../scenes** eine
+Um festzulegen wie die Szenen aussehen sollen, muss im Verzeichnis ``etc/scenes`` eine
 Konfigurationsdatei für die Szene-Definition angelegt werden. Für das obige
-Beispiel muss die Datei den Namen **wohnung.buero.szenen.yaml** tragen.
+Beispiel muss die Datei den Namen ``wohnung.buero.szenen.yaml`` tragen.
 
 
 .. code-block:: yaml

--- a/doc/user/source/konfiguration/konfigurationsdateien/smarthome.rst
+++ b/doc/user/source/konfiguration/konfigurationsdateien/smarthome.rst
@@ -9,14 +9,14 @@ Ort der SmartHomeNG Installation berechnen zu können, sind die geographischen K
 der SmartHomeNG Installation notwendig. Diese werden zusammen mit einigen globalen SmartHomeNG
 Konfigurationen in smarthome.yaml konfiguriert.
 
-Erzeuge eine neue Datei **smarthome.yaml** im Verzeichnis ***../etc*** oder kopiere die vorhandene
-Datei **smarthome.yaml.default** zu **smarthome.yaml** und passe sie nach Deinen Erfordernissen
+Erzeuge eine neue Datei ``smarthome.yaml`` im Verzeichnis *``etc``* oder kopiere die vorhandene
+Datei ``smarthome.yaml.default`` zu ``smarthome.yaml`` und passe sie nach Deinen Erfordernissen
 an.
 
 .. hint::
 
-    Falls beim Start von SmartHomeNG keine Datei **smarthome.yaml** existiert, wird die Datei
-    **smarthome.yaml.default** automatisch kopiert.
+    Falls beim Start von SmartHomeNG keine Datei ``smarthome.yaml`` existiert, wird die Datei
+    ``smarthome.yaml.default`` aus dem ``templates``-Ordner automatisch kopiert.
 
 Die Datei sollte folgendermaßen aussehen:
 

--- a/doc/user/source/konfiguration/konfigurationsdateien/struct.rst
+++ b/doc/user/source/konfiguration/konfigurationsdateien/struct.rst
@@ -4,17 +4,15 @@
 
 .. index:: structs; struct.yaml
 
-struct.yaml und struct_*.yaml
-=============================
+global_struct.yaml
+==================
 
 In dieser Konfigurationsdatei können eigene Item-Strukturen angelegt werden, die über das **struct** Attribut als
 Template verwendet werden können.
 
-Ab SmartHomeNG v1.9 können eigene Item-Strukturen auf mehrere Dateien verteilt werden.
-
-Außer der Datei **struct.yaml** im Verzeichnis ../etc können weitere Dateien angelegt werden. Deren
-Name muss mit **struct_** beginnen. Der danach folgende Teil des Dateinamens wird dabei dem struct Namen
-als Prefix vorangestellt, um Namensdopplungen vorzubeugen.
+Einfacher und strukturiert können Item-Strukturen auch in einzelnen Dateien im Ordner
+``etc/structs`` definiert werden. Der Dateiname wird dem struct-Namen als Präfix
+vorangestellt, um Namensdoppelungen zu vermeiden.
 
 .. note::
 

--- a/doc/user/source/konfiguration/logging.rst
+++ b/doc/user/source/konfiguration/logging.rst
@@ -85,17 +85,17 @@ Konfiguration des Loggings
 Auf der Seite `Python Logging <https://docs.python.org/3.6/library/logging.html#module-logging>`_
 sind die Konfigurationsmöglichkeiten detailliert beschrieben.
 
-SmartHomeNG lädt beim Start die Konfiguration des Logging aus der Datei **etc/logging.yaml**. Ist diese Datei nicht vorhanden,
-so versucht SmartHomeNG, die Datei **etc/logging.yaml.default** nach **etc/logging.yaml** zu kopieren und dann daraus
+SmartHomeNG lädt beim Start die Konfiguration des Logging aus der Datei ``etc/logging.yaml``. Ist diese Datei nicht vorhanden,
+so versucht SmartHomeNG, die Datei ``etc/logging.yaml.default`` nach ``etc/logging.yaml`` zu kopieren und dann daraus
 die Konfiguration des Loggings zu laden.
 
-Wenn bei der Konfiguration des Loggings etwas schief geht, kann also jederzeit die Datei **etc/logging.yaml** gelöscht oder
-besser umbenannt werden und wird dann beim nächsten Neustart durch den Inhalt der **etc/logging.yaml.default** frisch bereitgestellt.
+Wenn bei der Konfiguration des Loggings etwas schief geht, kann also jederzeit die Datei ``etc/logging.yaml`` gelöscht oder
+besser umbenannt werden und wird dann beim nächsten Neustart durch den Inhalt der ``etc/logging.yaml.default`` frisch bereitgestellt.
 
-Ein Beispiel für **etc/logging.yaml.default** im Folgenden:
+Ein Beispiel für ``etc/logging.yaml.default`` im Folgenden:
 
 .. literalinclude:: ../../../../templates/logging.yaml.default
-   :caption: ../etc/logging.yaml
+   :caption: etc/logging.yaml
    :language: yaml
 
 
@@ -109,7 +109,7 @@ Die einzelnen Konfigurationseinträge haben die folgende Bedeutung:
 +=================+====================================================================================================+
 | **formatters:** | Definiert das Ausgabeformat der einzelnen Loggingeinträge. Mehrere unterschiedliche                |
 |                 | **formatter** können dazu verwendet werden, um unterschiedlich aussehende Logdateien               |
-|                 | zu erzeugen. In der Konfigurationsdatei **etc/logging.yaml** sind ua. die Formatter                |
+|                 | zu erzeugen. In der Konfigurationsdatei ``etc/logging.yaml`` sind ua. die Formatter                |
 |                 | **`simple`** und **`detail`** vorkonfiguriert. Weitere Formatter können bei Bedarf                 |
 |                 | hinzugefügt werden.                                                                                |
 |                 | Weitere Infos sind unter :doc:`Logging Formatter </referenz/logging/logging_formatter>` zu finden. |
@@ -117,7 +117,7 @@ Die einzelnen Konfigurationseinträge haben die folgende Bedeutung:
 | **handlers:**   | Handler definieren die Log-Behandlungsroutinen/Ausgabekanäle die verwendet werden.                 |
 |                 | In Python gibt es bereits mehrere vorimplementierte und mächtige Handler-Typen, die in der         |
 |                 | `Python Doku <https://docs.python.org/3.4/library/logging.handlers.html#module-logging.handlers>`_ |
-|                 | beschrieben sind. Als eigentliche Handler sind in der Konfigurationsdatei **etc/logging.yaml**     |
+|                 | beschrieben sind. Als eigentliche Handler sind in der Konfigurationsdatei ``etc/logging.yaml``     |
 |                 | die Handler **`console`** und **`file`** vordefiniert. Wenn Log-Einträge z.B. in eine andere       |
 |                 | Datei geschrieben werden sollen, muss ein weiterer Handler definiert werden.                       |
 |                 | Sollen Filter angewendet werden, so sind diese im entsprechenden Handler durch                     |
@@ -164,7 +164,7 @@ Logging Handler und Filter
 ==========================
 
 Zusätzlich zu den Logging Handlern, die im Standard Logging Modul von Python definiert sind, bringt
-SmartHomeNG weitere Handler und Filter mit, die bei der Konfiguration in ../etc/logging.yaml verwendet werden
+SmartHomeNG weitere Handler und Filter mit, die bei der Konfiguration in etc/logging.yaml verwendet werden
 können.
 
 Die Beschreibung dieser Handler und Filter ist im Referenz Abschnitt unter Logging zu finden:
@@ -211,7 +211,7 @@ muss in der config auch dieser Name verwendet werden. Ohne `plugin.` oder `logic
 
 
 .. code-block:: yaml
-   :caption: ../etc/logging.yaml
+   :caption: etc/logging.yaml
 
    loggers:
        DWD:

--- a/doc/user/source/konfiguration/logging_best_practices.rst
+++ b/doc/user/source/konfiguration/logging_best_practices.rst
@@ -99,9 +99,9 @@ nicht beschrieben. Diese Grundkonfiguration definiert drei handler
 (Ziele für Logausgaben):
 
 -  Die Konsole
--  Das Logfile **smarthome-warnings.log**, welches nur Warnungen und
+-  Das Logfile ``smarthome-warnings.log``, welches nur Warnungen und
    Fehler aufnimmt
--  Das Logfile **smarthome-additional.log**, welches prinzipiell alle
+-  Das Logfile ``smarthome-additional.log``, welches prinzipiell alle
    Logmeldungen (von DEBUG bis CRITICAL) aufnimmt
 
 Die beiden Handler die Logfiles schreiben, sind als rotierende Handler
@@ -124,7 +124,7 @@ Um zusätzliche Logausgaben zu konfigurieren, muss nur der Abschnitt
 **logger:** der Logging Konfiguration angepasst/erweitert werden.
 
 Die meisten Plugins schreiben ihre Logausgaben in einen eigenen Logger,
-falls dieser in **logging.yaml** definiert ist. Die Logausgaben werden
+falls dieser in ``logging.yaml`` definiert ist. Die Logausgaben werden
 dann in diesen eigenen Logger und in den root-Logger geschrieben. Die
 Konfiguration des root-Loggers verhindert, das INFO und DEBUG ausgaben
 ins Hauptlog kommen.

--- a/doc/user/source/konfiguration/logiken.rst
+++ b/doc/user/source/konfiguration/logiken.rst
@@ -4,7 +4,7 @@
 Logiken
 =======
 
-Zur Konfiguration einer Logik wird in der Datei **../etc/logic.yaml** ein Abschnitt für die
+Zur Konfiguration einer Logik wird in der Datei ``etc/logic.yaml`` ein Abschnitt für die
 Logik angelegt. Unter dem Namen dieses Abschnitts wird die Logik an anderen Stellen referenziert.
 
 In diesem Abschnitt muss SmartHomeNG mitgeteilt werden, welche Code Datei ausgeführt werden soll

--- a/doc/user/source/konfiguration/module/module.rst
+++ b/doc/user/source/konfiguration/module/module.rst
@@ -22,7 +22,7 @@ möglich.
 .. note::
 
     Die Konfigurationsparameter der Module **http**, **websocket**, **admin** und **mqtt**, die in der
-    Datei **../etc/module.yaml** konfiguriert werden, können auch über das graphische Administrations-Interface
+    Datei ``etc/module.yaml`` konfiguriert werden, können auch über das graphische Administrations-Interface
     geändert werden.
 
 

--- a/doc/user/source/konfiguration/module/module_admin.rst
+++ b/doc/user/source/konfiguration/module/module_admin.rst
@@ -20,11 +20,11 @@ Konfiguration
 =============
 
 --------------------------
-Datei *../etc/module.yaml*
+Datei *etc/module.yaml*
 --------------------------
 
 .. code-block:: yaml
-   :caption: ../etc/module.yaml
+   :caption: etc/module.yaml
 
    # etc/module.yaml
    admin:

--- a/doc/user/source/konfiguration/module/module_http.rst
+++ b/doc/user/source/konfiguration/module/module_http.rst
@@ -25,17 +25,17 @@ bestimmte Features anzubieten.
 Anwendungen ermöglichen (z.B. ein REST Interface).
 
 
-.. index:: Konfigurationsdateien; /etc/module.yaml (http)
+.. index:: Konfigurationsdateien; etc/module.yaml (http)
 
 Konfiguration
 =============
 
---------------------------
-Datei *../etc/module.yaml*
---------------------------
+-----------------------
+Datei *etc/module.yaml*
+-----------------------
 
 .. code-block:: yaml
-   :caption: ../etc/module.yaml
+   :caption: etc/module.yaml
 
    # etc/module.yaml
    http:
@@ -115,10 +115,10 @@ Datei *../etc/module.yaml*
 |                         | installiert sein)                                                                                    |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | tls_cert                | **Optional**: Name der Zertifikatsdatei mit der Endung '.cer' oder '.pem'. Die Datei muss            |
-|                         | im Verzeichnis ../etc liegen                                                                         |
+|                         | im Verzeichnis ``etc`` liegen                                                                        |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | tls_key                 | **Optional**: Name der Datei mit dem privaten Schlüssel und der Endung '.key'. Die Datei muss        |
-|                         | im Verzeichnis ../etc liegen                                                                         |
+|                         | im Verzeichnis ``etc`` liegen                                                                        |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | serviceport             | **Optional**: Der Port auf welchem das html Interface lauscht. Dieser Port wird für den Zugriff      |
 |                         | auf Webservices genutzt, wie ihn z.B. das Plugin Webservices zur Verfügung stellt. Standard Port     |
@@ -149,7 +149,7 @@ Datei *../etc/module.yaml*
 | webif_pagelength        | **Optional**: Anzahl an Tabellenreihen, die in den Plugin Webinterfaces standardmäßig pro Seite      |
 |                         | angezeigt werden sollen. Bei **-1** werden alle Einträge auf einer Seite gezeigt, bei **0** (default)|
 |                         | so viele, dass sie genau auf die Seite ohne Scrolling passen. Weitere mögliche Werte sind 25, 50, 100|
-|                         | Der hier angegebene Wert kann pro Plugin im /etc/plugin.yaml File über den gleichnamigen Parameter   |
+|                         | Der hier angegebene Wert kann pro Plugin im ``etc/plugin.yaml``-File über den gleichnamigen Parameter|
 |                         | überschrieben werden.                                                                                |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 

--- a/doc/user/source/konfiguration/module/module_mqtt.rst
+++ b/doc/user/source/konfiguration/module/module_mqtt.rst
@@ -25,12 +25,12 @@ Projektes auch die Version MQTT v5.0 unterstützt, wird das SmartHomeNG Modul en
 Konfiguration
 =============
 
---------------------------
-Datei *../etc/module.yaml*
---------------------------
+-----------------------
+Datei *etc/module.yaml*
+-----------------------
 
 .. code-block:: yaml
-   :caption: ../etc/module.yaml
+   :caption: etc/module.yaml
 
    # etc/module.yaml
    mqtt:

--- a/doc/user/source/konfiguration/module/module_websocket.rst
+++ b/doc/user/source/konfiguration/module/module_websocket.rst
@@ -23,23 +23,17 @@ Varianten können parallel genutzt werden.
     Eine Alternative ist eine Client-Spezifische Konfiguration (cookie) in der Smartvisu.
 
 
-Anforderungen
-=============
-
-Dieses Modul läuft unter SmartHomeNG v1.8 und neuer und benötigt Python in der Version 3.6 oder neuer.
-
-
-.. index:: Konfigurationsdateien; /etc/module.yaml (websocket)
+.. index:: Konfigurationsdateien; etc/module.yaml (websocket)
 
 Konfiguration
 =============
 
---------------------------
-Datei *../etc/module.yaml*
---------------------------
+-----------------------
+Datei *etc/module.yaml*
+-----------------------
 
 .. code-block:: yaml
-   :caption: ../etc/module.yaml
+   :caption: etc/module.yaml
 
    # etc/module.yaml
    websocket:
@@ -81,10 +75,10 @@ Datei *../etc/module.yaml*
 |                         | Für die verschlüsselte Kommunikation müssen die Zertifikats- und Schlüssel-Datei konfiguriert sein.  |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | tls_cert                | **Optional**: Name der Zertifikatsdatei mit der Endung '.cer' oder '.pem'. Die Datei muss im         |
-|                         | Verzeichnis ../etc liegen. Dieser Parameter muss konfiguriert sein, damit eine verschlüsselte        |
+|                         | Verzeichnis ``etc`` liegen. Dieser Parameter muss konfiguriert sein, damit eine verschlüsselte       |
 |                         | Kommunikation möglich ist.                                                                           |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | tls_key                 | **Optional**: Name der Datei mit dem privaten Schlüssel und der Endung '.key'. Die Datei muss im     |
-|                         | Verzeichnis ../etc liegen. Dieser Parameter muss konfiguriert sein, damit eine verschlüsselte        |
+|                         | Verzeichnis ``etc`` liegen. Dieser Parameter muss konfiguriert sein, damit eine verschlüsselte       |
 |                         | Kommunikation möglich ist.                                                                           |
 +-------------------------+------------------------------------------------------------------------------------------------------+

--- a/doc/user/source/konfiguration/plugins.rst
+++ b/doc/user/source/konfiguration/plugins.rst
@@ -3,9 +3,9 @@ Plugins
 =======
 
 Das Grundsystem von SmartHomeNG kann durch den Einsatz von Plugins erweitert werden. Ein Plugin
-ist ein Zusatzmodul in einem Unterverzeichnis unterhalb des Verzeichnisses **../plugins**.
+ist ein Zusatzmodul in einem Unterverzeichnis unterhalb des Verzeichnisses ``plugins``.
 Um ein Plugin in SmartHomeNG zu verwenden (eine Instanz des Plugins zu laden) muss eine Sektion
-für das gewünschte Plugin in der Datei **etc/plugin.yaml** erstellt werden.
+für das gewünschte Plugin in der Datei ``etc/plugin.yaml`` erstellt werden.
 
 Für das oft benutzte KNX-Plugin sieht das z.B. so aus:
 
@@ -33,7 +33,7 @@ Es gibt folgende allgemeine Parameter im Abschnitt eines Plugins:
 | Parameter        | Bedeutung                                                                           |
 +==================+=====================================================================================+
 | plugin_name      | Der Kurzname des Plugins, das eingebunden werden soll (Name des Verzeichnisses      |
-|                  | im **../plugins** Verzeichnis). Statt des Parameters **plugin_name** konnten bisher |
+|                  | im ``../plugins`` Verzeichnis). Statt des Parameters **plugin_name** konnten bisher |
 |                  | auch die Parameter **class_name** und **class_path** angegeben werden.              |
 |                  |                                                                                     |
 |                  | **WICHTIG**: Bitte darauf achten, dass der Plugin Name Case-sensitive ist und der   |
@@ -64,7 +64,7 @@ Es gibt folgende allgemeine Parameter im Abschnitt eines Plugins:
 |                  | **avm_data_type: uptime** muss **avm_data_type@<instance>: uptime** geschrieben     |
 |                  | werden.                                                                             |
 |                  | Zukünftig wird bei mehrfacher Einbindung desselben Plugins der Bezeichner des       |
-|                  | Abschnitts in der **plugin.yaml** als Instanzbezeichner verwendet werden.           |
+|                  | Abschnitts in der ``plugin.yaml`` als Instanzbezeichner verwendet werden.           |
 +------------------+-------------------------------------------------------------------------------------+
 | default_instance | Optional: Kann zukünftig festlegen, welche Instanz von mehreren den leeren Instanz- |
 |                  | bezeichner erhält (für Item-Attribute ohne Instanzangabe)                           |
@@ -81,7 +81,7 @@ Es gibt folgende allgemeine Parameter im Abschnitt eines Plugins:
 .. note::
 
     Die zukünftigen Konfigurationsmöglichkeiten für Multiinstanz-Plugins können jetzt schon aktiviert
-    werden, wenn in der **etc/smarthome.yaml** der Eintrag **legacy_instances: false** angegeben wird.
+    werden, wenn in der ``etc/smarthome.yaml`` der Eintrag **legacy_instances: false** angegeben wird.
 
 
 Die weiteren Einträge sind Plugin spezifisch. Welche Parameter ein Plugin kennt ist auch der
@@ -104,7 +104,7 @@ beachten. Dann wird ein solches Plugin konfiguriert wie alle andern Plugins auch
 
 Wenn mehrere Instanzen eines Plugins konfiguriert werden, muss in der Konfiguration der Items
 eine Information hinterlegt werden, auf welche Instanz des Plugins sich das Item bezieht. Dazu
-**muss** jeder Instanz ein eindeutiger Name gegeben werden. Das erfolgt in der **../etc/plugin.yaml**
+**muss** jeder Instanz ein eindeutiger Name gegeben werden. Das erfolgt in der ``etc/plugin.yaml``
 dadurch, dass jeder Instanz ein Parameter **instance** hinzugefügt wird:
 
 .. code:: yaml

--- a/doc/user/source/konfiguration/plugins.rst
+++ b/doc/user/source/konfiguration/plugins.rst
@@ -73,7 +73,7 @@ Es gibt folgende allgemeine Parameter im Abschnitt eines Plugins:
 |                  | pro Seite angezeigt werden sollen. Bei **-1** werden alle Einträge auf einer Seite  |
 |                  | gezeigt, bei **0** so viele, dass sie genau auf die Seite ohne Scrolling passen.    |
 |                  | Weitere mögliche Werte sind 25, 50, 100. Der hier angegebene Wert überschreibt den  |
-|                  | für das **http Modul** im /etc/module.yaml File über den gleichnamigen Parameter    |
+|                  | für das **http Modul** im ``/etc/module.yaml`` File über den gleichnamigen Parameter|
 |                  | definierten globalen Wert.                                                          |
 +------------------+-------------------------------------------------------------------------------------+
 

--- a/doc/user/source/konfiguration/szenen.rst
+++ b/doc/user/source/konfiguration/szenen.rst
@@ -26,7 +26,7 @@ keine Unterstützung für die neueren Features.
 
 Die Nutzung der neuen Features ist unter :doc:`Konfiguation/Konfigurationsdateien/scenes/\*.yaml <./konfigurationsdateien/scenes>`
 beschrieben. Zu beachten ist, dass die Konfigurationsdateien für Szenen nur eingelesen werden, wenn ein Item **pfad.item**
-des Typs **scene** definiert ist und die Szenen-Datei **pfad.item.yaml** bzw. **pfad.item.conf** benannt ist.
+des Typs **scene** definiert ist und die Szenen-Datei ``pfad.item.yaml`` benannt ist.
 
 
 Funktionsweise von Szenen

--- a/doc/user/source/konfiguration/userfunctions.rst
+++ b/doc/user/source/konfiguration/userfunctions.rst
@@ -16,17 +16,17 @@ Ab Version 1.9 von SmartHomeNG ist die Möglichkeit implementiert, benutzerdefin
 schreiben und in eval Statements sowie in Logiken zu verwenden. Diese Funktionen können zur Laufzeit verändert und
 neu geladen werden.
 
-Die Python Dateien mit den Funktionen müssen dazu im Verzeichnis **../functions** abgelegt werden. Es sind normale
+Die Python Dateien mit den Funktionen müssen dazu im Verzeichnis ``etc/functions`` abgelegt werden. Es sind normale
 Python Dateien, die mehrere Funktionen enthalten können. Als formale Anforderung sind nur Informationen zur Version
 und eine kurze Beschreibung des Zwecks der Funktionen dieser Datei anzugeben.
 
-Im folgenden Beispiel wird eine Datei (Funktionssammlung) mit dem Namen **anhalter.py** im Verzeichnis **../functions**
+Im folgenden Beispiel wird eine Datei (Funktionssammlung) mit dem Namen ``anhalter.py`` im Verzeichnis ``etc/functions``
 erzeugt:
 
 Die Python Datei sieht folgendermaßen aus:
 
 .. code-block:: python
-   :caption: /usr/local/smarthome/functions/anhalter.py
+   :caption: etc/functions/anhalter.py
 
    #!/usr/bin/env python3
    # anhalter.py

--- a/doc/user/source/logiken/logics.rst
+++ b/doc/user/source/logiken/logics.rst
@@ -16,8 +16,8 @@ Logiken dienen dazu, komplexere Zustände und Abläufe zu steuern, die über Ite
 können. Logiken für SmartHomeNG sind Python Skripte. Zur Erstellung von Logiken müssen Sie über Kenntnisse
 der Programmiersprache Python verfügen.
 
-Die Logik-Skripte müssen im Verzeichnis **../logics** der SmartHomeNG Installation abgelegt werden. Damit die Logiken
-getriggert und ausgeführt werden, müssen sie zusätzlich in der Konfigurationsdatei **../etc/logic.yaml** konfiguriert
+Die Logik-Skripte müssen im Verzeichnis ``etc/logics`` der SmartHomeNG Installation abgelegt werden. Damit die Logiken
+getriggert und ausgeführt werden, müssen sie zusätzlich in der Konfigurationsdatei ``etc/logic.yaml`` konfiguriert
 werden.
 
 

--- a/doc/user/source/plugins_all.rst
+++ b/doc/user/source/plugins_all.rst
@@ -48,11 +48,11 @@ Die Plugins und die jeweiligen Beschreibungen sind auf den folgenden Seiten aufg
 
 
 Wenn ein Plugin Autor die Informationen auf diesen Seiten aktualisieren möchte, muss er nur
-die Metadaten Datei **plugin.yaml** in seinem Plugin aktualisieren. Beim nächsten Bau dieser
+die Metadaten Datei ``plugin.yaml`` in seinem Plugin aktualisieren. Beim nächsten Bau dieser
 Dokumentation werden dann diese aktualisierten Informationen automatisch mit aufgenommen.
 
 Wenn ein Plugin Autor eine Seite für sein Plugin links in die Navigation einklinken möchte, muss
-er nur eine Datei **user_doc.rst** in seinem Plugin Verzeichnis anlegen. Das Vorgehen ist in
+er nur eine Datei ``t`` in seinem Plugin Verzeichnis anlegen. Das Vorgehen ist in
 der Entwickler Dokumentation beschrieben.
 
 Informationen zur Erstellung eigener Plugins sind in der Entwickler Dokumentation zu finden.

--- a/doc/user/source/referenz/APIs.rst
+++ b/doc/user/source/referenz/APIs.rst
@@ -6,7 +6,7 @@ APIs von SmartHomeNG
 Es gibt einige APIs um auf die verschiedenen Objekte (oder Objekt Hierarchien) von SmartHomeNG zuzugreifen.
 Diese Programmier Interfaces können nützlich sein, wenn man Plugins oder auch Logiken entwickelt.
 
-Die APIs sind als Libraries implementiert und im Ordner ../lib gespeichert.
+Die APIs sind als Libraries implementiert und im Ordner ``lib`` gespeichert.
 Die Beschreibung ihrer Funktionalität ist hier beschrieben:
 
 

--- a/doc/user/source/referenz/items/attributes_relative_referenzen.rst
+++ b/doc/user/source/referenz/items/attributes_relative_referenzen.rst
@@ -41,7 +41,7 @@ Beispiele
 Die folgenden Beispiele beziehen sich auf diese Item Struktur:
 
 .. code-block:: yaml
-   :caption: ../items/\*.yaml
+   :caption: etc/items/\*.yaml
 
    item_tree:
        grandparent:
@@ -90,7 +90,7 @@ und zwar soll **my_item** den dreifachen Wert von **my_item.child** erhalten, so
 Attribute folgendermaßen aussehen:
 
 .. code-block:: yaml
-   :caption: ../items/\*.yaml
+   :caption: etc/items/\*.yaml
 
    my_item:
        eval: 3 * sh..child()
@@ -159,7 +159,7 @@ Im Attribut **sv_widget** des Plugins **visu_smartvisu** sind eine oder mehrere 
 enthalten.
 
 .. code-block:: yaml
-   :caption: ../items/\*.yaml
+   :caption: etc/items/\*.yaml
 
     schreibtischleuchte:
         sv_widget: {{ basic.switch('id_schreibtischleuchte', 'wohnung.buero.schreibtischleuchte.onoff') }}
@@ -177,7 +177,7 @@ Da im Beispiel oben ein absoluter Item-Pfad angegeben ist, passiert nichts. Wenn
 jedoch relativ wäre
 
 .. code-block:: yaml
-   :caption: ../items/\*.yaml
+   :caption: etc/items/\*.yaml
 
     schreibtischleuchte:
         sv_widget: {{ basic.switch('id_schreibtischleuchte', '.onoff') }}

--- a/doc/user/source/referenz/items/funktionen.rst
+++ b/doc/user/source/referenz/items/funktionen.rst
@@ -42,69 +42,7 @@ genutzt werden können.
 +--------------------------------+--------------------------------------------------------------------------------+
 
 
-
-Weiterhin werden die folgenden Funktionen unterstützt, die jedoch **ab SmartHomeNG v1.6** nicht mehr genutzt werden sollen.
-Bitte stattdessen die entsprechenden in SmartHomeNG v1.6 eingeführten :doc:`Properties </referenz/items/properties>` benutzen.
-
-+------------------------+------------------------------------------------------------------------------+
-| **Funktion**           | **Beschreibung**                                                             |
-+========================+==============================================================================+
-| id()                   | Liefert den item-Pfad des Items zurück. Aufruf: sh.item.id()                 |
-+------------------------+------------------------------------------------------------------------------+
-| ()                     | Liefert den aktuellen Wert des Items zurück. Aufruf: sh.item()               |
-+------------------------+------------------------------------------------------------------------------+
-| prev_value()           | Liefert den Wert des Items zurück, den es vor der letzten Änderung hatte.    |
-+------------------------+------------------------------------------------------------------------------+
-| last_update()          | Liefert ein *datetime* Objekt mit dem Zeitpunkt des letzten Updates des      |
-|                        | Items zurück. Im Gegensatz zu **last_change()** wird dieser Zeitstempel auch |
-|                        | verändert, wenn sich bei einem Update der Wert des Items nicht ändert.       |
-+------------------------+------------------------------------------------------------------------------+
-| prev_update()          | Liefert ein *datetime* Objekt mit dem Zeitpunkt des vorletzten Updates des   |
-|                        | Items zurück. Im Gegensatz zu **prev_change()** wird dieser Zeitstempel auch |
-|                        | verändert, wenn sich bei einem Update der Wert des Items nicht ändert.       |
-+------------------------+------------------------------------------------------------------------------+
-| last_change()          | Liefert ein *datetime* Objekt mit dem Zeitpunkt der letzten Änderung des     |
-|                        | Items zurück.                                                                |
-+------------------------+------------------------------------------------------------------------------+
-| prev_change()          | Liefert ein *datetime* Objekt mit dem Zeitpunkt der vorletzten Änderung des  |
-|                        | Items zurück.                                                                |
-+------------------------+------------------------------------------------------------------------------+
-| last_trigger()         | Liefert ein *datetime* Objekt mit dem Zeitpunkt der letzten eval Triggerung  |
-|                        | des Items zurück. Hat das Item kein eval Attribut oder wurde es nicht        |
-|                        | getriggert, wird der Zeitpunkt des letzten Updates übermittelt.              |
-|                        | (Neu **ab SmartHomeNG v1.9.1**)                                              |
-+------------------------+------------------------------------------------------------------------------+
-| prev_trigger()         | Liefert ein *datetime* Objekt mit dem Zeitpunkt der vorletzten eval          |
-|                        | Triggerung des Items zurück. (Neu **ab SmartHomeNG v1.9.1**)                 |
-+------------------------+------------------------------------------------------------------------------+
-| update_age()           | Liefert das Alter des Items seit dem letzten Update in Sekunden zurück. Das  |
-|                        | Update Age wird auch gesetzt, wenn sich bei einem Update der Wert des Items  |
-|                        | nicht ändert. (Neu **ab SmartHomeNG v1.4**)                                  |
-+------------------------+------------------------------------------------------------------------------+
-| prev_update_age()      | Liefert das Alter des vorangegangenen Updates in Sekunden zurück.            |
-+------------------------+------------------------------------------------------------------------------+
-| age()                  | Liefert das Alter des Items seit der letzten Änderung des Wertes in Sekunden |
-|                        | zurück.                                                                      |
-+------------------------+------------------------------------------------------------------------------+
-| prev_age()             | Liefert das Alter des vorangegangenen geänderten Wertes in Sekunden zurück.  |
-+------------------------+------------------------------------------------------------------------------+
-| trigger_age()          | Liefert das Alter der letzten Eval Triggerung in Sekunden zurück.            |
-|                        | (Neu **ab SmartHomeNG v1.9.1**)                                              |
-+------------------------+------------------------------------------------------------------------------+
-| prev_trigger_age()     | Liefert das Alter der vorletzten Eval Triggerung in Sekunden zurück.         |
-|                        | (Neu **ab SmartHomeNG v1.9.1**)                                              |
-+------------------------+------------------------------------------------------------------------------+
-| changed_by()           | Liefert einen String zurück, der auf das Objekt hinweist, welches das Item   |
-|                        | zuletzt geändert hat.                                                        |
-+------------------------+------------------------------------------------------------------------------+
-| updated_by()           | Liefert einen String zurück, der auf das Objekt hinweist, durch welches      |
-|                        | das Item zuletzt ein Update erfahren hat.                                    |
-+------------------------+------------------------------------------------------------------------------+
-| triggered_by()         | Liefert einen String zurück, der auf das Objekt hinweist, durch welches      |
-|                        | eine eventuell vorhandene eval Expression getriggert wurde.                  |
-|                        | (Neu **ab SmartHomeNG v1.9.1**)                                              |
-+------------------------+------------------------------------------------------------------------------+
-
+Weitere Funktionen sollten **nicht** mehr genutzt werden, dafür gibt es die :doc:`Properties </referenz/items/properties>`.
 
 
 Beispiele für die Nutzung von Funktionen

--- a/doc/user/source/referenz/items/plugin_attribute.rst
+++ b/doc/user/source/referenz/items/plugin_attribute.rst
@@ -49,7 +49,7 @@ oder die **hue_lamp_id**) nur an einer Stelle konfigurieren zu müssen.
 Das hue Plugin hat eine Vererbung der hue_lamp_id von übergeordneten Items im Plugin implementiert,
 indem das Plugin immer prüft, ob das Attribut in übergeordneten Items definiert wurde.
 
-Ab der Version 1.5 von SmartHomeNG gibt es einen Standardmechanismus der es möglich macht, selektiv
+Ein Standardmechanismus macht es möglich, selektiv
 den Wert aus einem übergeordneten Item zu erben. Dieser Mechanismus funktioniert **nur** bei
 plugin-spezifischen Attributen. Hierbei kann ein Attribut mit dem Wert eines Attributes eines
 übergeordneten Items belegt werden.
@@ -105,8 +105,8 @@ Start von SmartHomeNG kopiert wird. Im Backend wird in den Item Details des Chil
 .. index:: Zugriff auf Attribute anderer Items
 .. index:: Items; Zugriff auf Attribute anderer Items
 
-Zugriff auf Attribute anderer Items :bluesup:`update`
------------------------------------------------------
+Zugriff auf Attribute anderer Items
+-----------------------------------
 
 Der Zugriff auf Attribute anderer Items ist als Erweiterung der Vererbung von Attributen implementiert.
 Hierzu muss im aktuellen Item ein Attribut definiert werden, welches den Wert aufnimmt. Es ist hierbei
@@ -127,10 +127,10 @@ ein :code:`.` (für das aktuelle Item) angegeben (:code:`.:<Attribut>`).
 
 .. _Platzhalter_in_Attributwerten:
 
-Platzhalter in Attributwerten :redsup:`neu`
--------------------------------------------
+Platzhalter in Attributwerten
+-----------------------------
 
-Ab SmartHomeNG v1.10 ist es möglich in Attributwerten Platzhalter zu verwenden. Diese Platzhalter referenzieren
+In Attributwerten können Platzhalter verwendet werden. Diese Platzhalter referenzieren
 ein anderes Attribut und werden beim Start von SmartHomeNG durch den entsprechenden Wert ersetzt.
 
 Die Platzhalter sind Attribut-Referenzen, wie sie in den zwei vorangegangenen Abschnitten beschrieben wurden.
@@ -150,7 +150,7 @@ Platzhalter verwendet werden (:code:`name_: "Text {..:my_value}"`).
 Die Nutzung der Platzhalter wird am Beispiel der folgenden **structs** verdeutlicht:
 
 .. code-block:: yaml
-    :caption: ../etc/struct_knx.yaml
+    :caption: etc/structs/knx.yaml
 
     switch:
         _maingroup: 1
@@ -182,7 +182,7 @@ Die Nutzung der Platzhalter wird am Beispiel der folgenden **structs** verdeutli
 Wenn diese **structs** bei der Definition von Items folgendermaßen verwendet werden:
 
 .. code-block:: yaml
-    :caption: ../items/testitems.yaml
+    :caption: etc/items/testitems.yaml
 
     testitems:
 
@@ -230,7 +230,7 @@ Falls eine abweichende KNX Hauptgruppe verwendet wird, ist zusätzlich das Attri
 Hauptgruppe wird dann statt der in der struct definierten Hauptgruppe verwendet:
 
 .. code-block:: yaml
-    :caption: ../items/testitems.yaml
+    :caption: etc/items/testitems.yaml
 
     testitems:
 

--- a/doc/user/source/referenz/items/properties.rst
+++ b/doc/user/source/referenz/items/properties.rst
@@ -12,9 +12,7 @@ Jedes definierte Item bietet die folgenden Properties an, die unter anderem in *
 genutzt werden können. Alle Properties sind zumindest lesend (r/o) zugreifbar. Einige Properties können
 auch beschrieben (r/w) werden.
 
-Properties sind **ab SmartHomeNG v1.6** verfügbar.
-Die Properties ``last/prev_trigger(_by/_age)`` sind **ab SmartHomeNG v1.9.1** verfügbar.
-Die Property ``remark`` ist **ab SmartHomeNG v12** verfügbar.
+Die Property ``remark`` ist **ab SmartHomeNG v12.0** verfügbar.
 
 
 Properties werden in Logiken und eval-Ausdrücken folgendermaßen abgerufen:

--- a/doc/user/source/referenz/items/standard_attribute/autotimer.rst
+++ b/doc/user/source/referenz/items/standard_attribute/autotimer.rst
@@ -25,8 +25,7 @@ Das allgemeine Format für die Angabe des **autotimer** Attributes ist:
    myitem:
        autotimer: <Dauer> [; <Wert>]
 
-**Ab SmartHomeNG v1.10** sind die möglichen Angaben für die Dauer erweitert. Der Wert für **Dauer** kann auf folgende
-Weise angegeben werden:
+Weitere Möglichkeiten sind:
 
     - eine Zahl, die die Anzahl an Sekunden angibt
 
@@ -39,14 +38,10 @@ Der Wert für **Wert** ist optional. Falls er weg gelassen wird, wird nach Ablau
 
 Falls der Wert None ist, wird ebenfalls der zum Zeitpunkt des Triggers aktuelle Itemwert erneut gesetzt.
 
-Der Trenner (Delimiter) zwischen **Dauer** und **Wert** ist ab SmartHomeNG v1.10 standardmäßig ein Semikolon.
-Es kann jedoch auch der alte Delimiter (das Gleichheitszeichen) verwendet werden.
+Der Trenner (Delimiter) zwischen **Dauer** und **Wert** ist standardmäßig ein Semikolon.
+Aus Gründen der Rückwärtskompatibilität kann jedoch auch der alte Delimiter (das Gleichheitszeichen) verwendet werden.
 
-
-**Ab SmartHomeNG v1.11** werden die Konfigurationsmöglichkeiten erweitert: :redsup:`neu`
-
-
-Für **Dauer** und **Wert** können nun **eval** Ausdrücke angegeben werden, die zur Laufzeit entsprechend der Itemänderungen neu evaluiert werden.
+Für **Dauer** und **Wert** können auch **eval** Ausdrücke angegeben werden, die zur Laufzeit entsprechend der Itemänderungen neu evaluiert werden.
 Dabei können auch Item Properties genutzt werden.
 
 .. code-block:: yaml

--- a/doc/user/source/referenz/items/standard_attribute/crontab.rst
+++ b/doc/user/source/referenz/items/standard_attribute/crontab.rst
@@ -104,9 +104,7 @@ Admin Interface durch ``|`` getrennt werden.
 Durch Anhängen eines ``= value`` wird der entsprechende Wert ``value`` mitgesendet.
 Das Beispiel setzt den Wert des Items täglich um Mitternacht auf ``20``:
 
-**Ab SmartHomeNG v1.11** werden die Konfigurationsmöglichkeiten erweitert: :redsup:`neu`
-
-Für den **Wert** kann nun ein **eval** Ausdruck angegeben werden, der zur Laufzeit entsprechend neu evaluiert wird.
+Für den **Wert** kann auch ein **eval** Ausdruck angegeben werden, der zur Laufzeit entsprechend neu evaluiert wird.
 Dabei können auch Item Properties genutzt werden.
 
 .. code-block:: yaml

--- a/doc/user/source/referenz/items/standard_attribute/cycle.rst
+++ b/doc/user/source/referenz/items/standard_attribute/cycle.rst
@@ -44,12 +44,9 @@ Der Wert für **Wert** ist optional.
   Wenn die Angabe des Wertes weg gelassen wird, wird als zu setzender Wert der Wert angenommen, den das Item zum
   Zeitpunkt der auslösenden Wertänderung hat.
 
-Der Trenner (Delimiter) zwischen **Dauer** und **Wert** ist ab SmartHomeNG v1.10 standardmäßig ein Semikolon.
-Es kann jedoch auch der alte Delimiter (das Gleichheitszeichen) verwendet werden.
+Der Trenner (Delimiter) zwischen **Dauer** und **Wert** ist standardmäßig ein Semikolon. Aus Gründen der Rückwärtskompatibilität kann jedoch auch der alte Delimiter (das Gleichheitszeichen) verwendet werden.
 
-**Ab SmartHomeNG v1.11** werden die Konfigurationsmöglichkeiten erweitert:
-
-Für **Dauer** und **Wert** können nun **eval** Ausdrücke angegeben werden, die zur Laufzeit entsprechend der Itemänderungen neu evaluiert werden.
+Für **Dauer** und **Wert** können auch **eval** Ausdrücke angegeben werden, die zur Laufzeit entsprechend der Itemänderungen neu evaluiert werden.
 Dabei können auch Item Properties genutzt werden.
 
 .. hint:

--- a/doc/user/source/referenz/items/standard_attribute/enforce_updates.rst
+++ b/doc/user/source/referenz/items/standard_attribute/enforce_updates.rst
@@ -17,7 +17,7 @@ Wenn sich der Wert eines Items ändert, löst das eine Reihe von Aktionen aus:
     - *eval* Statements in anderen Items werden getriggert, wenn in anderen in den Items ein *eval_trigger* auf das geänderte Item verweist.
     - *on_change* Definitionen des Items werden ausgewertet
     - *on_update* Definitionen des Items werden ausgewertet
-    - Logiken werden getriggert, wenn der Trigger der Logik (in ../etc/logic.yaml) auf das geänderte Item verweist.
+    - Logiken werden getriggert, wenn der Trigger der Logik (in ``etc/logic.yaml``) auf das geänderte Item verweist.
     - Plugins, die mit diesem Item verbunden sind, erhalten eine Info über den neuen Wert
 
 

--- a/doc/user/source/referenz/items/standard_attribute/log_change.rst
+++ b/doc/user/source/referenz/items/standard_attribute/log_change.rst
@@ -14,7 +14,7 @@ Attribut *log_change*
 =====================
 
 Ab SmartHomeNG v1.5 ermöglicht das Attribut **log_change** das Loggen jeder Veränderung des Item-Wertes. **log_change**
-muss dazu den Namen des zu verwendeten Loggers enthalten. In **../etc/logging.yaml** muss der Logger als
+muss dazu den Namen des zu verwendeten Loggers enthalten. In ``etc/logging.yaml`` muss der Logger als
 **items.<Name>** konfiguriert sein. Wertänderungen des Items werden dann mit dem Level **INFO** geloggt.
 
 Ab **SmartHomeNG v1.9** kann das Item Logging über die Attribute **log_level** und **log_text** an die eigenen
@@ -33,7 +33,7 @@ ERROR, CRITICAL). Die Angabe kann durch den Namen oder den Integer Wert des Logl
 eval-Ausduck in log_level
 --------------------------
 
-Ab **SmarthomeNG v1.10.1** ist es möglich, das Loglevel variabel mittels Eval-Ausdruck festzulegen. Es wird dadurch
+Das Loglevel kann variabel mittels Eval-Ausdruck festgelegt werden. Es wird dadurch
 vor dem Schreiben eines jeden Logging-Eintrags neu evaluiert.
 
 **Beispiel:** ``log_level: '{10 if value == 5 else "WARNING" if value == 1 else "INFO"}'``
@@ -184,7 +184,7 @@ highlimit weitere Werte zulassen würden bzw. exclude einen der Werte ausschlie�
 
 .. hint::
 
-    Sämtliche Werte in den log_rules können ab SmartHomeNG 1.10 auch in Items hinterlegt werden.
+    Sämtliche Werte in den log_rules können auch in Items hinterlegt werden.
     Der Verweis auf das jeweilige Item erfolgt dabei durch den absoluten oder relativen Itempfad als String (ohne sh.).
 
 lowlimit

--- a/doc/user/source/referenz/items/standard_attribute/on_update.rst
+++ b/doc/user/source/referenz/items/standard_attribute/on_update.rst
@@ -14,7 +14,7 @@ Attribut *on_update*
 Ermöglicht das Setzen des Wertes anderer Items, wenn das aktuelle Item ein Update erhält
 (auch wenn sich der Wert des aktuellen Items dabei nicht ändert und enforce_updates nicht aktiviert ist).
 Das ist der Unterschied zu **on_change**, welches nur ausgelöst
-wird wenn sich bei einem Update der Wert des Items auch ändert oder **enforce_updates** aktiviert ist. **Seit SmartHomeNG v1.4**
+wird wenn sich bei einem Update der Wert des Items auch ändert oder **enforce_updates** aktiviert ist. 
 
 Die Syntax ist wie folgt:
 
@@ -44,7 +44,7 @@ Die Syntax ist wie folgt:
   Wert des Items zugegriffen werden soll, geht das mit der Item-Methode **prev_value()** oder dem
   Item Property **property.last_value**. Um das Item selbst zu adressieren kann am einfachsten
   die relative Adressierung mittels **sh..self.prev_value()** eingesetzt werden.
-- Zusätzlich zur Spezialvariable **value** werden ab SmartHomeNG 1.11 die Spazialvariablen **caller**, **source**
+- Zusätzlich zur Spezialvariable **value** werden die Spazialvariablen **caller**, **source**
   und **dest** unterstützt, um Wertzuweisungen in Abhängigkeit von dem auslösenden Item zu ermöglichen
 
 .. attention::
@@ -65,7 +65,7 @@ Die Syntax ist wie folgt:
 Beispiel:
 
 .. code-block:: yaml
-   :caption: ../items/<filename>.yaml (Ausschnitt)
+   :caption: etc/items/<filename>.yaml (Ausschnitt)
 
    itemA1:
        # eine einzelne Zuweisung
@@ -91,7 +91,7 @@ Attribut *on_change*
 
 Ermöglicht das Setzen des Wertes anderer Items, wenn der Wert des aktuellen Items verändert wird.
 Im Gegensatz zu **on_update** wird **on_change** nur ausgelöst, wenn sich beim Update
-eines Items der Wert auch ändert oder **enforce_updates** aktiviert ist. **Seit SmartHomeNG v1.4**
+eines Items der Wert auch ändert oder **enforce_updates** aktiviert ist.
 
 Der Syntax ist äquivalent zum Attribut **on_update**.
 

--- a/doc/user/source/referenz/items/standard_attribute/standard_attribute.rst
+++ b/doc/user/source/referenz/items/standard_attribute/standard_attribute.rst
@@ -96,16 +96,16 @@ plugin-spezifischen Attribute ist in der Dokumentation des jeweiligen Plugins na
 |                            | (Also folgendermaßen: ``initial_value: "{'k1': 'v1', 'k2': 'v2'}"`` )                  |
 +----------------------------+----------------------------------------------------------------------------------------+
 | log_change                 | Ermöglicht das Loggen jeder Veränderung des Item-Wertes. **log_change** muss dazu den  |
-|                            | Namen des zu verwendeten Loggers enthalten. In **logging.yaml** muss der Logger als    |
+|                            | Namen des zu verwendeten Loggers enthalten. In ``logging.yaml`` muss der Logger als    |
 |                            | **items.<Name>** konfiguriert sein. Wertänderungen des Items werden dann mit dem Level |
-|                            | **INFO** geloggt. (siehe :doc:`log_change <./log_change>`) **Ab SmartHomeNG v1.5**     |
+|                            | **INFO** geloggt. (siehe :doc:`log_change <./log_change>`)                             |
 +----------------------------+----------------------------------------------------------------------------------------+
 | log_level                  | Ermöglicht es einen anderen Loglevel für log_change festzulegen. Der angegebene        |
 |                            | Log_level kann jeder in SmartHomeNG unterstützte Python Loglevel sein. Die Angabe kann |
-|                            | durch den Namen oder den Integer Wert des Loglevels erfolgen. **Ab SmartHomeNG v1.9**  |
+|                            | durch den Namen oder den Integer Wert des Loglevels erfolgen.                          |
 +----------------------------+----------------------------------------------------------------------------------------+
 | log_text                   | Ermöglicht es einen eigenen Text für den Logeintrag festzulegen. **log_text** kann     |
-|                            | dabei eine Reihe von Variablen und eval-Ausdrücken enthalten. **Ab SmartHomeNG v1.9**  |
+|                            | dabei eine Reihe von Variablen und eval-Ausdrücken enthalten.                          |
 |                            | Unterstützt werden folgende Variablen: value, caller, source, dest, id, name, age,     |
 |                            | mvalue, lvalue, mlvalue, pid, pname, lowlimit, highlimit                               |
 |                            |                                                                                        |
@@ -115,10 +115,10 @@ plugin-spezifischen Attribute ist in der Dokumentation des jeweiligen Plugins na
 |                            | ``log_text: 'Alter={age}'``                                                            |
 +----------------------------+----------------------------------------------------------------------------------------+
 | log_mapping                | Ermöglicht es im Text ein Mapping von **value** auf einen anderen Wert auszugeben      |
-|                            | (siehe :doc:`log_change <./log_change>`). **Ab SmartHomeNG v1.9**                      |
+|                            | (siehe :doc:`log_change <./log_change>`).                                              |
 +----------------------------+----------------------------------------------------------------------------------------+
 | log_rules                  | Ermöglicht es Regeln zum log_change zu definieren                                      |
-|                            | (siehe :doc:`log_change <./log_change>`).  **Ab SmartHomeNG v1.9**                     |
+|                            | (siehe :doc:`log_change <./log_change>`).                                              |
 +----------------------------+----------------------------------------------------------------------------------------+
 | name                       | ein optionaler Name für das Item                                                       |
 +----------------------------+----------------------------------------------------------------------------------------+
@@ -139,7 +139,7 @@ plugin-spezifischen Attribute ist in der Dokumentation des jeweiligen Plugins na
 |                            | eines einzelnen Items in den Item-Tree eingefügt werden. **struct** kann ein           |
 |                            | String oder eine Liste von Strings sein. Wenn eine Liste angegeben wird,               |
 |                            | werden die Template Strukturen in der Reihenfolge angewendet, in der sie in            |
-|                            | der Liste angegeben wurden. **Ab SmartHomeNG v1.6**                                    |
+|                            | der Liste angegeben wurden.                                                            |
 +----------------------------+----------------------------------------------------------------------------------------+
 | threshold                  | legt einen Schwellwert oder einen Schwellwertbereich fest. Wenn der Wert               |
 |                            | diesen Wert über- bzw. unterschreitet oder der Wert Bereich verlässt oder              |

--- a/doc/user/source/referenz/items/standard_attribute/type.rst
+++ b/doc/user/source/referenz/items/standard_attribute/type.rst
@@ -33,7 +33,7 @@ Folgende mögliche Datentypen sind für Items definiert:
 |          | aufnehmen                                                                            |
 +----------+--------------------------------------------------------------------------------------+
 | scene    | Eine Szene - Die eigentliche Konfiguration der Szene für das jeweilige Item wird in  |
-|          | einer eigenen Datei im Verzeichnis **../scenes** von SmartHomeNG gespeichert. Dort   |
+|          | einer eigenen Datei im Verzeichnis ``etc/scenes`` von SmartHomeNG gespeichert. Dort  |
 |          | muss es für jede Szene (jedes Item vom Typ *scene* eine eigene Konfigurationsdatei   |
 |          | mit dem Namen des Item-Pfades geben. Genaueres ist dem Abschnitt                     |
 |          | **Konfiguration / Szenen** dieser Dokumentation zu entnehmen.                        |

--- a/doc/user/source/referenz/logging/logging_filter.rst
+++ b/doc/user/source/referenz/logging/logging_filter.rst
@@ -27,7 +27,7 @@ genutzt werden, den das http Modul mitbringt.
 Benutzung des Filters
 ---------------------
 
-In der Datei ``../etc/logging.yaml`` wird der **CherryPyFilter** im Abschnitt ``filters:`` zur Nutzung
+In der Datei ``etc/logging.yaml`` wird der **CherryPyFilter** im Abschnitt ``filters:`` zur Nutzung
 konfiguriert.
 
 .. code-block:: yaml
@@ -64,7 +64,7 @@ und nur den ersten Log Eintrag wirklich in das Log zu schreiben. Diese Aufgabe e
 Benutzung des Filters
 ---------------------
 
-In der Datei ``../etc/logging.yaml`` wird der **DuplicateFilter** im Abschnitt ``filters:`` zur Nutzung
+In der Datei ``etc/logging.yaml`` wird der **DuplicateFilter** im Abschnitt ``filters:`` zur Nutzung
 konfiguriert.
 
 .. code-block:: yaml
@@ -94,7 +94,7 @@ Bis auf **invert** können alle Parameter Listen von Regular Expressions sein.
 Benutzung des Filters
 ---------------------
 
-In der Datei ``../etc/logging.yaml`` wird der **Filter** im Abschnitt ``filters:`` zur Nutzung
+In der Datei ``etc/logging.yaml`` wird der **Filter** im Abschnitt ``filters:`` zur Nutzung
 konfiguriert. Dabei ist die erste Zeile `(): lib.logutils.Filter` zwingend anzugeben,
 außerdem zumindest eine der darauffolgenden Zeilen (module, msg, timestamp). Die Angaben
 sind dabei als reguläre Ausdrücke anzugeben und können sogar in Listenform erfolgen.

--- a/doc/user/source/referenz/logging/logging_formatter.rst
+++ b/doc/user/source/referenz/logging/logging_formatter.rst
@@ -6,15 +6,15 @@
 .. role:: redsup
 
 
-===================================
-Logging Formatter :bluesup:`Update`
-===================================
+=================
+Logging Formatter
+=================
 
 Mit **Logging Formattern** wird festgelegt, wie die Informationen aufbereitet werden sollen, wenn sie in ein
 Log geschrieben werden.
 
 Der standardmäßig in SmartHomeNG verwendete Logger ist **shng_simple** und in der Konfigurationsdatei
-``../etc/logging.yaml`` definiert. Dieser Logger sollte für das Warnings-Log (und möglichst auch für die weitern
+``etc/logging.yaml`` definiert. Dieser Logger sollte für das Warnings-Log (und möglichst auch für die weitern
 Logs) verwendet werden. Er bietet einen guten Kompromiss zwischen Übersichtlichkeit/Lesbarkeit und Detailreichtum.
 Die Ausgaben mit diesem Formatter helfen besonders bei Supportanfragen.
 

--- a/doc/user/source/referenz/logging/logging_handler.rst
+++ b/doc/user/source/referenz/logging/logging_handler.rst
@@ -11,7 +11,7 @@ Logging Handler
 ===============
 
 Zusätzlich zu den Logging Handlern, die im Standard Logging Modul von Python definiert, bringt SmartHomeNG
-weitere Handler mit, die bei der Konfiguration in ../etc/logging.yaml verwendet werden können.
+weitere Handler mit, die bei der Konfiguration in ``etc/logging.yaml`` verwendet werden können.
 
 |
 
@@ -38,7 +38,7 @@ in der GUI eines Betriebssystems geöffnet werden.
 Benutzung des Handlers
 ----------------------
 
-In der Datei ``../etc/logging.yaml`` wird der Handler als Ersatz für **TimedRotatingFileHandler** eingesetzt.
+In der Datei ``etc/logging.yaml`` wird der Handler als Ersatz für **TimedRotatingFileHandler** eingesetzt.
 Dort wo im Abschnitt ``handler:`` bisher der Handler **TimedRotatingFileHandler** konfiguriert ist:
 
 .. code-block:: yaml
@@ -163,7 +163,7 @@ und der Handler wird in den konfigurierten Loggern als (zusätzlicher) Logger ko
 Benutzung des Handlers
 ----------------------
 
-In der Datei ``../etc/logging.yaml`` wird der **ShngMemLogHandler** im Abschnitt ``handler:`` konfiguriert.
+In der Datei ``etc/logging.yaml`` wird der **ShngMemLogHandler** im Abschnitt ``handler:`` konfiguriert.
 
 .. code-block:: yaml
 

--- a/doc/user/source/referenz/logiken/logiken_funktionen.rst
+++ b/doc/user/source/referenz/logiken/logiken_funktionen.rst
@@ -12,37 +12,11 @@ Funktionen und Klassen in Logiken
 Funktionen in Logiken
 =====================
 
-Bei der Nutzung von Funktionen in Logiken ist eine Besonderheit zu beachten: Eine Logik verhält sich nicht
-wie ein Python Modul!
-
-.. note::
-
-    **Bis zu SmartHomeNG v1.9.2 gilt:**
-
-    Eine Logik verhält sich nicht wie ein Python Modul! Variablen und Funktionen die auf Ebene der Logik definiert
-    werden, sind keine globalen Objekte. Sie stehen in Funktionen die innerhalb der Logik definiert werden nicht
-    zur Verfügung. Daher müssen Variablen und Funktionen die innerhalb von Funktionen genutzt werden, der Funktion
-    explizit bekannt gemacht werden.
-
-    Sollen in der Logik weitere Python Module genutzt werden, so muss der import der Moduls innerhalb der Funktion
-    erfolgen, die eine Funktion aus dem zu importierenden Python Modul nutzt.
-
-.. important::
-
-    **Ab dem nachfolgenden Release v1.9.3 wurde ein global Environment für Logiken eingeführt**
-
-    Ab diesem Release stehen Variablen, die in der Hauptroutine der Logik definiert wurden auch in Funktionen
-    innerhalb der Logik zur Verfügung. Das gleiche gilt für Module, die in der Hauptroutine der Logik importiert
-    wurden.
-
-    Daher ist es auch nicht mehr notwendig, das logic Objekt als Parameter an die Funktionen innerhalb einer
-    Logik zu übergeben.
-
-Dafür müssen Funktionen und Variablen der Funktion als Parameter übergeben werden. Das kann geschehen, indem die
+Funktionen und Variablen müssen der Funktion als Parameter übergeben werden. Das kann geschehen, indem die
 Übergabe für jede Variable/Funktion einzeln erfolgt oder sie können in einem Objekt übergeben werden (was die zu
 bevorzugende Methode ist.
 
-Dazu kann das Objekt **logic** genutzt werden, welches SmartHomeNG zur Verfüfung stellt um Variablen zu implementieren,
+Dazu kann das Objekt **logic** genutzt werden, welches SmartHomeNG zur Verfüfung stellt, um Variablen zu implementieren,
 die den Lauf der Logik "überleben" und beim nächsten Lauf dieser Logik wieder zur Verfügung stehen. Das **logic**
 Objekt ist privat. Das bedeutet, jede Logik hat ihr eigenes **logic** Objekt.
 
@@ -52,40 +26,6 @@ kann der Wert auch gleich als Standard-Wert in der Funktionsdefinition mit angeg
 Aufrufen der Funktion nicht angegeben zu werden.
 
 Das folgende Beispiel verdeutlicht das Vorgehen:
-
-bis SmartHomeNG v1.9.2
-----------------------
-
-.. code-block:: python
-
-    # Variablen, die in Funktionen genutzt werden sollen, müssen dem logic Objekt zugewiesen werden
-    logic.sh = sh
-    logic.myvar1 = 5
-    logic.myvar2 = False
-
-    # Funktionen definieren und anschließend dem logic Objekt zuweisen
-    def func1(wert, logic=logic):
-        logic.logger.warning("Funktion 1: wert = {}".format(wert))
-    logic.func1 = func1
-
-    def func2(logic=logic):
-        logic.logger.warning("Funktion 2")
-        logic.func1(2)
-    logic.func2 = func2
-
-
-    # Main Routine der Logik
-    logic.func1(1)
-    logic.func2()
-
-Um aus Funktionen heraus auf das **sh** Objekt zugreifen zu können, sollte auch dieses (wie im obigen Beispiel) als
-Variable im **logic** Objekt abgelegt werden.
-
-ab SmartHomeNG v1.9.3
----------------------
-
-In neueren Versionen von SmartHomeNG kann der Syntax deutlich vereinfacht werden. Der alte Syntax ist jedoch weiterhin
-gültig.
 
 .. code-block:: python
 
@@ -112,48 +52,6 @@ Klassen in Logiken
 
 In Logiken können auch Klassen definiert werden. Damit diese Klassen in Funktionen zur Verfügung stehen,
 muss auch hier (wie bei Funktionen) die Klasse dem Logik Objekt zugewiesen werden (letzte Zeile im folgenden Beispiel):
-
-bis SmartHomeNG v1.9.2
-----------------------
-
-.. code-block:: python
-
-    class triggervalue():
-
-        def __init__(self, init_value=None, trigger_item=None, logic=None):
-            self.trigger_item = trigger_item
-            self.value = init_value
-            self.changed = False
-            self._last_value = init_value
-            if self.trigger_item is not None:
-                self.value = logic.items.return_item(trigger_item)()
-                self.changed = (logic.trigger_dict['source'] == trigger_item)
-                self._last_value = None
-
-        def set(self, newvalue):
-            if self.trigger_item is None:
-                self._last_value = self.value
-                self.value = newvalue
-                self.changed = self.value != self._last_value
-                return self.changed
-            return self.changed
-    logic.triggervalue = triggervalue
-
-Wenn in einer Klasse auf Elemente des **logic** Objektes zugegriffen werden soll (wie in dem obigen Beispiel),
-muss **logic** beim Erstellen einer Instanz mit übergeben werden:
-
-.. code-block:: python
-
-        logic.freigabe_sued = logic.triggervalue(trigger_item='beschattung.beschattungsautomatik.sued', logic=logic)
-
-
-
-
-ab SmartHomeNG v1.9.3
----------------------
-
-In neueren Versionen von SmartHomeNG kann der Syntax vereinfacht werden. Der alte Syntax ist jedoch weiterhin
-gültig.
 
 .. code-block:: python
 

--- a/doc/user/source/referenz/logiken/logiken_grundstruktur.rst
+++ b/doc/user/source/referenz/logiken/logiken_grundstruktur.rst
@@ -15,11 +15,11 @@ Eine Logik besteht aus einem Python Skript sowie einer Reihe von Parametern die 
 steuern. Eine Logik kan während der Laufzeit von SmartHomeNG geladen und entladen werden. Dadurch sind Veränderungen
 ein einer Logik möglich, ohne SmartHomeNG neu starten zu müssen.
 
-Das eigentliche Python Skript einer Logik muss im Verzeichnis ``../logics`` der SmartHomeNG Installation abgelegt
+Das eigentliche Python Skript einer Logik muss im Verzeichnis ``etc/logics`` der SmartHomeNG Installation abgelegt
 werden. Damit die Logik getriggert und ausgeführt wird, muss sie zusätzlich in der Konfigurationsdatei
-``../etc/logic.yaml`` konfiguriert werden.
+``etc/logic.yaml`` konfiguriert werden.
 
-Zur Erstellung einer neuen Logik sollte die Template Datei ``logics/logic.tpl`` als Vorlage genutzt werden.
+Zur Erstellung einer neuen Logik sollte die Template Datei ``templates/logic.tpl`` als Vorlage genutzt werden.
 
 Die einfachste Methode zu Erstellung einer neuen Logik stellt die Verwendung der Admin GUI dar. Dort kann sowohl
 das Skript erstellt werden, as auch die Parameter zur Konfiguration erfasst werden. Die Admin GUI ermöglicht auch

--- a/doc/user/source/referenz/logiken/logiken_items.rst
+++ b/doc/user/source/referenz/logiken/logiken_items.rst
@@ -42,7 +42,7 @@ Beispiel
 Eine Logik sieht prinzipiell folgendermaßen aus:
 
 .. code-block:: python
-   :caption: /usr/local/smarthome/logics/testlogik1.py
+   :caption: etc/logics/testlogik1.py
 
    #!/usr/bin/env python3
    # testlogik1.py

--- a/doc/user/source/referenz/logiken/logiken_konfiguration.rst
+++ b/doc/user/source/referenz/logiken/logiken_konfiguration.rst
@@ -10,7 +10,7 @@
 Logik Konfiguration
 ===================
 
-Zur Konfiguration einer Logik wird in der Datei **../etc/logic.yaml** ein Abschnitt für die
+Zur Konfiguration einer Logik wird in der Datei ``etc/logic.yaml`` ein Abschnitt für die
 Logik angelegt. Unter dem Namen dieses Abschnitts wird die Logik an anderen Stellen referenziert.
 
 In diesem Abschnitt muss SmartHomeNG mitgeteilt werden, welche Code Datei ausgeführt werden soll

--- a/doc/user/source/referenz/logiken/logiken_logic_objekt.rst
+++ b/doc/user/source/referenz/logiken/logiken_logic_objekt.rst
@@ -11,7 +11,7 @@ Die Objekte **logic** und **logics**
 .. index:: logic Objekt; Logiken
 .. index:: Logiken; logic Objekt
 
-Das ``logic`` Objekt
+Das **logic** Objekt
 ====================
 
 Dieses Objekt bietet Zugriff auf das aktuelle Logikobjekt. Es ist möglich, während der Laufzeit die meisten
@@ -26,7 +26,7 @@ Definierte Methoden des Logikobjekts:
 +----------------------+--------------------------------------------------------------------------------------------------------+
 | Methode              | Erläuterung                                                                                            |
 +======================+========================================================================================================+
-| ``logic.id()``       | Diese Methode liefert dem Namen der Logik wie in **../etc/logic.yaml** angegeben.                      |
+| ``logic.id()``       | Diese Methode liefert dem Namen der Logik wie in ``etc/logic.yaml`` angegeben.                         |
 +----------------------+--------------------------------------------------------------------------------------------------------+
 | ``logic.last_run()`` | Diese Methode liefert den letzten Lauf dieser Logik (vor aktuellen Lauf).                              |
 +----------------------+--------------------------------------------------------------------------------------------------------+
@@ -64,10 +64,10 @@ der Logik getriggert wurde.
 .. index:: trigger dict; Logiken
 .. index:: Logiken; trigger dict
 
-Das ``trigger`` Dictionary
+Das **trigger** Dictionary
 --------------------------
 
-Das ``trigger`` dict ist ein Python-Dictionary, welches als Laufzeitumgebung einige Informationen über das
+Das **trigger** dict ist ein Python-Dictionary, welches als Laufzeitumgebung einige Informationen über das
 Ereignis liefert, das die Logik ausgelöst hat.
 
 Das Dictionary enthält folgende Informationen:
@@ -94,7 +94,7 @@ Das Dictionary enthält folgende Informationen:
 .. index:: logics Objekt; Logiken
 .. index:: Logiken; logics Objekt
 
-Das ``logics`` Objekt
+Das **logics** Objekt
 =====================
 
 Zugriff auf das Logics-API über das logics Objekt:
@@ -115,7 +115,7 @@ Zugriff auf das Logics-API über das logics Objekt:
 +---------------------------------+---------------------------------------------------------------------------------------------------------+
 | logics.trigger()                | Triggern einer im Logik                                                                                 |
 +---------------------------------+---------------------------------------------------------------------------------------------------------+
-| logics.set_config_section_key() | Setzt den Wert eines Schlüssels für eine angegebene Logik (Abschnitt) permanent in ../etc/logic.yaml    |
+| logics.set_config_section_key() | Setzt den Wert eines Schlüssels für eine angegebene Logik (Abschnitt) permanent in etc/logic.yaml       |
 +---------------------------------+---------------------------------------------------------------------------------------------------------+
 
 Der vollständige Syntax der Methoden kann im Abschnitt :doc:`Entwicklung/APIs von SmartHomeNG </referenz/APIs>`

--- a/doc/user/source/referenz/logiken/logiken_persistente_vars.rst
+++ b/doc/user/source/referenz/logiken/logiken_persistente_vars.rst
@@ -39,7 +39,7 @@ SmartHomeNG gehen die gespeicherten Werte verloren.
 Einrichtung
 ===========
 
-Normale Variablen sind lokal zum Lauf der der Logik. Eine Variable **myvar** die während eines
+Normale Variablen sind lokal zum Lauf der der Logik. Eine Variable ``myvar`` die während eines
 Laufes der Logik einen Wert zugewiesen bekommt, ist beim Beginn des nächsten Laufes nicht
 definiert.
 
@@ -57,7 +57,7 @@ muss die Variable folgendermaßen definiert werden:
    logic.myvar = 'my Value'
 
 
-Die Variable **logic.myvar** übersteht die Zeit bis zum nächsten Lauf der Logik und sie steht
+Die Variable ``logic.myvar`` übersteht die Zeit bis zum nächsten Lauf der Logik und sie steht
 nur in der Logik zur Verfügung, die sie auch definiert hat.
 
 
@@ -68,7 +68,7 @@ Wenn auf eine Variable zugegriffen wird bevor sie definiert wird, führt das zu 
 und der Rest der Logik wird nicht ausgeführt. Beim ersten Lauf einer Logik nach einem Neustart
 von SmartHomeNG existiert jedoch keine Variable aus vorangegangenen Läufen. Sie muss erstmal
 definiert werden. Das kann zum Beispiel in der folgenden Form erfolgen, in der die Variable
-**logic.myvar** mit dem Wert **None** initialisiert wird, falls sie nicht existiert
+``logic.myvar`` mit dem Wert **None** initialisiert wird, falls sie nicht existiert
 
 .. code-block:: python
    :caption: Sicherstellen, dass die Variable existiert
@@ -80,7 +80,7 @@ definiert werden. Das kann zum Beispiel in der folgenden Form erfolgen, in der d
 Nutzung selbst definierter Parameter
 ====================================
 
-Es ist möglich eigene Parameter in der Datei **../etc/logic.yaml** zu definieren. Diese Parameter
+Es ist möglich eigene Parameter in der Datei ``etc/logic.yaml`` zu definieren. Diese Parameter
 stehen in der Logik unter **logic.<Parameter>** zur Verfügung. Diese Parameter können als
 eine bereits initialisierte Variable verstanden/genutzt werden. Sie können in der Logik nicht
 nur gelesen, sondern auch verändert werden. Diese Änderung geht wie beschrieben bei einem

--- a/doc/user/source/referenz/logiken/logiken_standardparameter.rst
+++ b/doc/user/source/referenz/logiken/logiken_standardparameter.rst
@@ -6,12 +6,12 @@
 Standardparameter
 =================
 
-Die folgenden Parameter können für eine Logik in der Konfigurationsdatei im Verzeichnis ../etc angegeben werden.
+Die folgenden Parameter können für eine Logik in der Konfigurationsdatei im Verzeichnis ``etc`` angegeben werden.
 
 +------------------+-----------------------------------------------------------------------------------------------+
 | **Parameter**    | **Beschreibung**                                                                              |
 +==================+===============================================================================================+
-| filename         | Dateiname des Logik-Codes. Diese Datei muss im Verzeichnis **../logics**  liegen. Dieser      |
+| filename         | Dateiname des Logik-Codes. Diese Datei muss im Verzeichnis ``etc/logics``  liegen. Dieser     |
 |                  | Parameter muss angegeben werden.                                                              |
 +------------------+-----------------------------------------------------------------------------------------------+
 | logic_groupname  | **Optional**: Logiken können mit diesem Parameter einer oder mehreren Gruppen zugeordnet      |

--- a/doc/user/source/referenz/metadata/item_attribute_prefixes.rst
+++ b/doc/user/source/referenz/metadata/item_attribute_prefixes.rst
@@ -17,7 +17,7 @@ Abschnitt der Metadaten) soll nur genutzt werden, wenn es unbedingt notwendig is
 Der ``item_attribute_prefixes:`` Abschnitt definiert die Items ansonsten analog zum Abschnitt ``item_attributes``.
 
 Die Definitionen im Abschnitt ``item_attribute_prefixes:``  werden für die Gültigkeitsprüfung der konfigurierten
-Werte in den Konfigurationsdateien im Verzeichnis ``../items``, sowie zur Dokumentation und in der Zukunft zur
+Werte in den Konfigurationsdateien im Verzeichnis **items**, sowie zur Dokumentation und in der Zukunft zur
 Konfiguration in der Admin GUI benutzt.
 
 .. code:: yaml

--- a/doc/user/source/referenz/metadata/item_attributes.rst
+++ b/doc/user/source/referenz/metadata/item_attributes.rst
@@ -13,7 +13,7 @@ beschreibt. Der Schlüssel des Unter-Abschnitts ist der Name des Attributes. Att
 Großbuchstaben und Sonderzeichen enthalten. Sie dürfen nicht mit einer Ziffer beginnen.
 
 Die Definitionen im Abschnitt ``item_attributes:``  werden für die Gültigkeitsprüfung der konfigurierten Werte in den
-Konfigurationsdateien im Verzeichnis ``../items``, sowie zur Dokumentation und in der Zukunft zur Konfiguration
+Konfigurationsdateien im Verzeichnis ``etc/items``, sowie zur Dokumentation und in der Zukunft zur Konfiguration
 in der Admin GUI benutzt.
 
 .. code:: yaml

--- a/doc/user/source/referenz/metadata/item_structs.rst
+++ b/doc/user/source/referenz/metadata/item_structs.rst
@@ -37,7 +37,7 @@ Definitionen von ``item_structs:`` haben das folgende Format:
 
 
 Zur Konfiguration von SmartHomeNG werden diese structs durch die Angabe einer Referenz in den Item Tree eingefügt.
-Das erfolgt in den Konfigurationsdateien für Items im Verzeichnis ``../items``:
+Das erfolgt in den Konfigurationsdateien für Items im Verzeichnis ``etc/items``:
 
 .. code:: yaml
 
@@ -120,7 +120,7 @@ realen Instanz Namen ersetzt.
                     initial_value: True
 
 
-In der Item Konfiguration in den Dateien im Verzeichnis ``../items`` wird der Instanz Name der Struktur mitgegeben.
+In der Item Konfiguration in den Dateien im Verzeichnis ``etc/items`` wird der Instanz Name der Struktur mitgegeben.
 Das sieht z.B. folgendermaßen aus:
 
 .. code:: yaml

--- a/doc/user/source/referenz/metadata/parameter_keys.rst
+++ b/doc/user/source/referenz/metadata/parameter_keys.rst
@@ -45,7 +45,7 @@ Beschreibung der Schlüssel im Abschnitt für einen Parameter bzw. ein Attribut:
     des Plugins diesen Parameter konfiguriert.
 
 - ``default:`` Optional: Gibt einen Standardwert vor, der verwendet wird, falls bei der Konfiguration des
-  Parameters in ``../etc/plugin.yaml`` bzw. ``../etc/module.yaml`` kein Wert angegeben wird.
+  Parameters in ``etc/plugin.yaml`` bzw. ``etc/module.yaml`` kein Wert angegeben wird.
 
 - ``description:`` Mehrsprachiger Text, der die Funktion das Plugins beschreibt. Die Beschreibung wird bei der
   Generierung des Dokumentations-Seiten des Plugins verwendet - Die Texte in den verschiedenen Sprachen werden

--- a/doc/user/source/referenz/metadata/parameters.rst
+++ b/doc/user/source/referenz/metadata/parameters.rst
@@ -10,7 +10,7 @@
 parameters
 ----------
 
-Parameter-Metadaten werden benutzt um die Gültigkeit von Parametern zu prüfen, die im Verzeichnis ``../etc``
+Parameter-Metadaten werden benutzt um die Gültigkeit von Parametern zu prüfen, die im Verzeichnis ``etc``
 konfiguriert wurden. Falls für einen Parameter ein ungültiger Wert konfiguriert wurde, wird eine Warnung im Logfile
 von SmartHomeNG eingetragen.
 

--- a/doc/user/source/referenz/module/module_metadata.rst
+++ b/doc/user/source/referenz/module/module_metadata.rst
@@ -2,7 +2,7 @@
 Metadaten für Module
 ====================
 
-Module werden in der Datei ``../etc/module.yaml`` bzw. über die Admit GUI konfiguriert. Die Parameter sind in
+Module werden in der Datei ``etc/module.yaml`` bzw. über die Admit GUI konfiguriert. Die Parameter sind in
 der Dokumentation des Moduls beschrieben.
 
 
@@ -14,15 +14,15 @@ Ein Modul besteht im minimum aus zwei Dateien:
 Eine genaue Beschreibung welche weiteren Dateien und Unterverzeichnisse ein Modul haben kann, ist im Abschnitt
 :doc:`Entwicklung </entwicklung/module/module>` beschrieben.
 
-Alle Dateien sind in einem Verzeichnis unterhalb von ``../modules`` gespeichert, welches den Namen des
+Alle Dateien sind in einem Verzeichnis unterhalb von **modules** gespeichert, welches den Namen des
 Moduls trägt (nur in Kleinbuchstaben).
 
 
-Die **Metadaten** Datei eines Moduls heißt ``/modules/<name of the module>/module.yaml``. Die bis zu sieben
+Die **Metadaten** Datei eines Moduls heißt **modules/<name of the module>/module.yaml**. Die bis zu sieben
 Abschnitte, die im folgenden beschrieben sind.
 
 - ``module:`` - Globale Metadaten des Moduls
-- ``parameters:`` - Definition der Parameter, welche zur Konfiguration des Moduls in der Datei ``../etc/module.yaml``
+- ``parameters:`` - Definition der Parameter, welche zur Konfiguration des Moduls in der Datei ``etc/module.yaml``
   benutzt werden können
 
 |

--- a/doc/user/source/referenz/plugins/plugin_metadata.rst
+++ b/doc/user/source/referenz/plugins/plugin_metadata.rst
@@ -2,7 +2,7 @@
 Metadaten für Plugins
 =====================
 
-Plugins werden in der Datei ``../etc/plugin.yaml`` bzw. über die Admit GUI konfiguriert. Die Parameter sind in
+Plugins werden in der Datei ``etc/plugin.yaml`` bzw. über die Admit GUI konfiguriert. Die Parameter sind in
 der Dokumentation des Plugins beschrieben.
 
 
@@ -15,7 +15,7 @@ Ein Plugin besteht im minimum aus drei Dateien:
 Eine genaue Beschreibung welche weiteren Dateien und Unterverzeichnisse ein Plugin haben kann, ist im Abschnitt
 :doc:`Entwicklung </entwicklung/plugins/plugins>` beschrieben.
 
-Alle drei Dateien sind in einem Verzeichnis unterhalb von ``../plugins`` gespeichert, welches den Namen des
+Alle drei Dateien sind in einem Verzeichnis unterhalb von ``plugins`` gespeichert, welches den Namen des
 Plugins trägt (nur in Kleinbuchstaben).
 
 
@@ -23,7 +23,7 @@ Die **Metadaten** Datei eines Plugins heißt ``/plugins/<name of the plugin>/plu
 Abschnitte, die im folgenden beschrieben sind.
 
 - ``plugin:`` - Globale Metadaten des Plugins
-- ``parameters:`` - Definition der Parameter, welche zur Konfiguration des Plugins in der Datei ``../etc/plugin.yaml``
+- ``parameters:`` - Definition der Parameter, welche zur Konfiguration des Plugins in der Datei ``etc/plugin.yaml``
   benutzt werden können
 - ``item_attributes:`` - Definition der Item Attribute, die durch das Plugin genutzt/unterstützt werden
 - ``item_structs:`` - Definition von Item Strukturen, welche im Zusammenhang mit dem Plugin genutzt werden können

--- a/doc/user/source/referenz/python/python_installation.rst
+++ b/doc/user/source/referenz/python/python_installation.rst
@@ -41,7 +41,7 @@ Download des Source Codes
 
 Auf der website **python.org** unter **Downloads/Source Code** die gewünschte Version suchen und die das entsprechende
 Archiv (XZ compressed source tarball) herunter laden. Die Datei träget den Namen **Python-3.10.12.tar.xz**.
-Anschließend diese Datei auf dem SmartHomeNG-System in das Verzeichnis **/usr/local/src** kopieren. (Aufgrund der
+Anschließend diese Datei auf dem SmartHomeNG-System in das Verzeichnis ``/usr/local/src`` kopieren. (Aufgrund der
 Verzeichnisrechte muss das evtl. mit sudo geschehen)
 
 |
@@ -49,7 +49,7 @@ Verzeichnisrechte muss das evtl. mit sudo geschehen)
 Das Archiv auspacken
 ====================
 
-Zum auspacken des Archivs in das Verzeichnis **/usr/local/src** wechseln und anschließend mit **tar** das Archiv
+Zum auspacken des Archivs in das Verzeichnis ``/usr/local/src`` wechseln und anschließend mit **tar** das Archiv
 auspacken.
 
 .. code-block:: bash
@@ -87,7 +87,7 @@ Der Build-Prozess wird mit
 
 gestartet.
 
-Wenn der Build Prozess erfolgreich war, wird die Python Version in das Verzeichnis **/usr/local/bin** installiert.
+Wenn der Build Prozess erfolgreich war, wird die Python Version in das Verzeichnis ``/usr/local/bin`` installiert.
 
 Dieses kann mit
 

--- a/doc/user/source/referenz/smarthomeng/ablauf_startup.rst
+++ b/doc/user/source/referenz/smarthomeng/ablauf_startup.rst
@@ -41,9 +41,9 @@ Schritte größer-gleich 10 und kleiner als 20 identifizieren Schritte innerhalb
 
 Das smarthome Objekt wird erzeugt und initialisiert. Dazu werden die grundlegenden Variablen initialisiert.
 Anschließend wird geprüft ob die benötigten Konfigurationsdateien existieren. Falls nicht, werden die
-entsprechenden **<name>.yaml.default** Dateien umkopiert.
+entsprechenden ``<name>.yaml.default`` Dateien umkopiert.
 
-Es werden die Konfigurationsdateienb **smarthome.yaml** und **logging.yaml** eingelesen und das Logging wird
+Es werden die Konfigurationsdateienb ``smarthome.yaml`` und ``logging.yaml`` eingelesen und das Logging wird
 initialisiert.
 
 

--- a/doc/user/source/referenz/smarthomeng/feiertage_datum_zeit.rst
+++ b/doc/user/source/referenz/smarthomeng/feiertage_datum_zeit.rst
@@ -13,7 +13,7 @@ Feiertage, Daten und Zeiten
 ===========================
 
 Das Modul **shtime** stellt eine Reihe von Funktionen zur Verfügung, die es erlauben festzustellen ob ein Datum ein
-Feiertag ist (und welcher). Dazu muss die Verwendung von Feiertagen in **/etc/holidays.yaml** konfiguriert sein.
+Feiertag ist (und welcher). Dazu muss die Verwendung von Feiertagen in ``/etc/holidays.yaml`` konfiguriert sein.
 
 Weiterhin gibt es Funktionen, die den Umgang mit Datums- und Zeitangaben vereinfachen.
 

--- a/doc/user/source/referenz/smarthomeng/kommandozeilen_optionen.rst
+++ b/doc/user/source/referenz/smarthomeng/kommandozeilen_optionen.rst
@@ -35,7 +35,7 @@ smarthome.py kann mit folgenden Kommandozeilen Optionen gestartet werden:
 +------------+----------------------+--------------------------------------------------------------------------------+
 | -e         | --config_etc         | Die Verzeichnisse mit benutzerdefinierter Konfiguration (items, structs,       |
 |            |                      | logics, scenes, uf) unterhalb von etc suchen                                   |
-|            |                      | (/etc/items/ statt /items/, /etc/structs/ statt /structs/ usw.)                |
+|            |                      | (``etc/items/`` statt ``items/``, ``etc/structs/`` statt ``structs/`` usw.)    |
 +------------+----------------------+--------------------------------------------------------------------------------+
 | -v         | --verbose            | Ausführliches Logging - DEPRECATED bitte die Logging-Konfiguration benutzen    |
 +------------+----------------------+--------------------------------------------------------------------------------+

--- a/doc/user/source/referenz/smarthomeng/methoden_sonne_mond.rst
+++ b/doc/user/source/referenz/smarthomeng/methoden_sonne_mond.rst
@@ -8,7 +8,7 @@ sh.sun
 
 Dieses Objekt bietet Zugriff auf Parameter der Sonne. Um dieses Objekt zu verwenden, ist es erforderlich,
 den Breitengrad (latitude, z.B. lat: 53.5989481) und den Längengrad (longitude z.B. lon: 10.0459898),
-sowie die Höhe über dem Meeresspiegel (elevation z.B.: elev: 20) in der Datei **../etc/smarthome.yaml** anzugeben.
+sowie die Höhe über dem Meeresspiegel (elevation z.B.: elev: 20) in der Datei ``etc/smarthome.yaml`` anzugeben.
 
 
 sh.sun.pos()

--- a/doc/user/source/referenz/userfunctions/userfunctions.rst
+++ b/doc/user/source/referenz/userfunctions/userfunctions.rst
@@ -14,18 +14,18 @@ schreiben und in eval Statements sowie in Logiken zu verwenden.
 Erstellung und Speicherung
 ==========================
 
-Die Python Dateien mit den Funktionen müssen dazu im Verzeichnis **../functions** abgelegt werden. Es sind normale
+Die Python Dateien mit den Funktionen müssen dazu im Verzeichnis ``../functions`` abgelegt werden. Es sind normale
 Python Dateien, die mehrere Funktionen enthalten können. Als formale Anforderung sind nur Informationen zur Version
 und eine kurze Beschreibung des Zwecks der Funktionen dieser Datei anzugeben. Diese müssen in der Python Datei
 als globale Variablen **_VERSION** und **_DESCRIPTION** definiert werden.
 
-Im folgenden Beispiel wird eine Datei (Funktionssammlung) mit dem Namen **anhalter.py** im Verzeichnis **../functions**
+Im folgenden Beispiel wird eine Datei (Funktionssammlung) mit dem Namen ``anhalter.py`` im Verzeichnis ``etc/functions``
 erzeugt:
 
 Die Python Datei sieht folgendermaßen aus:
 
 .. code-block:: python
-   :caption: /usr/local/smarthome/functions/anhalter.py
+   :caption: etc/functions/anhalter.py
 
    #!/usr/bin/env python3
    # anhalter.py
@@ -87,7 +87,7 @@ Als Hilfestellung bei der Erstellung und dem Testen von Funktionen kann aus den 
 Dazu muss das Logging Modul importiert und ein Logger definiert werden:
 
 .. code-block:: python
-   :caption: /usr/local/smarthome/functions/anhalter.py
+   :caption: etc/functions/anhalter.py
 
    #!/usr/bin/env python3
    # anhalter.py
@@ -113,7 +113,7 @@ Der Name des Loggers im obigen Beispiel ist **functions.anhalter**:
 
 
 Damit aus Funktionen ein Logging mit Leveln kleiner als WARNING erfolgt, muss in der Logging Konfiguration
-../etc/logging.yaml ein entsprechender Logger für **functions** ergänzt werden:
+``etc/logging.yaml`` ein entsprechender Logger für **functions** ergänzt werden:
 
 .. code:: yaml
 
@@ -148,7 +148,7 @@ werden:
 Die Userfunction dazu kann z.B. folgendermaßen aussehen:
 
 .. code-block:: python
-   :caption: /usr/local/smarthome/functions/beschattung.py
+   :caption: etc/functions/beschattung.py
 
    _VERSION     = '0.1.0'
    _DESCRIPTION = 'Hilfsfunktionen zur Beschattungssteuerung per Stateengine'
@@ -185,7 +185,7 @@ Das folgende Beispiel zeigt beide Varianten (übergabe der Item Werte und Refere
 
 
 .. code-block:: python
-   :caption: /usr/local/smarthome/functions/beschattung.py
+   :caption: etc/functions/beschattung.py
 
    _VERSION     = '0.2.0'
    _DESCRIPTION = 'Hilfsfunktionen zur Beschattungssteuerung per Stateengine'
@@ -218,7 +218,7 @@ kann das Smarthome-Objekt übergeben werden. Das würde dann folgendermaßen aus
 Die Userfunction dazu kann z.B. folgendermaßen aussehen:
 
 .. code-block:: python
-   :caption: /usr/local/smarthome/functions/beschattung.py
+   :caption: etc/functions/beschattung.py
 
    _VERSION     = '0.2.1'
    _DESCRIPTION = 'Hilfsfunktionen zur Beschattungssteuerung per Stateengine'
@@ -255,7 +255,7 @@ SmartHomeNG erstellt wurden.
 Zusätzliche Python Module
 =========================
 
-Wird ein zusätzliches Python Modul in einer Userfunction benötigt, so kann eine ``requirements.txt`` im Verzeichnis ``functions`` erstellt 
+Wird ein zusätzliches Python Modul in einer Userfunction benötigt, so kann eine ``requirements.txt`` im Verzeichnis ``etc/functions`` erstellt 
 und in dieser Datei Namen und Versionen für die Installation via PIP notiert werden.
 In diesem Fall muss SmartHomeNG auf jeden Fall neu gestartet werden da die Überprüfung nur beim Start von SmartHomeNG erfolgt.
 

--- a/doc/user/source/release/1_07.rst
+++ b/doc/user/source/release/1_07.rst
@@ -126,7 +126,7 @@ Updates in the CORE
 
 * Plugins:
 
-  * Configuration parameter **class_name** and **class_path** in **/etc/plugin.yaml** are now DEPRECATED
+  * Configuration parameter **class_name** and **class_path** in ``/etc/plugin.yaml`` are now DEPRECATED
   * Support for MQTT implemented
   * Web interfaces: make all tabs sticky on web interface for better scroll appearance
 

--- a/doc/user/source/tools/tools.rst
+++ b/doc/user/source/tools/tools.rst
@@ -7,7 +7,7 @@
 Tools
 =====
 
-Im Verzeichnis **../tools** sind einige Python Skripte abgelegt, die im Umgang mit SmartHomeNG
+Im Verzeichnis ``tools`` sind einige Python Skripte abgelegt, die im Umgang mit SmartHomeNG
 hilfreich sind.
 
 

--- a/doc/user/source/tools/tools_backup_restore.rst
+++ b/doc/user/source/tools/tools_backup_restore.rst
@@ -11,7 +11,7 @@ backup_restore.py
 
 
 Dieses Skript kann ein Backup der Konfiguration erzeugen, indem es die Konfigurationsdateien
-aus den Verzeichnissen **../etc**, **../items** und **../scenes** in eine tar.gz Datei
+aus den Verzeichnissen ``etc``, ``etc/items`` und ``etc/scenes`` in eine tar.gz Datei
 zusammenführt.
 
 Alternativ kann das Skript die Konfigurationsdateien aus einem früheren Backup wiederherstellen.

--- a/doc/user/source/tools/tools_build_requirements.rst
+++ b/doc/user/source/tools/tools_build_requirements.rst
@@ -11,10 +11,10 @@ Die Liste wird nicht auf ihre Richtigkeit oder auf andere bzw. gegenläufige Anf
 
 Das Verfahren zum Zusammenstellen der Anforderungen ist wie folgt:
 
-1) Durchsucht die Unterverzeichnisse des **../plugins** Verzeichnisses und sammelt alle Dateien mit Anforderungen
+1) Durchsucht die Unterverzeichnisse des ``plugins`` Verzeichnisses und sammelt alle Dateien mit Anforderungen
 2) Lesen der Anforderungen für den Core
 3) Lesen aller gefundenen Dateien mit Anforderungen und hinfügen (mit der Quellangabe) der Anforderung zu einem dict
-4) Schreiben aller gefundenen Anforderungen in die Datei **all.txt** im Verzeichnis **../requirements**
+4) Schreiben aller gefundenen Anforderungen in die Datei ``all.txt`` im Verzeichnis ``requirements``
 
 
 Anschließend kann die Python Installation mit dem folgenden Kommando auf den erforderlichen
@@ -29,3 +29,6 @@ Stand gebracht werden.
    Bitte darauf achten das Kommando **pip3** zu verwenden. Bei Verwendung von **pip** wird, falls
    eine Python v2.7 Installation auf dem Computer existiert, diese aktualisiert und nicht die
    Python 3 Version.
+
+   Sofern - wie empfohlen - in einem virtuellen Environment gearbeitet wird, ist dieser Hinweis
+   hinfällig, weil dort **pip** automatisch **pip3** startet.

--- a/doc/user/source/visualisierung/changes_in_1.8.rst
+++ b/doc/user/source/visualisierung/changes_in_1.8.rst
@@ -6,7 +6,7 @@ Ab SmartHomeNG v1.8 sind für die vollständige smartVISU Unterstützung das **w
 das **smartvisu** Plugins zu konfigurieren.
 
 .. code-block:: yaml
-   :caption: Ausschnitt aus **../etc/module.yaml**
+   :caption: Ausschnitt aus ``etc/module.yaml``
 
    websocket:
        module_name: websocket
@@ -19,7 +19,7 @@ das **smartvisu** Plugins zu konfigurieren.
 
 
 .. code-block:: yaml
-   :caption: Ausschnitt aus **../etc/plugin.yaml**
+   :caption: Ausschnitt aus ``etc/plugin.yaml``
 
    smartvisu:
        plugin_name: smartvisu

--- a/doc/user/source/visualisierung/features.rst
+++ b/doc/user/source/visualisierung/features.rst
@@ -325,7 +325,7 @@ laden. Wird die angeforderte Seite dort nicht gefunden, versucht smartVISU die S
 laden.
 
 Man kann also SmartHomeNG die Seiten vollständig generieren lassen und eine Seite, die manuelle Modifikationen enthalten
-soll aus dem Ordner **smarthome** in den unter **pages** angelegten Bereich kopieren und anschließend in dieser Kopie
+soll, aus dem Ordner ``smarthome`` in den unter **pages** angelegten Bereich kopieren und anschließend in dieser Kopie
 die gewünschten Modifikationen vornehmen.
 
 .. note::
@@ -333,7 +333,7 @@ die gewünschten Modifikationen vornehmen.
    Die modifizierte Seite erhält keine Änderungen mehr aus SmartHomeNG.
 
    Falls Änderungen aus SmartHomeNG in diese Seite übernommen werden sollen, müssen diese aus der generierten Seite
-   (im Ordner **smarthome**) in die manuell modifizierte Seite übernommen werden.
+   (im Ordner ``smarthome``) in die manuell modifizierte Seite übernommen werden.
 
    Alternativ kann die generierte Seite erneut kopiert werden und die Änderungen können dort eingearbeitet werden,
    wie dieses ursprünglich erfolgt ist.

--- a/doc/user/source/visualisierung/navigation_structure.rst
+++ b/doc/user/source/visualisierung/navigation_structure.rst
@@ -1,4 +1,3 @@
-
 .. role:: redsup
 .. role:: bluesup
 .. role:: darkbluesup
@@ -8,12 +7,12 @@
 Navigation Structure Definition
 ===============================
 
-Bisher wurde die Navigation der smartVISU ausschließlich in der Reihenfolge erzeugt, in der die Items
-beim Start von SmartHomeNG eingelesen werden. Seit SmartHomeNG v1.8 ist es möglich, diese Navigations-Struktur
+Die Navigation der smartVISU wird in der Reihenfolge erzeugt, in der die Items 
+beim Start von SmartHomeNG eingelesen werden. Es ist möglich, diese Navigations-Struktur
 (inclusive Icons und Sidebar Infos) in einer zentralen Datei zu konfigurieren und damit die Reihenfolge aus
 den Item-Definitionen zu übersteuern.
 
-In der Datei ``../etc/visu.yaml`` können auch die Einstellungen für die Attribute **sv_img**, **sv_nav_aside**
+In der Datei ``etc/visu.yaml`` können auch die Einstellungen für die Attribute **sv_img**, **sv_nav_aside**
 und **sv_nav_aside2** übersteuert und die Position von Trennern in der Navigation festgelegt werden.
 
 Die Struktur der Datei ist folgende:

--- a/doc/user/source/visualisierung/reverse_proxy.rst
+++ b/doc/user/source/visualisierung/reverse_proxy.rst
@@ -390,7 +390,7 @@ Nacharbeiten: Port 80 in NGINX deaktivieren
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Da NGINX im LAN aktuell noch auf Port 80 konfiguriert ist, sollte man in
-der /etc/nginx/sites-available/default noch ein ``return 403`` ergänzen:
+der ``/etc/nginx/sites-available/default`` noch ein ``return 403`` ergänzen:
 
 .. code-block:: nginx
 

--- a/doc/user/source/visualisierung/visualisierung.rst
+++ b/doc/user/source/visualisierung/visualisierung.rst
@@ -9,9 +9,9 @@
 .. index:: Visualisierung mit smartVISU
 .. index:: smartVISU; Visualisierung mit smartVISU
 
-###############################################
-Visualisierung mit smartVISU :greensup:`Update`
-###############################################
+############################
+Visualisierung mit smartVISU
+############################
 
 
 =========
@@ -57,9 +57,9 @@ Zusätzlich bietet das neue Plugin folgende Funktionalitäten:
     - structure definition file ...
 
 
-==============================================
-Generierung der Visu Seiten :greensup:`Update`
-==============================================
+===========================
+Generierung der Visu Seiten
+===========================
 
 Die Generierung der Visu Seiten erfolgt (wenn sie konfiguriert ist) beim Start von SmartHomeNG durch ein Plugin.
 Mit der Version 1.8 von SmartHomeNG gibt es hier einige Neuerungen.

--- a/doc/user/source/visualisierung/websocket_communication.rst
+++ b/doc/user/source/visualisierung/websocket_communication.rst
@@ -13,10 +13,10 @@ von SmartHomeNG.
    Die Kommunikation findet zwischen dem Browser und SmartHomeNG statt, NICHT zwischen dem
    Webserver und SmartHomeNG. Der Webserver liefert nur den statischen Kontent der Visu aus.
 
-Das Modul **websocket** muss in **../etc/module.yaml** konfiguriert werden.
+Das Modul **websocket** muss in ``etc/module.yaml`` konfiguriert werden.
 
 .. code-block:: yaml
-   :caption: Ausschnitt aus **../etc/module.yaml**
+   :caption: Ausschnitt aus ``etc/module.yaml``
 
    websocket:
        module_name: websocket
@@ -50,14 +50,14 @@ Das Modul **websocket** muss in **../etc/module.yaml** konfiguriert werden.
 +-------------+-----------------------------------------------------------------------------------+
 | use_tls     | Muss normalerweise nicht angegeben werden. Wenn use_tls auf True gesetzt wird,    |
 |             | wird die verschlüsselte Kommunikation über **tls_port** aktiviert. Dazu müssen    |
-|             | im Verzeichnis **../etc** gültige Zertifikatdateien **shng.cer** und **shng.key** |
+|             | im Verzeichnis ``etc`` gültige Zertifikatdateien ``shng.cer`` und ``shng.key``    |
 |             | abgelegt werden.                                                                  |
 +-------------+-----------------------------------------------------------------------------------+
 | tls_cert    | Muss normalerweise nicht angegeben werden. Hiermit wird der Name der Zertifikat-  |
-|             | Datei festgelegt. Wird kein Name angegeben, wird **shng.cer** verwendet.          |
+|             | Datei festgelegt. Wird kein Name angegeben, wird ``shng.cer`` verwendet.          |
 +-------------+-----------------------------------------------------------------------------------+
 | tls_key     | Muss normalerweise nicht angegeben werden. Hiermit wird der Name der Datei mit    |
-|             | dem privaten Schlüssel festgelegt. Wird kein Name angegeben, wird **shng.key**    |
+|             | dem privaten Schlüssel festgelegt. Wird kein Name angegeben, wird ``shng.key``    |
 |             | verwendet.                                                                        |
 +-------------+-----------------------------------------------------------------------------------+
 | sv_enabled  | Muss normalerweise nicht angegeben werden. Hiermit wird festgelegt, ob das        |

--- a/doc/user/source/was_ist_neu.rst
+++ b/doc/user/source/was_ist_neu.rst
@@ -55,6 +55,18 @@ diesem und den vorangegangenen Releases ist den :doc:`Release Notes </release/re
       Diese Plugins waren als `deprecated` markiert und wurden entfernt. Sie sind
       bei Bedarf im Repo `smarthomeNG/plugins-archive` verfügbar.
 
+  - **Dokumentation**:
+
+    - **Ordner/Dateien**: Vor dem Hintergrund, dass die Konfiguration zukünftig vollständig unterhalb von
+      ``etc`` abgelegt werden soll (Option **-e**/**--config-etc**), werden alle Datei- und Pfadnamen von
+      Konfigurationsdateien unterhalb von ``etc`` angegeben. In Ausnahmefällen können z.B. in Beispielen
+      nur lokale Dateinamen angegeben werden.
+
+    - **Verweise auf ältere SmartHomeNG-Versionen**: In der Beschreibung von Konfiguration oder Syntax wird
+      nur noch der aktuell gültige Stand angegeben. Beschreibungen, wie etwas in früheren Versionen
+      angegeben werden musste, oder seit welcher Version ein bestimmtes Feature implementiert ist, entfallen.
+      Nach Möglichkeit werden Dokumentationen von früheren Versionen von SmartHomeNG parallel als Archiv
+      bereitgestellt.
 |
 
 .. comment

--- a/doc/user/source/was_ist_neu.rst
+++ b/doc/user/source/was_ist_neu.rst
@@ -17,24 +17,24 @@ diesem und den vorangegangenen Releases ist den :doc:`Release Notes </release/re
       gesichert werden, zur Verfügung.
 
     - **Konfiguration unterhalb von etc mit Migration**: Wenn SmartHomeNG mit der Kommandozeilenoption **-e** gestartet
-      wird, sucht es die Konfigurationsverzeichnisse `items, `structs`, `logics`, `uf` und `scenes`
-      nicht mehr im Stammverzeichnis, sondern unterhalb von `etc`. Dies ist auch durch die Option
-      **config_etc: true** in der `etc/smarthome.yaml` möglich.
+      wird, sucht es die Konfigurationsverzeichnisse ``items``, ``structs``, ``logics``, ``uf`` und ``scenes``
+      nicht mehr im Stammverzeichnis, sondern unterhalb von ``etc``. Dies ist auch durch die Option
+      **config_etc: true** in der ``etc/smarthome.yaml`` möglich.
 
-      Gleichzeitig wird versucht, vorhandene Konfigurationsdateien nach `etc/<Verzeichnis>`` zu verschieben und -
-      beim Aufruf mit **-e** - den Eintrag **config_etc: true** in der `etc/smarthome.yaml` einzutragen, da nach
+      Gleichzeitig wird versucht, vorhandene Konfigurationsdateien nach ``etc/<Verzeichnis>`` zu verschieben und -
+      beim Aufruf mit **-e** - den Eintrag **config_etc: true** in der ``etc/smarthome.yaml`` einzutragen, da nach
       der Migration der Konfigurationsdateien der bisherige Aufruf nicht mehr funktionieren würde.
 
-      Die Konfiguration unterhalb von `etc` soll in zukünftigen Releases Standard werden.
+      Die Konfiguration unterhalb von ``etc`` soll in zukünftigen Releases Standard werden.
 
     - **Anpassung der Plugin-Instanzbenennung**: Bisher wurde der Instanzname eines Plugins aus der Angabe
-      **instance: <name>** in der `etc/plugin.yaml` ermittelt. Im - derzeit optional verfügbaren - neuen
-      System wird stattdessen der Name des entsprechenden Abschnitts in der `etc/plugin.yaml` verwendet.
+      **instance: <name>** in der ``etc/plugin.yaml`` ermittelt. Im - derzeit optional verfügbaren - neuen
+      System wird stattdessen der Name des entsprechenden Abschnitts in der ``etc/plugin.yaml`` verwendet.
       Damit erhält standardmäßig jedes Plugin, das mehrfach eingebunden wird, einen Instanzbezeichner. Wenn
       das für einzelne Instanzen nicht gewollt ist, kann mit **default_instance: true** für einzelne Plugins
       weiterhin der leere Instanzname verwendet werden.
 
-      Um dieses System jetzt schon zu aktivieren, muss in der `etc/smarthome.yaml` die Option
+      Um dieses System jetzt schon zu aktivieren, muss in der ``etc/smarthome.yaml`` die Option
       **legacy_instances: false** gesetzt werden.
 
       Diese Methode der Instanzbenennung soll in zukünftigen Releases Standard werden.
@@ -67,6 +67,7 @@ diesem und den vorangegangenen Releases ist den :doc:`Release Notes </release/re
       angegeben werden musste, oder seit welcher Version ein bestimmtes Feature implementiert ist, entfallen.
       Nach Möglichkeit werden Dokumentationen von früheren Versionen von SmartHomeNG parallel als Archiv
       bereitgestellt.
+
 |
 
 .. comment

--- a/doc/user/source/was_ist_neu.rst
+++ b/doc/user/source/was_ist_neu.rst
@@ -10,7 +10,7 @@ diesem und den vorangegangenen Releases ist den :doc:`Release Notes </release/re
 
     - **Backup der Konfiguration**: Das Sichern und Wiederherstellen der Konfiguration wurde erweitert.
       Beim sichern der Konfiguration werden nun, falls vorhanden, die privaten Plugins (Plugins, deren
-      Name mit **priv_** beginnt) und die privaten Tools (das Verzeichnis priv_tools) mit gesichert und
+      Name mit ``priv_`` beginnt) und die privaten Tools (das Verzeichnis priv_tools) mit gesichert und
       beim Wiederherstellen aus der Zip Datei zurück kopiert.
 
       Dadurch steht jetzt eine einfache Möglichkeit der Sicherung dieser Dateien, die nicht in git

--- a/doc/user/source/was_war_neu.rst
+++ b/doc/user/source/was_war_neu.rst
@@ -62,8 +62,8 @@ diesem und den vorangegangenen Releases ist den :doc:`Release Notes </release/re
       auf Unterebenen einer stuct eingebunden werden.
     - **relative Referenzen**: Bei der Einbindung von Sub-Structs aus der selben Datei können jetzt relative
       Angaben gemacht werden.
-    - **structs Verzeichnis**: Dateien mit struct Definitionen werden jetzt im Verzeichnis ``../structs`` abgelegt.
-      Bestehende Definitionsdateien werden automatisch aus dem ``../etc`` Verzeichnis in das ``../structs`` Verzeichnis
+    - **structs Verzeichnis**: Dateien mit struct Definitionen werden jetzt im Verzeichnis ``etc/structs`` abgelegt.
+      Bestehende Definitionsdateien werden automatisch aus dem ``etc`` Verzeichnis in das ``etc/structs`` Verzeichnis
       migriert.
   - **Plugins**:
 


### PR DESCRIPTION
Wie vorgeschlagen habe ich

- Ordner-/Dateinamen vereinheitlicht (z.B. etc/plugin.yaml statt ../etc/plugin.yaml, Konfig in etc, Schreibweise in doppelte Backticks)
- Verweise auf frühere Konfigurationsmöglichkeiten und Hinweise, seit wann etwas unterstützt wird, entfernt.
