### PR TITLE
lib.item: partial struct inclusion — import sub-trees of a struct by …

### DIFF
--- a/doc/user/source/konfiguration/item_structs.rst
+++ b/doc/user/source/konfiguration/item_structs.rst
@@ -368,6 +368,73 @@ werden die Listen zusammengefügt. Die Reihenfolge der Listeneinträge wird durc
 Attributdefinitionen eingelesen werden.
 
 
+Teilweises Einbinden von structs (partial struct inclusion) :redsup:`new`
+=========================================================================
+
+Normalerweise wird beim Verwenden des **struct**-Attributs die gesamte Struktur des Templates eingebunden.
+Es ist jedoch möglich, nur einen Teil einer Struktur einzubinden, indem der Pfad zum gewünschten Teilbaum
+angegeben wird.
+
+Wenn z.B. das Plugin **kodi** eine Struktur **master** mit den Unterpunkten **foo**, **bar** und **baz** definiert,
+kann mit:
+
+.. code-block:: yaml
+
+    myitem:
+        struct: kodi.master
+
+die gesamte Struktur eingebunden werden. Um nur den Teilbaum **bar** einzubinden, schreibt man:
+
+.. code-block:: yaml
+
+    myitem:
+        struct: kodi.master.bar
+
+Es lassen sich auch tiefere Pfade referenzieren:
+
+.. code-block:: yaml
+
+    myitem:
+        struct: kodi.master.bar.child1
+
+Dabei gilt: Es wird der **längste** registrierte Strukturname als Prefix gesucht. Ein direkt registrierter
+Strukturname (z.B. wenn ``kodi.master.bar`` selbst als eigenständige Struktur registriert wäre) hat immer
+Vorrang vor der Teilpfad-Auflösung.
+
+Das Einbinden von Teilstrukturen funktioniert auch in Strukturdefinitionen selbst (nested structs), nicht
+nur in Item-Definitionen:
+
+.. code-block:: yaml
+
+    # etc/structs/mydevice.yaml
+    mydevice:
+        struct: kodi.master.bar   # nur den 'bar'-Teilbaum von kodi.master einbinden
+
+Fehlermeldungen
+~~~~~~~~~~~~~~~
+
+Wenn ein Teilpfad angegeben wird, der nicht existiert, gibt SmartHomeNG eine aussagekräftige Fehlermeldung aus:
+
+* *struct 'kodi.master' found but sub-item 'bar' does not exist within it* — der Pfad existiert nicht im
+  Strukturbaum.
+* *struct 'kodi.master' found but 'bar.type' is a scalar value ('num'), not a sub-item tree* — der Pfad
+  verweist auf ein skalares Attribut (z.B. ``type: num``), nicht auf einen Teilbaum.
+* *struct 'kodi.master.bar' not found* — kein registrierter Strukturname passt als Präfix (Struktur komplett
+  unbekannt).
+
+.. note::
+
+    Mit ``struct: kodi.master.bar`` wird der Inhalt des Teilbaums **bar** direkt unter dem referenzierenden
+    Item eingefügt — **nicht** als Kind-Item namens **bar**. Wenn das gewünschte Ergebnis ein Kind-Item
+    namens **bar** sein soll, muss die Item-Definition entsprechend strukturiert werden:
+
+    .. code-block:: yaml
+
+        myitem:
+            bar:
+                struct: kodi.master.bar
+
+
 Verwendung mehrerer Definitionsdateien
 ======================================
 

--- a/doc/user/source/referenz/items/standard_attribute/struct.rst
+++ b/doc/user/source/referenz/items/standard_attribute/struct.rst
@@ -8,13 +8,30 @@
 .. index:: Item-Struktur Template
 
 .. role:: bluesup
-.. role:: redesup
+.. role:: redsup
 
 struct
 ------
 
-Über das Attribut **struct** werden vordefinierte Item-Stukturen in den Item-Treee eingefügt. Dazu muss bei dem Item an dessen Stelle der Teilbaum
-eingefügt werden soll, der Name des Templates (der Item-Struktur) angegeben werden.
+Über das Attribut **struct** werden vordefinierte Item-Strukturen in den Item-Tree eingefügt. Dazu muss bei dem Item,
+an dessen Stelle der Teilbaum eingefügt werden soll, der Name des Templates (der Item-Struktur) angegeben werden.
+
+**Vollständige Struktur einbinden:**
+
+.. code-block:: yaml
+
+    myitem:
+        struct: kodi.master          # fügt die gesamte Struktur 'kodi.master' ein
+
+**Nur einen Teilbaum einbinden** :redsup:`new`:
+
+Es kann auch nur ein Teil einer Struktur eingebunden werden, indem der Pfad zum gewünschten Teilbaum angegeben wird:
+
+.. code-block:: yaml
+
+    myitem:
+        struct: kodi.master.bar      # fügt nur den 'bar'-Teilbaum von 'kodi.master' ein
+        struct: kodi.master.bar.child1  # fügt einen noch tieferen Teilbaum ein
 
 Weitere Informationen zu **structs** sind auf der Seite :doc:`Konfiguration/structs </konfiguration/item_structs>` und :doc:`Konfiguration/Konfigurationsdateien/struct.yaml </konfiguration/konfigurationsdateien/struct>`)
 zu finden.

--- a/lib/config.py
+++ b/lib/config.py
@@ -355,6 +355,74 @@ def nested_get(input_dict, path):
     return internal_dict_value
 
 
