### PR TITLE
fix: use consistent timezone source

### DIFF
--- a/doc/user/source/referenz/smarthomeng/methoden_sonne_mond.rst
+++ b/doc/user/source/referenz/smarthomeng/methoden_sonne_mond.rst
@@ -50,6 +50,13 @@ Das Ergebnis ist ein auf UTC basierendes ``datetime`` Objekt
    sunset_tw = sh.sun.set(-6) # liefert den utc-basierten Zeitpunkt zu dem die Sonne 6° unter dem Horizont
                               # steht. (Ende der bürgerlichen Abenddämmerung)
 
+.. note::
+
+   An Orten mit Mitternachtssonne bzw. Polarnacht kann es vorkommen, dass die Sonne an einem bestimmten
+   Tag den angegebenen Horizont gar nicht erreicht (z.B. geht sie im Sommer gar nicht unter). In diesem
+   Fall liefert ``sh.sun.set()`` (und analog ``sh.sun.rise()``) den Wert ``None`` zurück, statt einer
+   Datums/Zeitangabe.
+
 
 sh.sun.rise()
 ~~~~~~~~~~~~~
@@ -118,6 +125,12 @@ Das Ergebnis ist ein auf UTC basierendes ``datetime`` Objekt
 
    moonset = sh.moon.set()      # liefert den utc-basierten Zeitpunkt des nächsten Monduntergangs
    moonset_tw = sh.moon.set(-6) # liefert den utc-basierten Zeitpunkt zu dem der Mond 6° unter dem Horizont steht
+
+.. note::
+
+   Analog zu ``sh.sun.set()``/``sh.sun.rise()`` kann ``sh.moon.set()``/``sh.moon.rise()`` an Orten mit
+   entsprechenden Bedingungen ``None`` zurückliefern, wenn der Mond den angegebenen Horizont an dem
+   betreffenden Tag nicht erreicht.
 
 
 sh.moon.rise()

--- a/lib/orb.py
+++ b/lib/orb.py
@@ -152,14 +152,14 @@ class Orb:
         return observer, orb
 
     def unaware_datetime_to_utc(self, naive_dt):
-        local_aware = naive_dt.astimezone()
+        local_aware = naive_dt.replace(tzinfo=self.shtime.tzinfo())
         return local_aware.astimezone(datetime.timezone.utc)
 
     def aware_datetime_to_utc(self, aware_dt):
         return aware_dt.astimezone(datetime.timezone.utc)
 
     def utc_to_local(self, utc_dt):
