### PR TITLE
core: add itemtypes datetime and timestamp

### DIFF
--- a/doc/user/source/referenz/items/items.rst
+++ b/doc/user/source/referenz/items/items.rst
@@ -8,9 +8,9 @@
 .. role:: blacksup
 
 
-=====
-Items
-=====
+=======================
+Items :bluesup:`Update`
+=======================
 
 In den folgenden Abschnitten sind Informationen zu den Items in SmartHomeNG zu finden.
 

--- a/doc/user/source/referenz/items/standard_attribute/type.rst
+++ b/doc/user/source/referenz/items/standard_attribute/type.rst
@@ -1,11 +1,13 @@
 .. index:: Standard-Attribute; type
 .. index:: type
 
+.. role:: bluesup
+
 .. index:: Items; Datentypen
 .. index:: Datentypen
 
-`type`
-------
+`type` :bluesup:`Update`
+------------------------
 
 Das Attribut **type** legt den Datentyp des Items fest. Dadurch wird bestimmt, was für Daten in
 dem Item gespeichert werden können und wie das Item verwendet werden kann.
@@ -38,4 +40,14 @@ Folgende mögliche Datentypen sind für Items definiert:
 |          | mit dem Namen des Item-Pfades geben. Genaueres ist dem Abschnitt                     |
 |          | **Konfiguration / Szenen** dieser Dokumentation zu entnehmen.                        |
 +----------+--------------------------------------------------------------------------------------+
-
+| datetime | Datums-/Zeittyp - Items dieses Typs geben ein `datetime.datetime`-Objekt zurück und  |
+|          | haben zusätzliche Methoden `item.as_ts()` und `item.as_str(format)`. Diese geben den |
+|          | Itemwert als POSIX-Timestamp bzw. als String zurück. Der Parameter `format` ist      |
+|          | optional. Ohne den Parameter wird das ISO-Format ausgegeben.                         |          
++----------+--------------------------------------------------------------------------------------+
+| timestamp| Zeitstempel. Intern als float definiert, können Datums-/Zeitwerte als POSIX-Timestamp|
+|          | gespeichert werden. Items dieses Typs haben die zusätzlichen Methoden `item.as_dt()` |
+|          | und `item.as_str(format)`. Diese geben den Itemwert als `datetime.datetime`-Objekt   |
+|          | bzw. als String zurück. Der Parameter `format` ist optional. Ohne den Parameter wird |
+|          | das ISO-Format zurückgegeben.                                                        |
++----------+--------------------------------------------------------------------------------------+

--- a/doc/user/source/referenz/referenz.rst
+++ b/doc/user/source/referenz/referenz.rst
@@ -7,8 +7,8 @@
 .. role:: redsup
 
 
-Referenz
-========
+Referenz :bluesup:`Update`
+==========================
 
 Hier entsteht nach und nach eine Referenz in der Details zu einzelnenen Themen von SmartHomeNG nachgelesen werden
 können.