+def _resolve_partial_struct(struct_name, struct_dict):
+    """
+    Attempt to resolve *struct_name* as a dotted sub-path into a registered struct.
+
+    This enables partial struct inclusion: instead of importing an entire struct,
+    only a named sub-tree of that struct is inserted into the item tree.
+
+    Example
+    -------
+    If the struct ``kodi.master`` is defined and contains sub-items ``foo``, ``bar``
+    and ``baz``, a user can write::
+
+        myitem:
+            struct: kodi.master.bar
+
+    which inserts only the ``bar`` sub-tree of ``kodi.master`` rather than the
+    whole struct.  Deeper paths (e.g. ``kodi.master.bar.child1``) are equally
+    supported.
+
+    Disambiguation
+    --------------
+    The algorithm tries the **longest possible registered prefix first**.  A struct
+    literally named ``kodi.master.bar`` (if such a thing were ever registered) takes
+    precedence over the partial-path interpretation of the same string, because the
+    direct ``struct_dict.get()`` call in the caller is attempted before this helper
+    is invoked.
+
+    Return value
+    ------------
+    Returns a 3-tuple ``(result, matched_struct_name, sub_path)`` where:
+
+    * ``(sub_tree, name, path)``  — the sub-path was found and points to a dict node.
+    * ``(None, name, path)``      — a registered struct prefix was found, but the
+      sub-path is absent or leads to a scalar value (not a dict).
+    * ``(None, None, None)``      — no registered struct matches any prefix at all.
+
+    :param struct_name:  Dotted name to resolve (e.g. ``'kodi.master.bar'``)
+    :param struct_dict:  Dict of all registered structs keyed by their full name
+    :type struct_name:   str
+    :type struct_dict:   dict
+    :return:             3-tuple (sub_tree_or_None, matched_name_or_None, sub_path_or_None)
+    :rtype:              tuple
+    """
+    parts = struct_name.split('.')
+    # Iterate from longest possible prefix down to shortest (greedy, longest wins)
+    for i in range(len(parts) - 1, 0, -1):
+        candidate_name = '.'.join(parts[:i])
+        candidate = struct_dict.get(candidate_name, None)
+        if candidate is None:
+            continue
+        # A registered struct was found — navigate the remaining sub-path key by key
+        sub_path = '.'.join(parts[i:])
+        sub_tree = candidate
+        for part in parts[i:]:
+            if not isinstance(sub_tree, dict):
+                sub_tree = None    # arrived at a scalar before exhausting the path
+                break
+            sub_tree = sub_tree.get(part, None)
+            if sub_tree is None:
+                break              # key not present at this level
+        # Return hit information regardless of sub-path outcome so the caller can
+        # emit a precise error message even when navigation fails
+        return (sub_tree if isinstance(sub_tree, dict) else None,
+                candidate_name,
+                sub_path)
+    return None, None, None
+
+
 def nested_put(output_dict, path, value, add=None):
     """
 
@@ -537,47 +605,96 @@ def set_attr_for_subtree(subtree, attr, value, indent=0):
 
 def add_struct_to_item_template(path, struct_name, template, struct_dict, instance, struct_attrs=None):
     """
-    Add the referenced struct to the items_template subtree
+    Add the referenced struct to the items_template subtree.
 
-    :param path: Path of the item which references a struct (template)
-    :param struct_name: Name of the to use for the item
-    :param template: Template dict to be merged into the item tree
-    :param struct_dict: dict with all defined structs (from /etc/structs.yaml and from loaded plugins)
-    :param instance: For multi instance plugins: instance for which the items work (is derived from item with struct attribute)
-    :param struct_attrs: OrderedDict with attributes to set for every item
+    Supports both full struct names and partial sub-path references:
 