-        return utc_dt.astimezone()
+        return utc_dt.astimezone(self.shtime.tzinfo())
 
     def _avoid_neverup(self, dt, date_utc, doff):
         """
@@ -346,13 +346,19 @@ class Orb:
         if not doff == 0:
             doff = self._avoid_neverup(dt, date_utc, doff)
         observer.horizon = str(doff)
-        if not doff == 0:
-            next_rising = observer.next_rising(orb, use_center=center).datetime()
-            observer.horizon = 0
-            next_real_rising = observer.next_rising(orb, use_center=center).datetime().replace(tzinfo=tzutc())
-        else:
-            next_rising = observer.next_rising(orb).datetime()
-            next_real_rising = next_rising.replace(tzinfo=tzutc())
+        try:
+            if not doff == 0:
+                next_rising = observer.next_rising(orb, use_center=center).datetime()
+                observer.horizon = 0
+                next_real_rising = observer.next_rising(orb, use_center=center).datetime().replace(tzinfo=tzutc())
+            else:
+                next_rising = observer.next_rising(orb).datetime()
+                next_real_rising = next_rising.replace(tzinfo=tzutc())
+        except (ephem.AlwaysUpError, ephem.NeverUpError) as e:
+            # _avoid_neverup only clamps non-zero degree offsets; a plain (doff=0) rise
+            # genuinely does not occur during midnight sun / polar night at this location.
+            logger.notice(f'ephem: {self.orb} has no rise event for {date_utc} at this location ({e}); returning None')
+            return None
         next_rising = next_rising + dateutil.relativedelta.relativedelta(minutes=moff)
         next_rising = next_rising.replace(tzinfo=tzutc())
         if doff < 0 and next_rising > next_real_rising:
@@ -400,13 +406,19 @@ class Orb:
         if not doff == 0:
             doff = self._avoid_neverup(dt, date_utc, doff)
         observer.horizon = str(doff)
-        if not doff == 0:
-            next_setting = observer.next_setting(orb, use_center=center).datetime()
-            observer.horizon = 0
-            next_real_setting = observer.next_setting(orb, use_center=center).datetime().replace(tzinfo=tzutc())
-        else:
-            next_setting = observer.next_setting(orb).datetime()
-            next_real_setting = next_setting.replace(tzinfo=tzutc())
+        try:
+            if not doff == 0:
+                next_setting = observer.next_setting(orb, use_center=center).datetime()
+                observer.horizon = 0
+                next_real_setting = observer.next_setting(orb, use_center=center).datetime().replace(tzinfo=tzutc())
+            else:
+                next_setting = observer.next_setting(orb).datetime()
+                next_real_setting = next_setting.replace(tzinfo=tzutc())
+        except (ephem.AlwaysUpError, ephem.NeverUpError) as e:
+            # _avoid_neverup only clamps non-zero degree offsets; a plain (doff=0) setting
+            # genuinely does not occur during midnight sun / polar night at this location.
+            logger.notice(f'ephem: {self.orb} has no set event for {date_utc} at this location ({e}); returning None')
+            return None
         next_setting = next_setting + dateutil.relativedelta.relativedelta(minutes=moff)
         next_setting = next_setting.replace(tzinfo=tzutc())
         if doff < 0 and next_setting < next_real_setting:

--- a/lib/shtime.py
+++ b/lib/shtime.py
@@ -181,6 +181,10 @@ class Shtime:
 
     def ts(self, dt, tz=None):
         """Return dt as posix timestamp, possibly with different local tz"""
+        if dt.tzinfo is not None and tz is None:
+            # already aware and no explicit override: timestamp() is tz-correct as-is,
+            # replacing tzinfo would silently shift the represented instant
+            return dt.timestamp()
         if tz is None:
             tz = self._tzinfo
         return dt.replace(tzinfo=tz).timestamp()
@@ -218,34 +222,34 @@ class Shtime:
 
     def tzname(self):
         """
-        Returns the name about the actual local timezone (e.g. CEST)
+        Returns the name about the actual configured timezone (e.g. CEST)
 
         :return: timezone string (like: 'CEST' or 'CET')
         :rtype: str
         """
 
-        return datetime.datetime.now(tz.tzlocal()).tzname()
+        return self.now().tzname()
 
     def tznameST(self):
         """
-        Returns the name for Standard Time in the local timezone (e.g. CET)
+        Returns the name for Standard Time in the configured timezone (e.g. CET)
 
         :return: Timezone info (like: 'CET')
         :rtype: str
         """
 
-        jan = datetime.datetime.fromtimestamp(datetime.datetime.timestamp(datetime.datetime(2020, 1, 1)), tz.tzlocal())
+        jan = datetime.datetime(2020, 1, 1, tzinfo=self._tzinfo)
         return jan.strftime('%Z')
 
     def tznameDST(self):
         """