--- a/doc/user/source/was_ist_neu.rst
+++ b/doc/user/source/was_ist_neu.rst
@@ -8,6 +8,10 @@ diesem und den vorangegangenen Releases ist den :doc:`Release Notes </release/re
 
   - **Core**:
 
+    - **Itemtypen**: Für Items gibt es jetzt die beiden Typen **datetime** und **timestamp**. Der Typ `datetime`
+      entspricht dem `datetime.datetime`-Objekt, der Typ `timestamp` entspricht einem POSIX-timestamp als `float`.
+      Beide Typen haben zusätzliche Methoden, um die Ausgabe im `datetime`-, `timestamp`- oder Textformat auszugeben.
+
     - **Backup der Konfiguration**: Das Sichern und Wiederherstellen der Konfiguration wurde erweitert.
       Beim sichern der Konfiguration werden nun, falls vorhanden, die privaten Plugins (Plugins, deren
       Name mit **priv_** beginnt) und die privaten Tools (das Verzeichnis priv_tools) mit gesichert und

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -25,15 +25,16 @@ This file describes a group of system wide constants for items, plugins and file
 """
 
 #item types
-ITEM_TYPES=["num","str","bool", "list","dict","foo","scene"]
-ITEM_DEFAULTS= __defaults = {'num': 0, 'str': '', 'bool': False, 'list': [], 'dict': {}, 'foo': None, 'scene': 0}
+ITEM_TYPES=["num", "str", "bool", "list", "dict", "foo", "scene", "timestamp", "datetime"]
+ITEM_DEFAULTS= __defaults = {'num': 0, 'str': '', 'bool': False, 'list': [], 'dict': {}, 'foo': None, 'scene': 0, 'timestamp': 0.0, 'datetime': None}
 FOO = 'foo'
 
 #metadata types
-META_DATA_TYPES=['bool', 'int', 'float', 'num', 'scene', 'str', 'password', 'list', 'dict', 'ip', 'ipv4', 'ipv6', 'mac', 'knx_ga', 'foo']
+META_DATA_TYPES=['bool', 'int', 'float', 'num', 'scene', 'str', 'password', 'list', 'dict', 'ip', 'ipv4', 'ipv6', 'mac', 'knx_ga', 'foo', 'timestamp']
 META_DATA_DEFAULTS={'bool': False, 'int': 0, 'float': 0.0, 'num': 0, 'scene': 0, 'str': '',  'password': '',
                     'list': [], 'dict': {}, 'OrderedDict': {},
-                    'ip': '0.0.0.0', 'ipv4': '0.0.0.0', 'ipv6': '', 'mac': '00:00:00:00:00:00', 'knx_ga': '', 'foo': None}
+                    'ip': '0.0.0.0', 'ipv4': '0.0.0.0', 'ipv6': '', 'mac': '00:00:00:00:00:00', 'knx_ga': '',
+                    'foo': None, 'timestamp': 0.0}
 
 #config params for items
 KEY_ENFORCE_UPDATES = 'enforce_updates'

--- a/lib/env/core.yaml
+++ b/lib/env/core.yaml
@@ -6,7 +6,7 @@ env:
             type: str
 
         start:
-            type: foo
+            type: datetime
 
         memory:
             type: num

--- a/lib/env/init.py
+++ b/lib/env/init.py
@@ -12,5 +12,4 @@ hostname=socket.gethostname()
 sh.env.system.name(hostname, logic.lname)
 
 # operating system start
-start=datetime.datetime.fromtimestamp(psutil.boot_time())
-sh.env.system.start(start, logic.lname)
+sh.env.system.start(psutil.boot_time(), logic.lname)

--- a/lib/env/location.yaml
+++ b/lib/env/location.yaml
@@ -18,7 +18,7 @@ env:
             type: bool
 
         sunrise:
-            type: foo
+            type: datetime
 
             azimut:
 
@@ -37,7 +37,7 @@ env:
                     type: num
 
         sunset:
-            type: foo
+            type: datetime
 
             azimut:
 
@@ -74,10 +74,10 @@ env:
                     type: num
 
         moonrise:
-            type: foo
+            type: datetime
 
         moonset:
-            type: foo
+            type: datetime
 
         moonphase:
             type: num

--- a/lib/env/system.yaml
+++ b/lib/env/system.yaml
@@ -3,7 +3,7 @@ env:
     system:
 
         start:
-            type: foo
+            type: datetime
 
         load:
             type: num

--- a/lib/item/helpers.py
+++ b/lib/item/helpers.py
@@ -25,6 +25,7 @@ import logging
 import os
 import datetime
 import json
+from lib.shtime import Shtime
 
 from ast import literal_eval
 import pickle
@@ -125,6 +126,63 @@ def cast_num(value):
     except Exception:
         pass
     raise ValueError
+
+
+def cast_timestamp(value):
+    """
+    cast a passed value to timestamp
+
+    :param value: numerical value (idem) or str in ISO time format or datetime object
+    :return: timestamp (float)
+    """
+    if isinstance(value, (int, float)):
+        return value
+
+    shtime = Shtime.get_instance()
+
+    if isinstance(value, datetime.datetime):
+        try:
+            return shtime.ts(value)  # type: ignore : shtime is set dynamically
+        except Exception:
+            pass
+
+    if isinstance(value, str):
+        try:
+            return shtime.ts(datetime.datetime.fromisoformat(value))  # type: ignore : shtime is set dynamically
+        except Exception:
+            pass
+
+    raise ValueError(f'{value} can not be converted to timestamp')
+
+
+def cast_datetime(value):
+    """
+    cast a passed value to datetime
+
+    :param value: numerical value (idem) or str in ISO time format or datetime object
+    :return: timestamp (float)
+    """
+    if isinstance(value, datetime.datetime):
+        return value
+
+    if value is None:
+        return None
+
+    shtime = Shtime.get_instance()
+
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.datetime.fromtimestamp(value, shtime.tzinfo())  # type: ignore : shtime is set dynamically
+        except Exception:
+            pass
+
+    if isinstance(value, str):
+        try:
+            return datetime.datetime.fromisoformat(value)  # type: ignore : shtime is set dynamically
+        except Exception:
+            pass
+
+    raise ValueError(f'{value} can not be converted to timestamp')
 
 
 #####################################################################

--- a/lib/item/item.py
+++ b/lib/item/item.py
@@ -22,7 +22,7 @@
 #  along with SmartHomeNG. If not, see <http://www.gnu.org/licenses/>.
 #########################################################################
 
-from __future__ import annotations
+from __future__ import annotations  # noqa: I001
 from typing import Any
 
 import logging
@@ -37,6 +37,7 @@ import re
 import inspect
 
 import time             # for calls to time in eval
+import dateutil.tz as _tz
 
 from lib.shtime import Shtime
 import lib.env
@@ -59,7 +60,8 @@ from lib.utils import Utils
 from .property import Property
 from .helpers import (  # noqa - cast_foo methods are accessed via globals()
     cast_str, cast_list, cast_dict, cast_foo, cast_bool, cast_scene, cast_num,
-    split_duration_value_string, cache_read, cache_write, fadejob)
+    split_duration_value_string, cache_read, cache_write, fadejob,
+    cast_timestamp, cast_datetime)
 
 _items_instance = None
 
@@ -377,7 +379,7 @@ class Item():
         setattr(self, '_type', dict(config.items()).get(KEY_TYPE))
         if self._type is None:
             self._type = FOO  # Every item has a type, type is FOO, if not defined in item
-        # __defaults = {'num': 0, 'str': '', 'bool': False, 'list': [], 'dict': {}, 'foo': None, 'scene': 0}
+        # __defaults = {'num': 0, 'str': '', 'bool': False, 'list': [], 'dict': {}, 'foo': None, 'scene': 0, 'timestamp': 0}
         if self._type not in ITEM_DEFAULTS:
             logger.error(f"Item {self._path}: type '{self._type}' unknown. Please use one of: {', '.join(list(ITEM_DEFAULTS.keys()))}.")
             raise AttributeError
@@ -588,7 +590,6 @@ class Item():
         #############################################################
         # Value
         #############################################################
-        initial_value = False
         if self._value is None:
             initial_value = False
             self._value = ITEM_DEFAULTS[self._type]
@@ -597,8 +598,7 @@ class Item():
         try:
             self._value = self.cast(self._value)
             if initial_value:
-                self.__changed_by = 'Init:Initial_Value'
-                self.__updated_by = self.__changed_by
+                self.__updated_by = self.__changed_by = 'Init:Initial_Value'
                 # Write item value to log, if Item has attribute log_change set
                 self._log_on_change(self._value, 'Init', 'Initial_Value', None)
         except Exception:
@@ -645,7 +645,7 @@ class Item():
                 logger.notice(f"Created cache for item {self._cache} in file {self._cache}")
 
         #############################################################
-        # add list/dict methods
+        # add list/dict/datetime methods
         #############################################################
         if self._type in ['list', 'dict']:
             # get proper subclass - ListHandler / DictHandler
@@ -654,6 +654,12 @@ class Item():
             obj = type_class(item=self)
             # create item member <item>.list / <item>.dict
             setattr(self, self._type, obj)
+        if self._type == 'timestamp':
+            setattr(self, 'as_dt', self.__ts_as_dt)
+            setattr(self, 'as_str', self.__ts_as_str)
+        if self._type == 'datetime':
+            setattr(self, 'as_ts', self.__dt_as_ts)
+            setattr(self, 'as_str', self.__dt_as_str)
 
         #############################################################
         # Plugins
@@ -790,6 +796,7 @@ class Item():
         # casting of value, if compat = latest
         if compat == ATTRIB_COMPAT_LATEST:
             if self._type is not None:
+# TODO: this should have been set as self._cast...?
                 mycast = globals()['cast_' + self._type]
                 try:
                     value = mycast(value)
@@ -1631,6 +1638,37 @@ class Item():
             logger.warning(msg)
             raise TypeError(msg)  # needed additionally to show error message in eval syntax checker
 
+#
+# helper methods for timestamp item output
+#
+
+    def __ts_as_dt(self, tz=None) -> datetime.datetime:
+        if tz is None:
+            tz = self.shtime.tzinfo()  # type: ignore : shtime is set dynamically
+        return datetime.datetime.fromtimestamp(self._value, tz)  # type: ignore : method is only made "public" if type matches
+
+    def __ts_as_str(self, format=None, tz=None) -> str:
+        dt = self.__ts_as_dt(tz)
+        if not format:
+            return str(dt)
+        return dt.strftime(format)
+
+#
+# helper methods for datetime item output
+#
+
+    def __dt_as_ts(self) -> float:
+        return self._value.timestamp()  # type: ignore : self._value is set dynamically
+
+
+    def __dt_as_str(self, format=None) -> str:
+        if not format:
+            return str(self._value)
+        return self._value.strftime(format)  # type: ignore : self.value is set dynamically
+
+#
+#
+#
 
     def get_class_from_frame(self, fr):
         # https://stackoverflow.com/questions/2203424/python-how-to-retrieve-class-information-from-a-frame-object
@@ -2141,7 +2179,7 @@ class Item():
                     sh = self._sh
                     shtime = self.shtime
                     items = _items_instance
-                    import math
+                    import math  # noqa: I001
                     import lib.userfunctions as uf
                     env = lib.env
 

--- a/lib/shtime.py
+++ b/lib/shtime.py
@@ -174,9 +174,16 @@ class Shtime:
         """
 
         if self._tzinfo is None:
-            self._tzinfo = tz.gettz()
+            self._tzinfo = self._tzinfo
         # tz aware 'localtime'
         return datetime.datetime.now(self._tzinfo)
+
+
+    def ts(self, dt, tz=None):
+        """ Return dt as posix timestamp, possibly with different local tz """
+        if tz is None:
+            tz = self._tzinfo
+        return dt.replace(tzinfo=tz).timestamp()
 
 
     def tz(self):

--- a/modules/admin/itemdata.py
+++ b/modules/admin/itemdata.py
@@ -317,7 +317,7 @@ class ItemData:
 
 
             item_data.append(data_dict)
-            return json.dumps(item_data)
+            return json.dumps(item_data, default=str)
         else:
             self.logger.error("Requested item '{}' is None, check if item really exists.".format(item_path))
             return

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -30,6 +30,7 @@ import lib.plugin
 import lib.item
 from lib.model.smartplugin import SmartPlugin
 import threading
+from datetime import datetime as dt, timezone as tz
 
 from lib.constants import YAML_FILE
 
@@ -344,6 +345,17 @@ class TestItem(unittest.TestCase):
         except AttributeError:
             return lib.item._cast_bool(value)
 
+    def item_cast_timestamp(self, value):
+        try:
+            return lib.item.helpers.cast_timestamp(value)
+        except AttributeError:
+            return lib.item._cast_timestamp(value)    
+
+    def item_cast_datetime(self, value):
+        try:
+            return lib.item.helpers.cast_datetime(value)
+        except AttributeError:
+            return lib.item._cast_datetime(value)    
 
     def test_cast_str(self):
         #with self.assertRaises(ValueError):
@@ -392,6 +404,29 @@ class TestItem(unittest.TestCase):
         self.assertEqual(1.2, self.item_cast_num(float(1.2)))
         with self.assertRaises(ValueError):
             self.assertEqual(10, self.item_cast_num(' 0x0a'))
+
+    def test_cast_timestamp(self):
+        d = dt.now(tz.utc)
+        ts = d.timestamp()
+        ds = d.isoformat()
+
+        self.assertEqual(ts, self.item_cast_timestamp(ts))
+        self.assertEqual(int(ts), self.item_cast_timestamp(int(ts)))
+        self.assertEqual(ts, self.item_cast_timestamp(ds))
+        self.assertEqual(ts, self.item_cast_timestamp(d))
+        with self.assertRaises(ValueError):
+            self.assertEqual(ts, self.item_cast_timestamp(f' {ds}'))        
+
+    def test_cast_datetime(self):
+        d = dt.now(tz.utc)
+        ts = d.timestamp()
+        ds = d.isoformat()
+
+        self.assertEqual(d, self.item_cast_datetime(d))
+        self.assertEqual(d, self.item_cast_datetime(ts))
+        self.assertEqual(d, self.item_cast_datetime(ds))
+        with self.assertRaises(ValueError):
+            self.assertEqual(d, self.item_cast_datetime(f' {ds}'))        
 
     def test_cast_bool(self):
         """


### PR DESCRIPTION
Adds item types `datetime` (datetime.datetime object) and `timestamp` (POSIX timestamp implemented as float).

datetime items have additional methods `item.as_ts()` and `item.as_str(format)`, which output timestamp or text respectively. `format` parameter is optional (as for strftime), None means ISO format.

timestamp items have additional methods `item.as_dt()` and `item.as_str(format)`, which output datetime or text respectively. `format` parameter is optional (as for strftime), None means ISO format.

As of now, both types can not be edited in AdminUI as they are not yet implemented there; both will be displayed correctly. I modified the Admin-Module as to enable transferring datetime as JSON (json.encode added the default=str parameter). This might have to be revisited later, as of now, I see no problems. 

Feel free to try out and find errors ;) most probably in timezone conversion, though I tried to work with tz-aware datetimes everywhere and get the timezone from shtime.tzinfo().

Oh, and I used `datetime` and `timestamp` as item type codes; but I'm thinking of changing those to `dt` and `ts` respectively. Any opinions on this?

closes #421 