-    :return:
+    * ``struct: kodi.master``       — imports the whole ``kodi.master`` struct (existing behaviour)
+    * ``struct: kodi.master.bar``   — imports only the ``bar`` sub-tree of ``kodi.master``
+    * ``struct: kodi.master.bar.child1`` — imports a deeper sub-tree
+
+    When a partial path is used, the algorithm first checks whether a struct with
+    the exact name exists (direct lookup).  Only if that fails, it tries to find the
+    longest registered struct name that is a prefix of the given name, then navigates
+    into the struct tree along the remaining path components.  This means that a
+    struct literally named ``kodi.master.bar`` is never shadowed by the partial-path
+    mechanism.
+
+    Errors are reported with context-specific messages:
+
+    * *struct not found* — no registered struct name matches any prefix of the given name.
+    * *sub-item not found* — a registered struct was found but the sub-path does not exist.
+    * *not a sub-item tree* — the sub-path resolves to a scalar attribute, not an item tree.
+
+    :param path:         Path of the item which references a struct (template)
+    :param struct_name:  Name (or partial path) of the struct to use for the item
+    :param template:     Template dict to be merged into the item tree
+    :param struct_dict:  Dict with all defined structs (from etc/structs/ and loaded plugins)
+    :param instance:     For multi-instance plugins: instance the items belong to
+    :param struct_attrs: OrderedDict with attributes to propagate to every item in the struct
+    :type path:          str
+    :type struct_name:   str
+    :type template:      OrderedDict
+    :type struct_dict:   dict
+    :type instance:      str
+    :type struct_attrs:  OrderedDict | None
     """
     logger.info(f"add_struct_to_item_template: path (parent)={path}, struct_name={struct_name}, template={dict(template)}")
     struct = struct_dict.get(struct_name, None)
-    if struct is None:
-        # no struct/template with this name
-        nf = collections.OrderedDict()
-        nf['name'] = "ERROR: struct '" + struct_name + "' not found!"
-        nested_put(template, path, nf)
-        logger.error(f"add_struct_to_item_template: Struct definition for '{struct_name}' not found (referenced in item {path})")
-    else:
-        # add struct/template to temporary item(template) tree
-        #logger.debug("- add_struct_to_item_template: struct_dict = {}".format(dict(struct_dict)))
-        #logger.debug("- add_struct_to_item_template: struct '{}' to item '{}'".format(struct_name, path))
-        tmp_struct = copy.deepcopy(struct)
-        if '__struct_is_optional' in tmp_struct:
-            del tmp_struct['__struct_is_optional']
-        if 'name' in tmp_struct and isinstance(struct["name"], str):
-            from lib.smarthome import SmartHome
-            _sh = SmartHome.get_instance()
-            if Utils.to_bool(getattr(_sh, '_struct_strip_name', False)):
-                del tmp_struct['name']
-                logger.debug(f'removed "name" attribute from struct {struct_name}')
-        nested_put(template, path, tmp_struct, add=struct_attrs)
 
-        if instance != '' or True:
-            # add instance to items added by template struct
-            subtree = nested_get(template, path)
-            # logger.info(f"add_struct_to_item_template: Adding 'instance: {instance}' to template for subtree '{path}'")
-            # add instance name to attributes which carry '@instance'
-            logger.debug(f"- add_struct_to_item_template: Add instance={instance} to subtree={subtree}")
-            replace_struct_instance(path, subtree, instance)
+    if struct is None:
+        # Try to resolve as a partial sub-path of a registered struct
+        sub_tree, matched_name, sub_path = _resolve_partial_struct(struct_name, struct_dict)
+        if sub_tree is not None:
+            logger.info(f"add_struct_to_item_template: '{struct_name}' resolved as "
+                        f"sub-path '{sub_path}' of struct '{matched_name}'")
+            struct = sub_tree
+        elif matched_name is not None:
+            # A registered struct was found but the sub-path is missing or scalar
+            raw = nested_get(struct_dict.get(matched_name, {}), sub_path)
+            if raw is None:
+                err = (f"struct '{matched_name}' found but sub-item '{sub_path}' "
+                       f"does not exist within it")
+            else:
+                err = (f"struct '{matched_name}' found but '{sub_path}' is a scalar "
+                       f"value ({repr(raw)}), not a sub-item tree")
+            nf = collections.OrderedDict()
+            nf['name'] = f"ERROR: {err}"
+            nested_put(template, path, nf)
+            logger.error(f"add_struct_to_item_template: {err} (referenced in item '{path}')")
+            logger.info(f"- add_struct_to_item_template: - after add - template={dict(template)}")
+            return
+        else:
+            # No registered struct matches any prefix — original "not found" error
+            nf = collections.OrderedDict()
+            nf['name'] = "ERROR: struct '" + struct_name + "' not found!"
+            nested_put(template, path, nf)
+            logger.error(f"add_struct_to_item_template: Struct definition for '{struct_name}' not found (referenced in item '{path}')")
+            logger.info(f"- add_struct_to_item_template: - after add - template={dict(template)}")
+            return
+
+    # --- struct resolved (either direct or via partial sub-path) ---
+    # add struct/template to temporary item(template) tree
+    #logger.debug("- add_struct_to_item_template: struct_dict = {}".format(dict(struct_dict)))
+    #logger.debug("- add_struct_to_item_template: struct '{}' to item '{}'".format(struct_name, path))
+    tmp_struct = copy.deepcopy(struct)
+    if '__struct_is_optional' in tmp_struct:
+        del tmp_struct['__struct_is_optional']
+    if 'name' in tmp_struct and isinstance(tmp_struct.get("name"), str):
+        from lib.smarthome import SmartHome
+        _sh = SmartHome.get_instance()
+        if Utils.to_bool(getattr(_sh, '_struct_strip_name', False)):
+            del tmp_struct['name']
+            logger.debug(f'removed "name" attribute from struct {struct_name}')
+    nested_put(template, path, tmp_struct, add=struct_attrs)
+
+    if instance != '' or True:
+        # add instance to items added by template struct
+        subtree = nested_get(template, path)
+        # logger.info(f"add_struct_to_item_template: Adding 'instance: {instance}' to template for subtree '{path}'")
+        # add instance name to attributes which carry '@instance'
+        logger.debug(f"- add_struct_to_item_template: Add instance={instance} to subtree={subtree}")
+        replace_struct_instance(path, subtree, instance)
 
     logger.info(f"- add_struct_to_item_template: - after add - template={dict(template)}")
     return

--- a/lib/item/structs.py
+++ b/lib/item/structs.py
@@ -384,38 +384,139 @@ class Structs():
         return new_struct
 
 
+    def _resolve_partial_struct_def(self, substruct_name):
+        """
+        Attempt to resolve *substruct_name* as a dotted sub-path into a registered
+        struct definition (used during struct-within-struct expansion at startup).
+
+        This is the struct-definition-time counterpart of ``_resolve_partial_struct``
+        in ``lib/config.py``.  Both implement the same greedy-prefix algorithm; this
+        version operates on ``self._struct_definitions`` rather than the item-loading
+        ``struct_dict``.
+
+        Returns a 3-tuple ``(result, matched_name, sub_path)``:
+
+        * ``(sub_tree, name, path)``  — sub-path found and points to a dict node.
+        * ``(None, name, path)``      — a registered prefix was found but the sub-path
+          is absent or leads to a scalar value.
+        * ``(None, None, None)``      — no registered struct matches any prefix.
+
+        :param substruct_name: Dotted name to resolve (e.g. ``'kodi.master.bar'``)
+        :type substruct_name:  str
+        :return:               3-tuple (sub_tree_or_None, matched_name_or_None, sub_path_or_None)
+        :rtype:                tuple
+        """
+        parts = substruct_name.split('.')
+        for i in range(len(parts) - 1, 0, -1):
+            candidate_name = '.'.join(parts[:i])
+            candidate = self._struct_definitions.get(candidate_name, None)
+            if candidate is None:
+                continue
+            sub_path = '.'.join(parts[i:])
+            sub_tree = candidate
+            for part in parts[i:]:
+                if not isinstance(sub_tree, dict):
+                    sub_tree = None
+                    break
+                sub_tree = sub_tree.get(part, None)
+                if sub_tree is None:
+                    break
+            return (sub_tree if isinstance(sub_tree, dict) else None,
+                    candidate_name,
+                    sub_path)
+        return None, None, None
+
+
     def merge_substruct_to_struct(self, main_struct, substruct_name, main_struct_name='?', key_prefix=''):
         """
+        Merge a referenced struct (or a partial sub-path of a struct) into *main_struct*.
 