-        Returns the name for Daylight Saving Time (DST) in the local timezone (e.g. CEST)
+        Returns the name for Daylight Saving Time (DST) in the configured timezone (e.g. CEST)
 
         :return: Timezone info (like: 'CEST')
         :rtype: str
         """
 
-        jul = datetime.datetime.fromtimestamp(datetime.datetime.timestamp(datetime.datetime(2020, 7, 1)), tz.tzlocal())
+        jul = datetime.datetime(2020, 7, 1, tzinfo=self._tzinfo)
         return jul.strftime('%Z')
 
     def utcnow(self):
@@ -581,8 +585,9 @@ class Shtime:
         else:
             raise TypeError(self.translate("Cannot convert type '{key}' to datetime").format(key=type(key)))
         if isinstance(key, datetime.datetime) and key.tzinfo is None:
-            # key = self._timezone.localize(key)   # uses a pytz method
-            key = key.astimezone(self._timezone)
+            # naive datetime: label it as being in shng's configured timezone, don't shift it.
+            # .astimezone() would instead treat it as OS-local time and convert (shift) it.
+            key = key.replace(tzinfo=self._timezone)
         return key
 
     def date_transform(self, key):
@@ -699,7 +704,7 @@ class Shtime:
         :return: date of today
         :rtype: datetime.date
         """