-        :param main_struct:
-        :param substruct_name:
-        :param main_struct_name:
-        :return:
+        Supports partial sub-path references in addition to full struct names, allowing
+        a struct definition to embed only part of another struct:
+
+        .. code-block:: yaml
+
+            # etc/structs/mydevice.yaml
+            mydevice:
+                struct: kodi.master.bar   # only the 'bar' sub-tree of kodi.master
+
+        Resolution order:
+
+        1. Exact match — ``substruct_name`` is looked up directly in ``_struct_definitions``.
+        2. Partial match — the longest registered struct name that is a prefix of
+           ``substruct_name`` is found, then the remaining path is navigated within
+           that struct's tree.
+
+        Errors are reported with context-specific messages:
+
+        * *struct not found* — no prefix matches any registered struct name.
+        * *sub-item not found* — a registered prefix was found but the sub-path is absent.
+        * *not a sub-item tree* — the sub-path resolves to a scalar, not a dict node.
+
+        :param main_struct:       Struct being built (modified in place)
+        :param substruct_name:    Name (or partial path) of the struct to merge in
+        :param main_struct_name:  Name of *main_struct* (for error messages)
+        :param key_prefix:        Prefix for relative struct references starting with '.'
+        :type main_struct:        OrderedDict
+        :type substruct_name:     str
+        :type main_struct_name:   str
+        :type key_prefix:         str
         """
-
         self.logger.dbgmed(f"merge_substruct_to_struct: substruct_name='{substruct_name}' -> main_struct='{main_struct_name}'")
         if substruct_name.startswith('.'):
-            # referencing a struct from same definition file
+            # referencing a struct from the same definition file
             substruct_name = key_prefix + substruct_name
+
         substruct = self._struct_definitions.get(substruct_name, None)
+
         if substruct is None:
-            self.logger.error(f"struct '{substruct_name}' not found in structdefinitions (used in struct '{main_struct_name}') - key_prefix={key_prefix}")
-        else:
-            # merge the sub-struct to the main-struct key by key
-            for key in substruct:
-                if key == '__struct_is_optional':
-                    continue
-                if main_struct.get(key, None) is None:
-                    self.logger.dbglow(f" - add key='{key}', value='{substruct[key]}' -> new_struct='{dict(main_struct)}'")
-                    main_struct[key] = copy.deepcopy(substruct[key])
-                elif isinstance(main_struct.get(key, None), dict):
-                    self.logger.dbglow(f" - merge key='{key}', value='{substruct[key]}' -> new_struct='{dict(main_struct)}'")
-                    self.merge(substruct[key], main_struct[key], substruct_name + '.' + key, main_struct_name + '.' + key)
-                elif isinstance(main_struct.get(key, None), list) or isinstance(substruct.get(key, None), list):
-                    self.logger.dbglow(f" - merge list(s) key='{key}', value='{substruct[key]}' -> new_struct='{dict(main_struct)}'")
-                    main_struct[key] = self.merge_structlists(main_struct[key], substruct[key], key)
+            # Try partial sub-path resolution
+            sub_tree, matched_name, sub_path = self._resolve_partial_struct_def(substruct_name)
+            if sub_tree is not None:
+                self.logger.info(f"merge_substruct_to_struct: '{substruct_name}' resolved as "
+                                 f"sub-path '{sub_path}' of struct '{matched_name}'")
+                substruct = sub_tree
+            elif matched_name is not None:
+                # Struct found but sub-path missing or scalar
+                raw = self._struct_definitions.get(matched_name, {})
+                # navigate manually to get the raw value for the error message
+                for part in sub_path.split('.'):
+                    if isinstance(raw, dict):
+                        raw = raw.get(part, None)
+                    else:
+                        raw = None
+                        break
+                if raw is None:
+                    self.logger.error(
+                        f"struct '{matched_name}' found but sub-item '{sub_path}' does not exist "
+                        f"(used in struct '{main_struct_name}') - key_prefix={key_prefix}")
                 else:
-                    self.logger.dbglow(f" - key='{key}', value '{substruct[key]}' is ignored'")
+                    self.logger.error(
+                        f"struct '{matched_name}' found but '{sub_path}' is a scalar value "
+                        f"({repr(raw)}), not a sub-item tree "
+                        f"(used in struct '{main_struct_name}') - key_prefix={key_prefix}")
+                return
+            else:
+                self.logger.error(
+                    f"struct '{substruct_name}' not found in struct definitions "
+                    f"(used in struct '{main_struct_name}') - key_prefix={key_prefix}")
+                return
+
+        # merge the sub-struct into the main struct key by key
+        for key in substruct:
+            if key == '__struct_is_optional':
+                continue
+            if main_struct.get(key, None) is None:
+                self.logger.dbglow(f" - add key='{key}', value='{substruct[key]}' -> new_struct='{dict(main_struct)}'")
+                main_struct[key] = copy.deepcopy(substruct[key])
+            elif isinstance(main_struct.get(key, None), dict):
+                self.logger.dbglow(f" - merge key='{key}', value='{substruct[key]}' -> new_struct='{dict(main_struct)}'")
+                self.merge(substruct[key], main_struct[key], substruct_name + '.' + key, main_struct_name + '.' + key)
+            elif isinstance(main_struct.get(key, None), list) or isinstance(substruct.get(key, None), list):
+                self.logger.dbglow(f" - merge list(s) key='{key}', value='{substruct[key]}' -> new_struct='{dict(main_struct)}'")
+                main_struct[key] = self.merge_structlists(main_struct[key], substruct[key], key)
+            else:
+                self.logger.dbglow(f" - key='{key}', value '{substruct[key]}' is ignored'")
 
         return
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -1,0 +1,509 @@
+"""
+Tests for partial struct inclusion (struct sub-path resolution).
+
+Covers:
+  - _resolve_partial_struct()               in lib/config.py
+  - add_struct_to_item_template()           in lib/config.py
+  - Structs._resolve_partial_struct_def()   in lib/item/structs.py
+  - Structs.merge_substruct_to_struct()     in lib/item/structs.py
+
+Test scenarios
+--------------
+Successful partial resolution
+  Single-level sub-path:   'plugin.master.bar'
+  Multi-level sub-path:    'plugin.master.bar.child1'
+  User-defined prefix:     'my.custom.sensor.temperature'
+
+Error cases
+  Sub-item not found:      'plugin.master.nonexistent'
+  Sub-path is a scalar:    'plugin.master.bar.type'   (type='str' is scalar)
+  No struct matches:       'completely.unknown.path'
+
+Longest-match-first concurrency
+  Both 'plugin.master' and 'plugin.master.bar' are registered.
+  'plugin.master.bar.direct_child' must resolve against 'plugin.master.bar'
+  (longer prefix), NOT against 'plugin.master' with sub-path 'bar.direct_child'.
+"""
+
+import collections
+import logging
+import unittest
+
+from lib.config import _resolve_partial_struct, add_struct_to_item_template
+from lib.item.structs import Structs
+
+from . import common  # noqa: F401  (ensures sys.path includes the project root)
+
+
+# ---------------------------------------------------------------------------
+# Register SmartHomeNG custom log levels so Structs' logger calls don't fail.
+# lib/log.py normally does this at startup; we replicate the minimum needed here.
+# ---------------------------------------------------------------------------
+
+def _ensure_shng_loglevels():
+    for name, value in [('NOTICE', 29), ('DBGHIGH', 13), ('DBGMED', 12),
+                        ('DBGLOW', 11), ('DEVELOP', 9)]:
+        if not hasattr(logging.getLoggerClass(), name.lower()):
+            def _make_method(v):
+                def logForLevel(self, message, *args, **kwargs):
+                    if self.isEnabledFor(v):
+                        self._log(v, message, args, **kwargs)
+                return logForLevel
+            logging.addLevelName(value, name)
+            setattr(logging, name, value)
+            setattr(logging.getLoggerClass(), name.lower(), _make_method(value))
+
+
+_ensure_shng_loglevels()
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _make_base_struct_dict():
+    """
+    Base fixture with two registered top-level structs.
+
+    plugin.master:
+        foo      — simple dict (type: num)
+        bar      — dict with child1 (bool) and child2 (num + unit); also has scalar 'type'
+        baz      — simple dict (type: list)
+
+    my.custom.sensor:
+        temperature  — dict with type, unit, and sub-item 'reading'
+        humidity     — simple dict
+
+    No intermediate registrations — partial path resolution is the only way to
+    reach sub-trees of these structs.
+    """
+    return {
+        'plugin.master': collections.OrderedDict([
+            ('foo', collections.OrderedDict([('type', 'num')])),
+            ('bar', collections.OrderedDict([
+                ('type', 'str'),
+                ('child1', collections.OrderedDict([('type', 'bool')])),
+                ('child2', collections.OrderedDict([('type', 'num'), ('unit', 'km')])),
+            ])),
+            ('baz', collections.OrderedDict([('type', 'list')])),
+        ]),
+        'my.custom.sensor': collections.OrderedDict([
+            ('temperature', collections.OrderedDict([
+                ('type', 'num'),
+                ('unit', '°C'),
+                ('reading', collections.OrderedDict([('type', 'num'), ('precision', '2')])),
+            ])),
+            ('humidity', collections.OrderedDict([('type', 'num'), ('unit', '%')])),
+        ]),
+    }
+
+
+def _make_concurrency_struct_dict():
+    """
+    Extended fixture: adds 'plugin.master.bar' as a separately registered struct
+    alongside 'plugin.master'.  Used exclusively for the longest-match-first tests.
+
+    plugin.master.bar  (separately registered):
+        type          — scalar 'foo_type'
+        direct_child  — dict with special: yes
+
+    With this setup, 'plugin.master.bar.direct_child' must resolve against
+    'plugin.master.bar' (the longer registered prefix).
+    """
+    d = _make_base_struct_dict()
+    d['plugin.master.bar'] = collections.OrderedDict([
+        ('type', 'foo_type'),
+        ('direct_child', collections.OrderedDict([('type', 'str'), ('special', 'yes')])),
+    ])
+    return d
+
+
+# ===========================================================================
+# Tests for lib.config._resolve_partial_struct
+# ===========================================================================
+
+class TestResolvePartialStruct(unittest.TestCase):
+    """Unit tests for the _resolve_partial_struct() helper in lib/config.py."""
+
+    def setUp(self):
+        self.sd = _make_base_struct_dict()
+        self.sd_conc = _make_concurrency_struct_dict()
+
+    # --- successful resolution ---
+
+    def test_single_level_subpath(self):
+        """'plugin.master.bar' → sub-tree of 'bar' from 'plugin.master'."""
+        sub_tree, matched, sub_path = _resolve_partial_struct('plugin.master.bar', self.sd)
+        self.assertIsNotNone(sub_tree, "Expected a sub-tree to be returned")
+        self.assertIsInstance(sub_tree, dict)
+        self.assertEqual(matched, 'plugin.master')
+        self.assertEqual(sub_path, 'bar')
+        self.assertIn('child1', sub_tree)
+        self.assertIn('child2', sub_tree)
+
+    def test_multi_level_subpath(self):
+        """'plugin.master.bar.child1' → sub-tree two levels deep."""
+        sub_tree, matched, sub_path = _resolve_partial_struct(
+            'plugin.master.bar.child1', self.sd)
+        self.assertIsNotNone(sub_tree)
+        self.assertIsInstance(sub_tree, dict)
+        self.assertEqual(matched, 'plugin.master')
+        self.assertEqual(sub_path, 'bar.child1')
+        self.assertEqual(sub_tree.get('type'), 'bool')
+
+    def test_user_defined_prefix_subpath(self):
+        """Three-segment prefix 'my.custom.sensor' plus one sub-path key."""
+        sub_tree, matched, sub_path = _resolve_partial_struct(
+            'my.custom.sensor.temperature', self.sd)
+        self.assertIsNotNone(sub_tree)
+        self.assertEqual(matched, 'my.custom.sensor')
+        self.assertEqual(sub_path, 'temperature')
+        self.assertEqual(sub_tree.get('unit'), '°C')
+
+    def test_three_level_subpath(self):
+        """'my.custom.sensor.temperature.reading' — four total segments."""
+        sub_tree, matched, sub_path = _resolve_partial_struct(
+            'my.custom.sensor.temperature.reading', self.sd)
+        self.assertIsNotNone(sub_tree)
+        self.assertEqual(matched, 'my.custom.sensor')
+        self.assertEqual(sub_path, 'temperature.reading')
+        self.assertEqual(sub_tree.get('precision'), '2')
+
+    # --- error cases ---
+
+    def test_subitem_not_found(self):
+        """Struct exists but sub-path key is absent → (None, name, path)."""
+        sub_tree, matched, sub_path = _resolve_partial_struct(
+            'plugin.master.nonexistent', self.sd)
+        self.assertIsNone(sub_tree)
+        self.assertEqual(matched, 'plugin.master')
+        self.assertEqual(sub_path, 'nonexistent')
+
+    def test_subpath_is_scalar(self):
+        """Sub-path navigates to a scalar value → (None, name, path)."""
+        # plugin.master.bar.type — 'type' inside 'bar' is a scalar string 'str'
+        sub_tree, matched, sub_path = _resolve_partial_struct(
+            'plugin.master.bar.type', self.sd)
+        self.assertIsNone(sub_tree)
+        self.assertEqual(matched, 'plugin.master')
+        self.assertEqual(sub_path, 'bar.type')
+
+    def test_subpath_intermediate_scalar(self):
+        """Path traversal hits a scalar at an intermediate step."""
+        # plugin.master.foo.type — 'foo' is a dict but 'foo.type' is scalar 'num'
+        sub_tree, matched, sub_path = _resolve_partial_struct(
+            'plugin.master.foo.type', self.sd)
+        self.assertIsNone(sub_tree)
+        self.assertEqual(matched, 'plugin.master')
+        self.assertEqual(sub_path, 'foo.type')
+
+    def test_no_matching_prefix(self):
+        """No registered struct matches any prefix → (None, None, None)."""
+        sub_tree, matched, sub_path = _resolve_partial_struct(
+            'completely.unknown.path', self.sd)
+        self.assertIsNone(sub_tree)
+        self.assertIsNone(matched)
+        self.assertIsNone(sub_path)
+
+    def test_single_segment_name(self):
+        """A name with no dot cannot have a prefix → (None, None, None)."""
+        sub_tree, matched, sub_path = _resolve_partial_struct('unknown', self.sd)
+        self.assertIsNone(sub_tree)
+        self.assertIsNone(matched)
+        self.assertIsNone(sub_path)
+
+    # --- longest-match-first concurrency ---
+
+    def test_longest_prefix_wins_over_shorter(self):
+        """
+        Both 'plugin.master.bar' and 'plugin.master' are registered.
+        'plugin.master.bar.direct_child' must resolve against 'plugin.master.bar'
+        (longer prefix), NOT against 'plugin.master' with sub-path 'bar.direct_child'.
+        """
+        sub_tree, matched, sub_path = _resolve_partial_struct(
+            'plugin.master.bar.direct_child', self.sd_conc)
+        self.assertIsNotNone(sub_tree)
+        self.assertEqual(matched, 'plugin.master.bar',
+                         "The longer registered prefix must win")
+        self.assertEqual(sub_path, 'direct_child')
+        self.assertIn('special', sub_tree)
+
+    def test_shorter_prefix_used_when_longer_doesnt_have_subpath(self):
+        """
+        When the longer prefix 'plugin.master.bar' doesn't have the requested
+        sub-path but the shorter prefix 'plugin.master' does, the shorter one
+        should NOT be tried — the greedy algorithm stops at the first prefix match.
+        This verifies that the algorithm returns NOT-FOUND rather than silently
+        falling back to an unexpected prefix.
+        """
+        # 'plugin.master.bar' exists but has no 'child1'; 'plugin.master' has bar.child1.
+        # The algorithm stops at 'plugin.master.bar' and reports not-found.
+        sub_tree, matched, sub_path = _resolve_partial_struct(
+            'plugin.master.bar.child1', self.sd_conc)
+        self.assertIsNone(sub_tree)
+        # matched should be 'plugin.master.bar' (longest registered prefix found)
+        self.assertEqual(matched, 'plugin.master.bar')
+        self.assertEqual(sub_path, 'child1')
+
+
+# ===========================================================================
+# Tests for lib.config.add_struct_to_item_template
+# ===========================================================================
+
+class TestAddStructToItemTemplate(unittest.TestCase):
+    """
+    Integration-level tests for add_struct_to_item_template() in lib/config.py.
+    Verifies template content and error item insertion.
+    """
+
+    def setUp(self):
+        self.sd = _make_base_struct_dict()
+        self.sd_conc = _make_concurrency_struct_dict()
+
+    def _run(self, struct_name, path='myitem', sd=None):
+        if sd is None:
+            sd = self.sd
+        template = collections.OrderedDict()
+        add_struct_to_item_template(path, struct_name, template, sd, '')
+        return template
+
+    # --- successful partial inclusion ---
+
+    def test_partial_inclusion_single_level(self):
+        """Only 'bar' from 'plugin.master' is merged; siblings 'foo' and 'baz' are absent."""
+        template = self._run('plugin.master.bar')
+        myitem = template['myitem']
+        self.assertIn('child1', myitem)
+        self.assertIn('child2', myitem)
+        self.assertNotIn('foo', myitem)
+        self.assertNotIn('baz', myitem)
+
+    def test_partial_inclusion_multi_level(self):
+        """Two-level sub-path: only the deepest requested dict is inserted."""
+        template = self._run('plugin.master.bar.child1')
+        myitem = template['myitem']
+        self.assertIn('type', myitem)
+        self.assertEqual(myitem['type'], 'bool')
+        self.assertNotIn('child2', myitem)
+
+    def test_partial_inclusion_user_struct(self):
+        """User-defined struct with three-segment prefix + one-level sub-path."""
+        template = self._run('my.custom.sensor.temperature', path='sensor')
+        self.assertIn('sensor', template)
+        self.assertEqual(template['sensor'].get('unit'), '°C')
+        self.assertIn('reading', template['sensor'])
+
+    def test_direct_struct_lookup_unaffected(self):
+        """Full struct name still works exactly as before."""
+        template = self._run('plugin.master')
+        myitem = template['myitem']
+        self.assertIn('foo', myitem)
+        self.assertIn('bar', myitem)
+        self.assertIn('baz', myitem)
+
+    # --- error cases produce an item with a descriptive name ---
+
+    def test_error_subitem_not_found(self):
+        """Struct found but sub-path missing → error item with context."""
+        template = self._run('plugin.master.nonexistent')
+        name_attr = template.get('myitem', {}).get('name', '')
+        self.assertIn('ERROR', name_attr)
+        self.assertIn('plugin.master', name_attr)
+        self.assertIn('nonexistent', name_attr)
+
+    def test_error_subpath_is_scalar(self):
+        """Struct found but sub-path is a scalar → error item mentions scalar."""
+        template = self._run('plugin.master.bar.type')
+        name_attr = template.get('myitem', {}).get('name', '')
+        self.assertIn('ERROR', name_attr)
+        self.assertIn('plugin.master', name_attr)
+        self.assertIn('bar.type', name_attr)
+
+    def test_error_struct_not_found(self):
+        """No matching prefix → original 'struct not found' error."""
+        template = self._run('completely.unknown')
+        name_attr = template.get('myitem', {}).get('name', '')
+        self.assertIn('ERROR', name_attr)
+        self.assertIn('completely.unknown', name_attr)
+
+    # --- longest-match-first concurrency ---
+
+    def test_longest_match_wins_in_template(self):
+        """
+        With both 'plugin.master.bar' and 'plugin.master' registered,
+        'plugin.master.bar.direct_child' must use 'plugin.master.bar' as base.
+        """
+        template = self._run('plugin.master.bar.direct_child', sd=self.sd_conc)
+        myitem = template['myitem']
+        self.assertIn('special', myitem)
+        self.assertNotIn('child2', myitem)
+
+    def test_direct_name_takes_precedence_over_partial(self):
+        """
+        'plugin.master.bar' is a registered struct name in the concurrency dict.
+        It must be returned directly (exact match), not resolved as a partial path
+        into 'plugin.master'.  Content must come from the separately-registered
+        struct, not from plugin.master's 'bar' sub-tree.
+        """
+        template = self._run('plugin.master.bar', sd=self.sd_conc)
+        myitem = template['myitem']
+        # The separately-registered struct has 'direct_child', not 'child1'/'child2'
+        self.assertIn('direct_child', myitem)
+        self.assertNotIn('child1', myitem)
+
+
+# ===========================================================================
+# Tests for Structs._resolve_partial_struct_def and merge_substruct_to_struct
+# ===========================================================================
+
+class MockSH:
+    """Minimal SmartHomeNG stand-in for constructing a Structs instance."""
+    _etc_dir = ''
+    _structs_dir = ''
+
+    def get_config_dir(self, config):
+        return ''
+
+    def get_structsdir(self):
+        return ''
+
+
+class TestStructsPartialResolution(unittest.TestCase):
+    """
+    Tests for partial struct resolution inside struct definitions
+    (Structs._resolve_partial_struct_def and merge_substruct_to_struct).
+    """
+
+    def setUp(self):
+        sh = MockSH()
+        self.structs = Structs(sh)
+        # Shadow the class-level dicts with instance-level ones for test isolation
+        self.structs._struct_definitions = collections.OrderedDict(
+            _make_base_struct_dict())
+        self.structs._finalized_structs = []
+        # Keep a separate instance for concurrency tests
+        self.structs_conc = Structs(sh)
+        self.structs_conc._struct_definitions = collections.OrderedDict(
+            _make_concurrency_struct_dict())
+        self.structs_conc._finalized_structs = []
+
+    # --- _resolve_partial_struct_def ---
+
+    def test_def_single_level_subpath(self):
+        sub_tree, matched, sub_path = self.structs._resolve_partial_struct_def(
+            'plugin.master.bar')
+        self.assertIsNotNone(sub_tree)
+        self.assertEqual(matched, 'plugin.master')
+        self.assertEqual(sub_path, 'bar')
+        self.assertIn('child1', sub_tree)
+
+    def test_def_multi_level_subpath(self):
+        sub_tree, matched, sub_path = self.structs._resolve_partial_struct_def(
+            'plugin.master.bar.child2')
+        self.assertIsNotNone(sub_tree)
+        self.assertEqual(sub_tree.get('unit'), 'km')
+
+    def test_def_subitem_not_found(self):
+        sub_tree, matched, sub_path = self.structs._resolve_partial_struct_def(
+            'plugin.master.missing')
+        self.assertIsNone(sub_tree)
+        self.assertEqual(matched, 'plugin.master')
+        self.assertEqual(sub_path, 'missing')
+
+    def test_def_scalar_path(self):
+        sub_tree, matched, sub_path = self.structs._resolve_partial_struct_def(
+            'plugin.master.foo.type')
+        self.assertIsNone(sub_tree)
+        self.assertEqual(matched, 'plugin.master')
+
+    def test_def_no_match(self):
+        sub_tree, matched, sub_path = self.structs._resolve_partial_struct_def(
+            'nobody.here')
+        self.assertIsNone(sub_tree)
+        self.assertIsNone(matched)
+        self.assertIsNone(sub_path)
+
+    def test_def_longest_match_wins(self):
+        sub_tree, matched, sub_path = self.structs_conc._resolve_partial_struct_def(
+            'plugin.master.bar.direct_child')
+        self.assertIsNotNone(sub_tree)
+        self.assertEqual(matched, 'plugin.master.bar')
+        self.assertEqual(sub_path, 'direct_child')
+        self.assertIn('special', sub_tree)
+
+    # --- merge_substruct_to_struct ---
+
+    def test_merge_full_struct(self):
+        """Existing behaviour: merge a full registered struct."""
+        main = collections.OrderedDict()
+        self.structs.merge_substruct_to_struct(main, 'plugin.master')
+        self.assertIn('foo', main)
+        self.assertIn('bar', main)
+        self.assertIn('baz', main)
+
+    def test_merge_partial_struct_single_level(self):
+        """Partial reference: merge only the 'bar' sub-tree of 'plugin.master'."""
+        main = collections.OrderedDict()
+        self.structs.merge_substruct_to_struct(main, 'plugin.master.bar')
+        self.assertIn('child1', main)
+        self.assertIn('child2', main)
+        self.assertNotIn('foo', main)
+        self.assertNotIn('baz', main)
+
+    def test_merge_partial_struct_multi_level(self):
+        """Two-level sub-path: only the deepest requested dict is merged."""
+        main = collections.OrderedDict()
+        self.structs.merge_substruct_to_struct(main, 'plugin.master.bar.child2')
+        self.assertIn('type', main)
+        self.assertEqual(main['type'], 'num')
+        self.assertIn('unit', main)
+
+    def test_merge_subitem_not_found_logs_error(self):
+        """Sub-item missing → error logged, main struct unchanged."""
+        main = collections.OrderedDict()
+        with self.assertLogs('lib.item.structs', level='ERROR') as cm:
+            self.structs.merge_substruct_to_struct(
+                main, 'plugin.master.nonexistent', main_struct_name='test_struct')
+        self.assertEqual(len(main), 0, "main struct must be unchanged on error")
+        combined = ' '.join(cm.output)
+        self.assertIn('plugin.master', combined)
+        self.assertIn('nonexistent', combined)
+
+    def test_merge_scalar_path_logs_error(self):
+        """Sub-path is a scalar → error logged, main struct unchanged."""
+        main = collections.OrderedDict()
+        with self.assertLogs('lib.item.structs', level='ERROR') as cm:
+            self.structs.merge_substruct_to_struct(
+                main, 'plugin.master.foo.type', main_struct_name='test_struct')
+        self.assertEqual(len(main), 0)
+        combined = ' '.join(cm.output)
+        self.assertIn('plugin.master', combined)
+
+    def test_merge_unknown_struct_logs_error(self):
+        """No matching prefix at all → original error logged."""
+        main = collections.OrderedDict()
+        with self.assertLogs('lib.item.structs', level='ERROR') as cm:
+            self.structs.merge_substruct_to_struct(
+                main, 'completely.unknown', main_struct_name='test_struct')
+        self.assertEqual(len(main), 0)
+        combined = ' '.join(cm.output)
+        self.assertIn('completely.unknown', combined)
+
+    def test_merge_longest_match_wins(self):
+        """'plugin.master.bar.direct_child' uses 'plugin.master.bar', not 'plugin.master'."""
+        main = collections.OrderedDict()
+        self.structs_conc.merge_substruct_to_struct(main, 'plugin.master.bar.direct_child')
+        self.assertIn('special', main)
+        self.assertNotIn('foo', main)
+        self.assertNotIn('baz', main)
+
+    def test_merge_does_not_overwrite_existing_keys(self):
+        """First-wins rule: keys already in main_struct are not overwritten."""
+        main = collections.OrderedDict([('type', 'original_type')])
+        self.structs.merge_substruct_to_struct(main, 'plugin.master.bar.child1')
+        # child1 has 'type: bool' but main already has 'type: original_type'
+        self.assertEqual(main['type'], 'original_type')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
…dotted path

lib/config.py:
- Add _resolve_partial_struct(struct_name, struct_dict) helper. Uses greedy longest-prefix matching to resolve e.g. 'kodi.master.bar' as sub-path 'bar' within registered struct 'kodi.master'. Returns 3-tuple (sub_tree|None, matched_name|None, sub_path|None) so the caller can emit precise, context-specific error messages.
- Update add_struct_to_item_template() to fall back to the helper when the direct dict lookup fails, with tiered error messages:
    * sub-item not found: struct 'X' found but sub-item 'Y' does not exist
    * scalar path: struct 'X' found but 'Y.z' is a scalar value, not a sub-item tree
    * not found at all: struct 'X' not found (existing message, unchanged)
- Improve docstring: document partial-path syntax, disambiguation rule, and all three error conditions.

lib/item/structs.py:
- Add Structs._resolve_partial_struct_def(): same greedy-prefix algorithm operating on self._struct_definitions (used during struct-within-struct resolution at startup).
- Update merge_substruct_to_struct() to use the helper with identical tiered error messages. Expand docstring.

tests/test_structs.py (new):
- 34 tests across three test classes covering all scenarios:
  * TestResolvePartialStruct: unit tests for the config.py helper (single/multi-level, user-prefix, scalar path, not-found, concurrency)
  * TestAddStructToItemTemplate: integration tests for the full template flow (successful inclusion, error items, direct-name precedence)
  * TestStructsPartialResolution: tests for structs.py helper and merge_substruct_to_struct (full/partial merge, error logging, first-wins, longest-match concurrency)
- Separate base and concurrency fixtures so tests requiring a separately- registered intermediate struct don't interfere with simple resolution tests.
- Registers ShNG custom log levels (dbgmed etc.) before the Structs tests so logger calls don't fail outside the full SmartHomeNG startup.

doc/user/source/konfiguration/item_structs.rst:
- New section "Teilweises Einbinden von structs (partial struct inclusion)" with syntax examples, disambiguation note, error message descriptions, and a note about insertion semantics.

doc/user/source/referenz/items/standard_attribute/struct.rst:
- Add partial-path syntax examples alongside the full-struct example.