-        return (datetime.datetime.now() + datetime.timedelta(days=offset)).date()
+        return (self.now() + datetime.timedelta(days=offset)).date()
 
     def tomorrow(self):
         """

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,8 @@
+import contextlib
 import logging
 import os
 import sys
+import time
 import pathlib
 
 # with Linux standard installation of SmartHomeNG
@@ -34,3 +36,26 @@ def register_shng_log_levels():
             logging.addLevelName(level, name)
             setattr(logging, name, level)
             setattr(logging.getLoggerClass(), name.lower(), _make_method(level))
+
+
+@contextlib.contextmanager
+def force_os_tz(tz_name):
+    """Force the process's OS-level timezone to tz_name for the duration of the block.
+
+    Shtime.set_tz() writes os.environ['TZ'], which on some platforms makes naive
+    .astimezone()/.now() calls silently track the *configured* shng timezone too -
+    masking bugs where code should use shng's configured tz but instead falls back
+    to "whatever the OS thinks". This forces a genuine OS/configured mismatch via
+    time.tzset() (POSIX only) so such bugs are actually exercised by tests.
+    """
+    orig_tz = os.environ.get('TZ')
+    os.environ['TZ'] = tz_name
+    time.tzset()
+    try:
+        yield
+    finally:
+        if orig_tz is None:
+            os.environ.pop('TZ', None)
+        else:
+            os.environ['TZ'] = orig_tz
+        time.tzset()

--- a/tests/mock/core.py
+++ b/tests/mock/core.py
@@ -35,7 +35,19 @@ class MockScheduler:
 
         lib.scheduler._scheduler_instance = self
 
-    def add(self, name, obj, prio=3, cron=None, cycle=None, value=None, offset=None, next=None):
+    def add(
+        self,
+        name,
+        obj,
+        prio=3,
+        cron=None,
+        cycle=None,
+        value=None,
+        offset=None,
+        next=None,
+        from_smartplugin=False,
+        items=None,
+    ):
         logger.warning(
             'MockScheduler (add): {}, cron={}, cycle={}, value={}, offset={}'.format(
                 name, str(cron), str(cycle), str(value), str(offset)
@@ -47,8 +59,13 @@ class MockScheduler:
         except AttributeError:
             pass
 
-    def remove(self, name):
+    def remove(self, name, from_smartplugin=False):
         logger.warning('MockScheduler (remove): {}'.format(name))
+
+    def trigger(
+        self, name, obj=None, by='Logic', source=None, value=None, dest=None, prio=3, dt=None, from_smartplugin=False
+    ):
+        logger.warning('MockScheduler (trigger): {}, by={}, value={}'.format(name, by, value))
 
 
 class MockSmartHome:

--- a/tests/test_orb.py
+++ b/tests/test_orb.py
@@ -56,9 +56,18 @@ _SUMMER_SOLSTICE = datetime.datetime(2024, 6, 21, 0, 0, 0, tzinfo=datetime.timez
 _WINTER_SOLSTICE = datetime.datetime(2024, 12, 21, 0, 0, 0, tzinfo=datetime.timezone.utc)
 # Noon on summer solstice (for position tests)
 _SUMMER_NOON = datetime.datetime(2024, 6, 21, 11, 31, 0, tzinfo=datetime.timezone.utc)
+# Spring equinox 2024 (Berlin) — day/night roughly equal length
+_SPRING_EQUINOX = datetime.datetime(2024, 3, 20, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+# Tromsø, Norway (69.65°N) — well inside the Arctic Circle, exercises
+# midnight sun (summer) / polar night (winter), where the sun's plain
+# (doff=0) rise/set genuinely does not occur on the given calendar day.
+TROMSO_LON = 18.9553
+TROMSO_LAT = 69.6492
+TROMSO_ELEV = 10
 
 
-def _make_shtime():
+def _make_shtime(tz='UTC'):
     import lib.shtime as _m
 
     _m._shtime_instance = None
@@ -71,7 +80,7 @@ def _make_shtime():
             return os.path.join(base, basename + extension)
 
     st = Shtime(_Sh())
-    st.set_tz('UTC')
+    st.set_tz(tz)
     return st
 
 
@@ -287,6 +296,159 @@ class TestCoordinateConversions(unittest.TestCase):
         utc = datetime.datetime(2024, 6, 21, 12, 0, 0, tzinfo=datetime.timezone.utc)
         result = self.sun.utc_to_local(utc)
         self.assertIsInstance(result, datetime.datetime)
+
+
+@unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
+class TestCoordinateConversionsUseConfiguredTz(unittest.TestCase):
+    """Regression tests: unaware_datetime_to_utc/utc_to_local must use shng's
+    configured timezone (self.shtime.tzinfo()), not whatever the OS-level
+    timezone happens to be. force_os_tz creates a genuine mismatch so these
+    actually exercise the bug rather than relying on OS/configured tz happening
+    to agree in the test environment."""
+
+    def setUp(self):
+        self.shtime = _make_shtime('Pacific/Honolulu')
+        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+
+    def test_unaware_to_utc_uses_configured_tz(self):
+        with common.force_os_tz('Europe/Berlin'):
+            naive = datetime.datetime(2024, 6, 15, 12, 0, 0)
+            result = self.sun.unaware_datetime_to_utc(naive)
+            # 12:00 Honolulu (UTC-10) -> 22:00 UTC same day
+            self.assertEqual(result, datetime.datetime(2024, 6, 15, 22, 0, 0, tzinfo=datetime.timezone.utc))
+
+    def test_utc_to_local_uses_configured_tz(self):
+        with common.force_os_tz('Europe/Berlin'):
+            utc_dt = datetime.datetime(2024, 6, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+            result = self.sun.utc_to_local(utc_dt)
+            # 12:00 UTC -> 02:00 Honolulu (UTC-10) same day
+            self.assertEqual(result.hour, 2)
+            self.assertEqual(result.utcoffset(), datetime.timedelta(hours=-10))
+
+
+# ===========================================================================
+# Equinox sanity (second reference point beyond the solstice tests, prep
+# for ephem-to-skyfield comparison)
+# ===========================================================================
+
+
+@unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
+class TestEquinox(unittest.TestCase):
+    def setUp(self):
+        self.shtime = _make_shtime()
+        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+
+    def test_equinox_day_length_close_to_twelve_hours(self):
+        # True day/night equality ("equilux") happens a few days after the
+        # astronomical equinox due to atmospheric refraction and the sun's
+        # angular size; 30 min tolerance covers that gap.
+        rise = self.sun.rise(dt=_SPRING_EQUINOX)
+        sset = self.sun.set(dt=_SPRING_EQUINOX)
+        day_length = sset - rise
+        self.assertLess(abs(day_length.total_seconds() - 12 * 3600), 30 * 60)
+
+    def test_equinox_rise_approx(self):
+        expected = datetime.datetime(2024, 3, 20, 5, 8, 0, tzinfo=datetime.timezone.utc)
+        result = self.sun.rise(dt=_SPRING_EQUINOX)
+        diff = abs(result.replace(tzinfo=datetime.timezone.utc) - expected)
+        self.assertLessEqual(diff, datetime.timedelta(minutes=15))
+
+    def test_equinox_set_approx(self):
+        expected = datetime.datetime(2024, 3, 20, 17, 21, 0, tzinfo=datetime.timezone.utc)
+        result = self.sun.set(dt=_SPRING_EQUINOX)
+        diff = abs(result.replace(tzinfo=datetime.timezone.utc) - expected)
+        self.assertLessEqual(diff, datetime.timedelta(minutes=15))
+
+
+# ===========================================================================
+# Moon rise/set sanity (only phase/light were characterized before)
+# ===========================================================================
+
+
+@unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
+class TestMoonRiseSet(unittest.TestCase):
+    def setUp(self):
+        self.shtime = _make_shtime()
+        self.moon = Orb('moon', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+
+    def test_moon_rise_is_utc_aware(self):
+        result = self.moon.rise(dt=_SPRING_EQUINOX)
+        self.assertIsNotNone(result.tzinfo)
+
+    def test_moon_set_is_utc_aware(self):
+        result = self.moon.set(dt=_SPRING_EQUINOX)
+        self.assertIsNotNone(result.tzinfo)
+
+    def test_moon_rise_within_24h_of_search_start(self):
+        # Moon rise/set always occurs roughly once per ~24h50m (lunar day);
+        # a "next" search should never jump multiple days.
+        result = self.moon.rise(dt=_SPRING_EQUINOX)
+        self.assertLess((result - _SPRING_EQUINOX).total_seconds() / 3600, 26)
+
+    def test_moon_set_within_24h_of_search_start(self):
+        result = self.moon.set(dt=_SPRING_EQUINOX)
+        self.assertLess((result - _SPRING_EQUINOX).total_seconds() / 3600, 26)
+
+    def test_moon_minute_offset_shifts_time(self):
+        rise_plain = self.moon.rise(dt=_SPRING_EQUINOX)
+        rise_plus30 = self.moon.rise(moff=30, dt=_SPRING_EQUINOX)
+        diff = rise_plus30 - rise_plain
+        self.assertAlmostEqual(diff.total_seconds() / 60, 30, delta=1)
+
+
+# ===========================================================================
+# High-latitude (midnight sun / polar night) regression tests
+#
+# Orb.rise()/set() with doff=0 (the default) used to crash with an uncaught
+# ephem.AlwaysUpError/NeverUpError at any location where the sun's plain
+# horizon crossing genuinely does not occur on the given day. _avoid_neverup
+# only clamps non-zero degree offsets, so this path had no protection.
+# ===========================================================================
+
+
+@unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
+class TestHighLatitudeNeverUp(unittest.TestCase):
+    def setUp(self):
+        self.shtime = _make_shtime()
+        self.sun = Orb('sun', TROMSO_LON, TROMSO_LAT, TROMSO_ELEV)
+
+    def test_midnight_sun_rise_returns_none_not_raises(self):
+        # Tromsø, summer solstice: sun never sets, so it never "rises" either
+        # (it's already up). Must not raise AlwaysUpError.
+        result = self.sun.rise(dt=_SUMMER_SOLSTICE)
+        self.assertIsNone(result)
+
+    def test_midnight_sun_set_returns_none_not_raises(self):
+        result = self.sun.set(dt=_SUMMER_SOLSTICE)
+        self.assertIsNone(result)
+
+    def test_polar_night_rise_returns_none_not_raises(self):
+        # Tromsø, winter solstice: sun never rises above the horizon.
+        result = self.sun.rise(dt=_WINTER_SOLSTICE)
+        self.assertIsNone(result)
+
+    def test_polar_night_set_returns_none_not_raises(self):
+        result = self.sun.set(dt=_WINTER_SOLSTICE)
+        self.assertIsNone(result)
+
+    def test_noon_unaffected_by_midnight_sun(self):
+        # Transit (solar noon) always exists regardless of whether the sun
+        # crosses the horizon that day.
+        result = self.sun.noon(dt=_SUMMER_SOLSTICE)
+        self.assertIsInstance(result, datetime.datetime)
+
+    def test_midnight_unaffected_by_polar_night(self):
+        result = self.sun.midnight(dt=_WINTER_SOLSTICE)
+        self.assertIsInstance(result, datetime.datetime)
+
+    def test_equinox_rise_set_work_normally_at_high_latitude(self):
+        # Sanity check: away from the solstices, Tromsø still has normal
+        # rise/set events (this should never have been broken).
+        rise = self.sun.rise(dt=_SPRING_EQUINOX)
+        sset = self.sun.set(dt=_SPRING_EQUINOX)
+        self.assertIsInstance(rise, datetime.datetime)
+        self.assertIsInstance(sset, datetime.datetime)
+        self.assertLess(rise, sset)
 
 
 if __name__ == '__main__':

--- a/tests/test_shtime.py
+++ b/tests/test_shtime.py
@@ -30,6 +30,8 @@ import unittest
 # Make shng root importable
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
+import tests.common as common
+
 
 # ---------------------------------------------------------------------------
 # Register shng's custom log levels before importing shtime.
@@ -244,6 +246,17 @@ class TestDatetimeTransform(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.st.datetime_transform([2024, 1, 1])
 
+    def test_naive_datetime_is_labeled_not_shifted(self):
+        # Regression test: a naive datetime must be interpreted as wall-clock
+        # time *in the configured timezone*, not as OS-local time that gets
+        # converted. force_os_tz creates a genuine OS/configured mismatch.
+        st = _make_shtime('Pacific/Honolulu')
+        with common.force_os_tz('Europe/Berlin'):
+            dt = datetime.datetime(2024, 6, 15, 12, 0, 0)
+            result = st.datetime_transform(dt)
+            self.assertEqual(result.hour, 12)
+            self.assertEqual(result.utcoffset(), datetime.timedelta(hours=-10))
+
 
 class TestDateTransform(unittest.TestCase):
     def setUp(self):
@@ -437,6 +450,100 @@ class TestBeginningOf(unittest.TestCase):
     def test_beginning_of_year_with_positive_offset(self):
         result = self.st.beginning_of_year(year=2024, offset=1)
         self.assertEqual(result, datetime.date(2025, 1, 1))
+
+
+# ===========================================================================
+# today / tomorrow / yesterday
+#
+# NOTE: real OS-tz/configured-tz mismatch can't be exercised deterministically
+# here because the bug only manifests near midnight relative to the offset
+# difference, and "now" is real wall-clock time at test run. These verify the
+# contract instead: today() must derive from the configured tz via now().
+# ===========================================================================
+
+
+class TestTodayTomorrowYesterday(unittest.TestCase):
+    def setUp(self):
+        self.st = _make_shtime('Pacific/Honolulu')
+
+    def test_today_matches_now_date_in_configured_tz(self):
+        self.assertEqual(self.st.today(), self.st.now().date())
+
+    def test_tomorrow_is_today_plus_one(self):
+        self.assertEqual(self.st.tomorrow(), self.st.today() + datetime.timedelta(days=1))
+
+    def test_yesterday_is_today_minus_one(self):
+        self.assertEqual(self.st.yesterday(), self.st.today() - datetime.timedelta(days=1))
+
+    def test_today_offset(self):
+        self.assertEqual(self.st.today(offset=2), self.st.today() + datetime.timedelta(days=2))
+
+
+# ===========================================================================
+# tzname / tznameST / tznameDST
+#
+# Regression tests: these must report the *configured* timezone's name, not
+# whatever the OS-level timezone happens to be (dateutil's tz.tzlocal() reads
+# OS state dynamically, so force_os_tz can genuinely discriminate here).
+# ===========================================================================
+
+
+class TestTzNames(unittest.TestCase):
+    def setUp(self):
+        self.st = _make_shtime('Pacific/Honolulu')
+
+    def test_tzname_reports_configured_tz(self):
+        with common.force_os_tz('Europe/Berlin'):
+            self.assertEqual(self.st.tzname(), 'HST')
+
+    def test_tznameST_reports_configured_tz(self):
+        with common.force_os_tz('Europe/Berlin'):
+            self.assertEqual(self.st.tznameST(), 'HST')
+
+    def test_tznameDST_reports_configured_tz(self):
+        with common.force_os_tz('Europe/Berlin'):
+            self.assertEqual(self.st.tznameDST(), 'HST')
+
+    def test_tzname_distinguishes_st_and_dst_for_dst_observing_zone(self):
+        # Pacific/Honolulu has no DST (always HST); Europe/Berlin does
+        # (CET in winter, CEST in summer) - use it to confirm ST != DST name.
+        st = _make_shtime('Europe/Berlin')
+        self.assertEqual(st.tznameST(), 'CET')
+        self.assertEqual(st.tznameDST(), 'CEST')
+
+
+# ===========================================================================
+# ts()
+#
+# Regression test: ts() must not overwrite tzinfo on an already-aware
+# datetime (no OS-tz involvement needed - this is purely an
+# overwrite-vs-preserve bug).
+# ===========================================================================
+
+
+class TestTs(unittest.TestCase):
+    def setUp(self):
+        self.st = _make_shtime('Europe/Berlin')
+
+    def test_aware_datetime_timestamp_unaffected_by_configured_tz(self):
+        # 12:00 UTC must yield the same posix timestamp regardless of shng's
+        # configured timezone - ts() must not relabel it to Europe/Berlin.
+        utc_dt = datetime.datetime(2024, 6, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        expected = utc_dt.timestamp()
+        self.assertEqual(self.st.ts(utc_dt), expected)
+
+    def test_naive_datetime_uses_configured_tz(self):
+        naive_dt = datetime.datetime(2024, 6, 15, 12, 0, 0)
+        result = self.st.ts(naive_dt)
+        expected = naive_dt.replace(tzinfo=self.st.tzinfo()).timestamp()
+        self.assertEqual(result, expected)
+
+    def test_explicit_tz_override_still_works(self):
+        naive_dt = datetime.datetime(2024, 6, 15, 12, 0, 0)
+        honolulu = _make_shtime('Pacific/Honolulu').tzinfo()
+        result = self.st.ts(naive_dt, tz=honolulu)
+        expected = naive_dt.replace(tzinfo=honolulu).timestamp()
+        self.assertEqual(result, expected)
 
 
 # ===========================================================================

--- a/tests/test_triggertimes.py
+++ b/tests/test_triggertimes.py
@@ -25,12 +25,57 @@ from . import common
 import unittest
 import logging
 import datetime
+import os
 
 from tests.mock.core import MockSmartHome
 
-from lib.triggertimes import Crontab
+from lib.triggertimes import Crontab, Skytime
+
+try:
+    import ephem as _ephem_check
+
+    HAS_EPHEM = True
+except ImportError:
+    HAS_EPHEM = False
+
+from lib.shtime import Shtime
+from lib.orb import Orb
+
+common.register_shng_log_levels()
 
 logger = logging.getLogger(__name__)
+
+BERLIN_LON = 13.4050
+BERLIN_LAT = 52.5200
+BERLIN_ELEV = 34
+
+
+def _make_sky_env(tz='Europe/Berlin'):
+    """Set up a minimal Shtime + Orb('sun') environment and register it with
+    Skytime, mirroring how bin/smarthome.py wires sh.shtime/sh.sun/sh.moon."""
+    import lib.shtime as _m
+
+    _m._shtime_instance = None
+
+    class _Sh:
+        _default_language = 'de'
+
+        def get_config_file(self, basename, extension='.yaml'):
+            base = os.path.join(os.path.dirname(__file__), 'resources', 'etc')
+            return os.path.join(base, basename + extension)
+
+    shtime = Shtime(_Sh())
+    shtime.set_tz(tz)
+    sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+
+    class _SkySh:
+        def __init__(self, shtime, sun):
+            self.shtime = shtime
+            self.sun = sun
+            self.moon = sun  # unused by these tests, just needs to exist
+
+    Skytime.set_smarthome_reference(_SkySh(shtime, sun))
+    return shtime, sun
 
 
 class TestCrontab(unittest.TestCase):
@@ -200,6 +245,38 @@ class TestCrontab(unittest.TestCase):
 
         logger.warning('\nfurthermore fancy dates')
         self.assertEqual(Crontab('59 59 23 31 10 *').get_next(now), datetime.datetime(year, 10, 31, 23, 59, 59))
+
+
+@unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
+class TestSkytimeSolsticeGuard(unittest.TestCase):
+    """Regression guard for a forum-reported bug: a sun-bound trigger like
+    'sunset+35m', re-triggered day after day across the summer solstice, was
+    reported to occasionally skip forward by several weeks instead of firing
+    the next evening (smarthome v1.9.5). This was NOT reproducible against
+    current develop with real pyephem (verified empirically: every gap across
+    2024-06-01..2024-07-30 at Berlin coordinates came out to a clean ~24h).
+    This test locks in that correct behaviour so a future change (e.g. the
+    planned ephem->skyfield port) can't silently reintroduce the jump."""
+
+    MAX_PLAUSIBLE_GAP = datetime.timedelta(hours=30)
+
+    def setUp(self):
+        self.shtime, self.sun = _make_sky_env()
+
+    def test_sunset_plus_offset_advances_by_about_one_day_across_solstice(self):
+        sky = Skytime('sunset+35m')
+        starttime = datetime.datetime(2024, 6, 1, 12, 0, 0, tzinfo=self.shtime.tzinfo())
+        end = datetime.datetime(2024, 7, 30, tzinfo=self.shtime.tzinfo())
+        prev = None
+        while starttime < end:
+            nxt = sky.get_next(starttime)
+            if prev is not None:
+                gap = nxt - prev
+                self.assertLessEqual(
+                    gap, self.MAX_PLAUSIBLE_GAP, f'gap from {prev} to {nxt} is {gap}, expected roughly 24h'
+                )
+            prev = nxt
+            starttime = nxt + datetime.timedelta(microseconds=1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Several places in lib.shtime and lib.orb silently fell back to the process's OS-level timezone instead of shng's configured one (Shtime's _tzinfo/_tz): Shtime.datetime_transform() shifted naive datetimes via .astimezone() instead of labeling them, today()/tomorrow()/yesterday() and tzname()/tznameST()/tznameDST() read OS-local time, ts() clobbered tzinfo on already-aware datetimes, and Orb.unaware_datetime_to_utc()/ utc_to_local() used bare .astimezone() rather than self.shtime.tzinfo(). These only diverge when the OS timezone differs from the configured one (e.g. Docker containers defaulting to UTC), which is why they went unnoticed.
Also fixes Orb.rise()/set() crashing with an uncaught ephem.AlwaysUpError/ NeverUpError for any midnight-sun/polar-night location when doff=0 (the default) — _avoid_neverup only ever clamped non-zero degree offsets. Now returns None.
Adds regression tests for all of the above (using a new force_os_tz() test helper to create genuine OS/configured-tz mismatches), plus characterization tests for equinox and moon rise/set, and a Skytime solstice regression guard reproducing a forum-reported sunset+Nm bug report (not reproducible on current develop, but locked in as a guard ahead of the planned ephem->skyfield port).