### PR TITLE
lib.org: use skyfield as alternative to pyephem

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,12 +15,16 @@ if [ -z "$STAGED" ]; then
     exit 0
 fi
 
+# --force-exclude: ruff's [tool.ruff] exclude only applies during directory
+# discovery, not to explicit file paths (which is what xargs passes here) -
+# without it, staging a file under an excluded path (e.g. lib/env/) would
+# wrongly fail this gate.
 # --- Format (auto-apply + re-stage) ---
-echo "$STAGED" | xargs "$RUFF" format --quiet && echo 'Formatted.'
+echo "$STAGED" | xargs "$RUFF" format --force-exclude --quiet && echo 'Formatted.'
 echo "$STAGED" | xargs git add
 
 # --- Lint ---
-if ! echo "$STAGED" | xargs "$RUFF" check; then
+if ! echo "$STAGED" | xargs "$RUFF" check --force-exclude; then
     echo ""
     echo "==> COMMIT REJECTED: ruff found lint errors in staged files."
     echo ""

--- a/doc/user/source/lib/orb.rst
+++ b/doc/user/source/lib/orb.rst
@@ -1,7 +1,60 @@
 lib.orb
 -------
 
+.. role:: greensup
+
 .. automodule:: lib.orb
     :members:
     :undoc-members:
     :show-inheritance:
+
+
+lib.orb Backends :greensup:`Update`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Die Bibliothek `lib.orb` kann intern mit verschiedenen Backends arbeiten:
+ 
+  - ephem (pyephem)
+  - skyfield
+  - skyfield mit Cache
+
+``ephem`` hat den Vorteil, dass es als native C-Bibliothek sehr schnell ist.
+Nachteilig ist, dass es auf manchen Plattformen keine fertigen Pakete gibt
+oder die Installation schwierig ist.
+
+``skyfield`` ist als reines Python-Modul trivial zu installieren, muss vor dem
+erstmaligen Start eine Datei (17 MB) herunterladen, die bis 2053 gültig bleibt.
+Die Berechnungen sind langsamer als ephem.
+
+In der Variante von ``skyfield`` mit Cache werden alle Daten für ein Jahr auf einen Schlag
+berechnet und alle folgenden Abfragen, die in das Fenster der 365 Tage fallen,
+werden ohne erneute Berechnung zurückgegeben.
+
+``ephem`` ist pro Einzelabfrage mit Abstand am schnellsten (~70-100x schneller
+als ungecachted ``skyfield``) - die Cache-Schicht gleicht das nur gegenüber
+``skyfield`` selbst aus, nicht gegenüber ``ephem``. Der Cache-Aufbau kostet
+konstant ~7ms, unabhängig von der Anzahl der Aufrufe, und amortisiert sich
+gegenüber ungecachtem ``skyfield`` bereits nach 3-4 Abfragen. Sequenzielle
+Abfragen (das reale Nutzungsmuster von ``Skytime``, Tag fuer Tag vorwärts)
+profitieren deutlich stärker vom Cache als zufällige Abfragen, da letztere
+gelegentlich einen erneuten Cache-Aufbau auslösen.
+
+.. table:: Benchmark-Ergebnisse: lib.orb Backends (Berlin, 365-Tage-Fenster)
+
+   =========  ============  ============  =============  ======================  =================
+   Aufrufe    Modus         ephem (ms)    skyfield (ms)  skyfield-cached Ø (ms)  Cache-Aufbau (ms)
+   =========  ============  ============  =============  ======================  =================
+   10         zufällig      0,033         2,441          0,788                   6,9
+   10         sequenziell   0,029         2,409          0,013                   7,0
+   100        zufällig      0,027         1,952          0,149                   7,1
+   100        sequenziell   0,025         1,889          0,010                   6,8
+   1000       zufällig      0,025         1,863          0,039                   6,8
+   1000       sequenziell   0,022         1,859          0,023                   6,9
+   =========  ============  ============  =============  ======================  =================
+
+Werte = Durchschnitt pro Aufruf in Millisekunden
+außer "Cache-Aufbau" = einmalige Kosten für die erste Abfrage
+
+Die Backends können über den ``etc/smarthome.yaml``-Parameter
+`orb_backend: <Wert>` konfiguriert werden. Gültige Werte sind
+"ephem", "skyfield" und "skyfield-cache".

--- a/doc/user/source/referenz/libraries_plugins_logics.rst
+++ b/doc/user/source/referenz/libraries_plugins_logics.rst
@@ -1,5 +1,7 @@
-Libraries für Plugins und Logiken
-=================================
+.. role:: greensup
+
+Libraries für Plugins und Logiken :greensup:`Update`
+====================================================
 
 Es gibt einige Libraries (Python Module), die bei der Entwicklung von Plugins und Logiken genutzt werden können.
 Der Aufruf der darin bereitgestellten Funktionen ist im Folgenden beschrieben:

--- a/doc/user/source/referenz/smarthomeng/methoden_sonne_mond.rst
+++ b/doc/user/source/referenz/smarthomeng/methoden_sonne_mond.rst
@@ -10,6 +10,15 @@ Dieses Objekt bietet Zugriff auf Parameter der Sonne. Um dieses Objekt zu verwen
 den Breitengrad (latitude, z.B. lat: 53.5989481) und den Längengrad (longitude z.B. lon: 10.0459898),
 sowie die Höhe über dem Meeresspiegel (elevation z.B.: elev: 20) in der Datei ``etc/smarthome.yaml`` anzugeben.
 
+.. note::
+
+   Die Berechnungen für ``sh.sun`` und ``sh.moon`` werden intern von einer austauschbaren
+   Ephemeriden-Bibliothek durchgeführt. Standardmäßig wird **ephem** verwendet. Optional kann in
+   ``etc/smarthome.yaml`` mit ``orb_backend: skyfield`` auf die Bibliothek **skyfield** umgeschaltet
+   werden. Vor der ersten Verwendung von skyfield muss einmalig ``tools/fetch_skyfield_data.py``
+   ausgeführt werden, um die benötigten Ephemeriden-Daten (~17MB, gültig bis 2053) herunterzuladen -
+   danach ist kein Netzwerkzugriff mehr erforderlich.
+
 
 sh.sun.pos()
 ~~~~~~~~~~~~

--- a/doc/user/source/referenz/smarthomeng/methoden_sonne_mond.rst
+++ b/doc/user/source/referenz/smarthomeng/methoden_sonne_mond.rst
@@ -50,6 +50,13 @@ Das Ergebnis ist ein auf UTC basierendes ``datetime`` Objekt
    sunset_tw = sh.sun.set(-6) # liefert den utc-basierten Zeitpunkt zu dem die Sonne 6° unter dem Horizont
                               # steht. (Ende der bürgerlichen Abenddämmerung)
 
+.. note::
+
+   An Orten mit Mitternachtssonne bzw. Polarnacht kann es vorkommen, dass die Sonne an einem bestimmten
+   Tag den angegebenen Horizont gar nicht erreicht (z.B. geht sie im Sommer gar nicht unter). In diesem
+   Fall liefert ``sh.sun.set()`` (und analog ``sh.sun.rise()``) den Wert ``None`` zurück, statt einer
+   Datums/Zeitangabe.
+
 
 sh.sun.rise()
 ~~~~~~~~~~~~~
@@ -118,6 +125,12 @@ Das Ergebnis ist ein auf UTC basierendes ``datetime`` Objekt
 
    moonset = sh.moon.set()      # liefert den utc-basierten Zeitpunkt des nächsten Monduntergangs
    moonset_tw = sh.moon.set(-6) # liefert den utc-basierten Zeitpunkt zu dem der Mond 6° unter dem Horizont steht
+
+.. note::
+
+   Analog zu ``sh.sun.set()``/``sh.sun.rise()`` kann ``sh.moon.set()``/``sh.moon.rise()`` an Orten mit
+   entsprechenden Bedingungen ``None`` zurückliefern, wenn der Mond den angegebenen Horizont an dem
+   betreffenden Tag nicht erreicht.
 
 
 sh.moon.rise()

--- a/lib/env/location.py
+++ b/lib/env/location.py
@@ -3,6 +3,7 @@
 # prevent warnings when using linting tools like pyright, pylance
 # TYPE_CHECKING is False during runtime
 from typing import TYPE_CHECKING, Any
+
 if TYPE_CHECKING:
     sh: Any
     logic: Any
@@ -15,35 +16,37 @@ if sh.env.location.lon() == 0 and sh.env.location.lat() == 0:
         sh.env.location.lon(sh._lon, logic.lname)
         sh.env.location.lat(sh._lat, logic.lname)
         sh.env.location.elev(sh._elev, logic.lname)
-    except: pass
+    except:
+        pass
 
 if sh.sun:
     try:
-        sunrise = sh.sun.rise().astimezone(shtime.tzinfo())
-        sh.env.location.sunrise(sunrise, logic.lname)
+        sunrise_utc = sh.sun.rise()
+        sunrise_local = sunrise_utc.astimezone(shtime.tzinfo())
+        sh.env.location.sunrise(sunrise_local, logic.lname)
     except Exception as e:
-        logger.error("ephem error while calculating sun rise: {}".format(e))
-
-    azimut_rise_radians, elevation_rise_radians = sh.sun.pos(dt=sunrise)
-    azimut_rise_degrees, elevation_rise_degrees = sh.sun.pos(dt=sunrise, degree=True)
-    sh.env.location.sunrise.azimut.degrees(round(azimut_rise_degrees, 2), logic.lname)
-    sh.env.location.sunrise.elevation.degrees(round(elevation_rise_degrees, 2), logic.lname)
-    sh.env.location.sunrise.azimut.radians(round(azimut_rise_radians,2), logic.lname)
-    sh.env.location.sunrise.elevation.radians(round(elevation_rise_radians,2), logic.lname)
+        logger.error('ephem error while calculating sun rise: {}'.format(e))
+    else:
+        azimut_rise_radians, elevation_rise_radians = sh.sun.pos(dt=sunrise_utc)
+        azimut_rise_degrees, elevation_rise_degrees = sh.sun.pos(dt=sunrise_utc, degree=True)
+        sh.env.location.sunrise.azimut.degrees(round(azimut_rise_degrees, 2), logic.lname)
+        sh.env.location.sunrise.elevation.degrees(round(elevation_rise_degrees, 2), logic.lname)
+        sh.env.location.sunrise.azimut.radians(round(azimut_rise_radians, 2), logic.lname)
+        sh.env.location.sunrise.elevation.radians(round(elevation_rise_radians, 2), logic.lname)
 
     try:
         sunset_utc = sh.sun.set()
         sunset_local = sunset_utc.astimezone(shtime.tzinfo())
         sh.env.location.sunset(sunset_local, logic.lname)
     except Exception as e:
-        logger.error("ephem error while calculating sun set: {}".format(e))
+        logger.error('ephem error while calculating sun set: {}'.format(e))
     else:
         azimut_set_radians, elevation_set_radians = sh.sun.pos(dt=sunset_utc)
         azimut_set_degrees, elevation_set_degrees = sh.sun.pos(dt=sunset_utc, degree=True)
         sh.env.location.sunset.azimut.degrees(round(azimut_set_degrees, 2), logic.lname)
         sh.env.location.sunset.elevation.degrees(round(elevation_set_degrees, 2), logic.lname)
-        sh.env.location.sunset.azimut.radians(round(azimut_set_radians,2), logic.lname)
-        sh.env.location.sunset.elevation.radians(round(elevation_set_radians,2), logic.lname)
+        sh.env.location.sunset.azimut.radians(round(azimut_set_radians, 2), logic.lname)
+        sh.env.location.sunset.elevation.radians(round(elevation_set_radians, 2), logic.lname)
 
     # setting day and night
     try:
@@ -51,18 +54,18 @@ if sh.sun:
         sh.env.location.day(day, logic.lname)
         sh.env.location.night(not day, logic.lname)
     except Exception as e:
-        logger.error("ephem error while calculating day/night: {}".format(e))
+        logger.error('ephem error while calculating day/night: {}'.format(e))
 
 if sh.moon:
     try:
         moonrise_utc = sh.moon.rise()
         sh.env.location.moonrise(moonrise_utc.astimezone(shtime.tzinfo()), logic.lname)
     except Exception as e:
-        logger.error("ephem error while calculating moon rise: {}".format(e))
+        logger.error('ephem error while calculating moon rise: {}'.format(e))
     try:
         moonset_utc = sh.moon.set()
         sh.env.location.moonset(moonset_utc.astimezone(shtime.tzinfo()), logic.lname)
     except Exception as e:
-        logger.error("ephem error while calculating moon set: {}".format(e))
+        logger.error('ephem error while calculating moon set: {}'.format(e))
 
     sh.env.location.moonphase(sh.moon.phase(), logic.lname)

--- a/lib/orb.py
+++ b/lib/orb.py
@@ -281,7 +281,11 @@ class _SkyfieldBackend(_OrbBackend):
 
     def _observer(self, lon, lat, elev):
         self._ensure_loaded()
-        topos = wgs84.latlon(latitude_degrees=lat, longitude_degrees=lon, elevation_m=elev or 0)
+        # skyfield's Angle() does plain numeric division on the degrees value
+        # without coercing it first - non-float types (e.g. Decimal, as
+        # configured via etc/smarthome.yaml) raise a numpy TypeError instead
+        # of computing (python-skyfield#1090). Coerce explicitly.
+        topos = wgs84.latlon(latitude_degrees=float(lat), longitude_degrees=float(lon), elevation_m=float(elev or 0))
         return self._planets['earth'] + topos
 
     def get_observer_and_orb(self, lon, lat, elev, body):

--- a/lib/orb.py
+++ b/lib/orb.py
@@ -29,9 +29,15 @@ import dateutil.relativedelta
 
 from dateutil.tz import tzutc
 
+from lib.constants import DIR_CACHE, DIR_VAR
 from lib.shtime import Shtime
 
 logger = logging.getLogger(__name__)
+
+# shng root directory - same computation lib/smarthome.py uses for its own
+# BASE constant. Not imported from lib.smarthome directly: that module
+# constructs Orb instances itself, so importing it here would be circular.
+_BASE_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 try:
     import ephem
@@ -229,18 +235,34 @@ class _SkyfieldBackend(_OrbBackend):
         if cls._planets is not None:
             return
         data_dir = cls._data_dir()
+        target = os.path.join(data_dir, 'de421.bsp')
+        missing = not os.path.exists(target)
+        if missing:
+            logger.error(
+                f"skyfield: ephemeris data not found at {target}. Run 'tools/fetch_skyfield_data.py' once "
+                f'to download it (~17MB, one-time download, valid through 2053) - attempting to download '
+                f'it now, which will fail if no network access is available.'
+            )
         cls._load = Loader(data_dir)
-        cls._planets = cls._load('de421.bsp')
+        try:
+            cls._planets = cls._load('de421.bsp')
+        except Exception as e:
+            if missing:
+                logger.error(
+                    f'skyfield: automatic download of ephemeris data to {target} failed ({e}). '
+                    f"Fetch it manually once network access is available: 'tools/fetch_skyfield_data.py'"
+                )
+            raise
         cls._ts = cls._load.timescale()
         logger.info(f'skyfield: loaded de421.bsp ephemeris data from {data_dir}')
 
     @staticmethod
     def _data_dir():
-        sh = getattr(Shtime.get_instance(), '_sh', None)
-        var_dir = getattr(sh, '_var_dir', None)
-        if var_dir:
-            return os.path.join(var_dir, 'skyfield-data')
-        return '~/.skyfield-data'
+        # var/cache/ is shng's established location for runtime-downloaded/
+        # regenerable data that should never be committed to the repo. Fixed
+        # relative to shng's own install location - no dependency on a live
+        # Shtime/smarthome instance, and no fallback to the user's home dir.
+        return os.path.join(_BASE_DIR, DIR_VAR, DIR_CACHE, 'skyfield-data')
 
     def _body(self, body):
         self._ensure_loaded()

--- a/lib/orb.py
+++ b/lib/orb.py
@@ -40,30 +40,170 @@ except ImportError:
 
 """
 This library contains a class Orb for calculating sun or moon related events.
-Currently it uses ephem for calculation of the sky bound events.
+
+The actual ephemeris computation is delegated to a swappable backend (see
+_OrbBackend below) - currently only an ephem-based backend exists. This
+indirection exists to allow evaluating alternative ephemeris libraries
+(e.g. skyfield) without changing Orb's public API or any of its callers.
 """
+
+
+class _OrbBackend:
+    """
+    Backend interface for astronomical calculations.
+
+    All datetime/timezone normalisation, degree-offset clamping (avoiding
+    NeverUp/AlwaysUp conditions for non-zero offsets) and moff/day-adjustment
+    arithmetic lives in Orb itself, so it is identical across backends. A
+    backend only has to answer "given this resolved UTC instant, body and
+    horizon, when does the next transit/antitransit/rising/setting happen,
+    or where is the body right now" - nothing more.
+
+    next_rising()/next_setting() must return None (not raise) when the body
+    does not cross the given horizon during the relevant circuit (midnight
+    sun / polar night with doff=0, or an unreachable offset that slipped
+    through despite clamping) - this is a backend-agnostic contract, not an
+    ephem-specific exception type.
+    """
+
+    def get_observer_and_orb(self, lon, lat, elev, body):
+        raise NotImplementedError
+
+    def next_transit(self, lon, lat, elev, body, date_utc, doff):
+        raise NotImplementedError
+
+    def next_antitransit(self, lon, lat, elev, body, date_utc, doff):
+        raise NotImplementedError
+
+    def next_rising(self, lon, lat, elev, body, date_utc, doff, center):
+        raise NotImplementedError
+
+    def next_setting(self, lon, lat, elev, body, date_utc, doff, center):
+        raise NotImplementedError
+
+    def position(self, lon, lat, elev, body, date_utc):
+        """Returns (azimuth_rad, altitude_rad)."""
+        raise NotImplementedError
+
+    def moon_light_percent(self, lon, lat, elev, date_utc):
+        """Returns the illuminated fraction of the moon's disc, 0-100."""
+        raise NotImplementedError
+
+    def moon_phase_octant(self, lon, lat, elev, date_utc):
+        """Returns the moon phase as an octant of its cycle, 0-7."""
+        raise NotImplementedError
+
+
+class _EphemBackend(_OrbBackend):
+    """PyEphem-based implementation of _OrbBackend."""
+
+    def get_observer_and_orb(self, lon, lat, elev, body):
+        """
+        Return a tuple of an instance of an observer with location information
+        and a celestial body
+        Both returned objects are uniquely created to prevent errors in computation
+
+        See also this thread at `Stackoverflow <https://stackoverflow.com/questions/26428904/pyephem-advances-observer-date-on-neveruperror>`_
+        dated back to 2015 where the creator of pyephem writes:
+
+        > Second answer: As long as each thread has its own Moon and Observer objects,
+          it should be able to do its own computations without ruining those of any other threads.
+
+        :return: tuple of observer and celestial body
+        """
+        observer = ephem.Observer()
+        # ephem expects lat and lon as strings
+        observer.long = str(lon)
+        observer.lat = str(lat)
+        if elev:
+            observer.elevation = float(elev)
+
+        if body == 'sun':
+            orb = ephem.Sun()
+            logger.debug("'sun' object requested in function get_observer_and_orb()")
+        elif body == 'moon':
+            orb = ephem.Moon()
+            logger.debug("'moon' object requested in function get_observer_and_orb()")
+        else:
+            logger.error("neither 'sun' nor 'moon' requested in function get_observer_and_orb()")
+
+        return observer, orb
+
+    def next_transit(self, lon, lat, elev, body, date_utc, doff):
+        observer, orb = self.get_observer_and_orb(lon, lat, elev, body)
+        observer.date = date_utc
+        observer.horizon = str(doff)
+        return observer.next_transit(orb).datetime().replace(tzinfo=tzutc())
+
+    def next_antitransit(self, lon, lat, elev, body, date_utc, doff):
+        observer, orb = self.get_observer_and_orb(lon, lat, elev, body)
+        observer.date = date_utc
+        observer.horizon = str(doff)
+        return observer.next_antitransit(orb).datetime().replace(tzinfo=tzutc())
+
+    def next_rising(self, lon, lat, elev, body, date_utc, doff, center):
+        observer, orb = self.get_observer_and_orb(lon, lat, elev, body)
+        observer.date = date_utc
+        observer.horizon = str(doff)
+        try:
+            if not doff == 0:
+                next_rising = observer.next_rising(orb, use_center=center).datetime()
+            else:
+                next_rising = observer.next_rising(orb).datetime()
+        except (ephem.AlwaysUpError, ephem.NeverUpError) as e:
+            logger.notice(f'ephem: {body} has no rise event for {date_utc} at this location ({e}); returning None')
+            return None
+        return next_rising.replace(tzinfo=tzutc())
+
+    def next_setting(self, lon, lat, elev, body, date_utc, doff, center):
+        observer, orb = self.get_observer_and_orb(lon, lat, elev, body)
+        observer.date = date_utc
+        observer.horizon = str(doff)
+        try:
+            if not doff == 0:
+                next_setting = observer.next_setting(orb, use_center=center).datetime()
+            else:
+                next_setting = observer.next_setting(orb).datetime()
+        except (ephem.AlwaysUpError, ephem.NeverUpError) as e:
+            logger.notice(f'ephem: {body} has no set event for {date_utc} at this location ({e}); returning None')
+            return None
+        return next_setting.replace(tzinfo=tzutc())
+
+    def position(self, lon, lat, elev, body, date_utc):
+        observer, orb = self.get_observer_and_orb(lon, lat, elev, body)
+        observer.date = date_utc
+        orb.compute(observer)
+        return (orb.az, orb.alt)
+
+    def moon_light_percent(self, lon, lat, elev, date_utc):
+        observer, orb = self.get_observer_and_orb(lon, lat, elev, 'moon')
+        observer.date = date_utc
+        orb.compute(observer)
+        return int(round(orb.moon_phase * 100))
+
+    def moon_phase_octant(self, lon, lat, elev, date_utc):
+        observer, orb = self.get_observer_and_orb(lon, lat, elev, 'moon')
+        observer.date = date_utc
+        orb.compute(observer)
+        cycle = 29.530588861
+        last = ephem.previous_new_moon(observer.date)
+        frac = (observer.date - last) / cycle
+        return int(round(frac * 8))
+
+
+_BACKENDS = {}
+if ephem is not None:
+    _BACKENDS['ephem'] = _EphemBackend
 
 
 class Orb:
     """
     Save an observers location and the name of a celestial body for future use
 
-    The Methods internally use PyEphem for computation
+    The Methods internally use a swappable backend for computation (currently
+    only PyEphem is implemented, see _OrbBackend/_EphemBackend above).
 
-    An `Observer` instance allows  to compute the positions of
-    celestial bodies as seen from a particular position on the Earth's surface.
-    Following attributes can be set after creation (used defaults are given):
-
-        `date` - the moment the `Observer` is created
-        `lat` - zero degrees latitude
-        `lon` - zero degrees longitude
-        `elevation` - 0 meters above sea level
-        `horizon` - 0 degrees
-        `epoch` - J2000
-        `temp` - 15 degrees Celsius
-        `pressure` - 1010 mBar
-
-    All calculations by ephem will be based on utc time.
+    All calculations are based on utc time.
     Changelog of pypehem:
     > Version 4.1.1 (2021 November 27)
     > When you provide PyEphem with a Python datetime that has a time zone attached,
@@ -84,7 +224,7 @@ class Orb:
     This ambiguity is not handled right now
     """
 
-    def __init__(self, orb, lon, lat, elev=False, neverup_delta=0.00001):
+    def __init__(self, orb, lon, lat, elev=False, neverup_delta=0.00001, backend='ephem'):
         """
         Save location and celestial body
 
@@ -92,9 +232,12 @@ class Orb:
         :param lon: longitude of observer in degrees
         :param lat: latitude of observer in degrees
         :param elev: elevation of observer in meters
+        :param backend: name of the ephemeris backend to use (currently only 'ephem')
         """
-        if ephem is None:
-            logger.warning('Could not find/use ephem!')
+        try:
+            self._backend = _BACKENDS[backend]()
+        except KeyError:
+            logger.warning(f"Could not find/use ephemeris backend '{backend}'!")
             return
 
         self.shtime = Shtime.get_instance()
@@ -116,40 +259,17 @@ class Orb:
             self.phase = self._phase
             self.light = self._light
 
-        logger.debug(f'Orb object {orb=} created with location {lon=},{lat=},{elev=}')
+        logger.debug(f'Orb object {orb=} created with location {lon=},{lat=},{elev=}, {backend=}')
 
     def get_observer_and_orb(self):
         """
         Return a tuple of an instance of an observer with location information
-        and a celestial body
-        Both returned objects are uniquely created to prevent errors in computation
-
-        See also this thread at `Stackoverflow <https://stackoverflow.com/questions/26428904/pyephem-advances-observer-date-on-neveruperror>`_
-        dated back to 2015 where the creator of pyephem writes:
-
-        > Second answer: As long as each thread has its own Moon and Observer objects,
-          it should be able to do its own computations without ruining those of any other threads.
+        and a celestial body, as provided by the active backend. Both returned
+        objects are uniquely created to prevent errors in computation.
 
         :return: tuple of observer and celestial body
         """
-
-        observer = ephem.Observer()
-        # ephem expects lat and lon as strings
-        observer.long = str(self.lon)
-        observer.lat = str(self.lat)
-        if self.elev:
-            observer.elevation = float(self.elev)
-
-        if self.orb == 'sun':
-            orb = ephem.Sun()
-            logger.debug("'sun' object requested in function get_observer_and_orb()")
-        elif self.orb == 'moon':
-            orb = ephem.Moon()
-            logger.debug("'moon' object requested in function get_observer_and_orb()")
-        else:
-            logger.error("neither 'sun' nor 'moon' requested in function get_observer_and_orb()")
-
-        return observer, orb
+        return self._backend.get_observer_and_orb(self.lon, self.lat, self.elev, self.orb)
 
     def unaware_datetime_to_utc(self, naive_dt):
         local_aware = naive_dt.replace(tzinfo=self.shtime.tzinfo())
@@ -160,6 +280,19 @@ class Orb:
 
     def utc_to_local(self, utc_dt):
         return utc_dt.astimezone(self.shtime.tzinfo())
+
+    def _resolve_to_utc(self, dt, moff=0):
+        """Resolve an optional dt parameter (None/naive/aware) to a UTC datetime,
+        applying the minute offset the same way for all callers."""
+        if dt is None:
+            return (
+                self.shtime.utcnow()
+                - dateutil.relativedelta.relativedelta(minutes=moff)
+                + dateutil.relativedelta.relativedelta(seconds=2)
+            )
+        if dt.tzinfo is None:
+            return self.unaware_datetime_to_utc(dt) - dateutil.relativedelta.relativedelta(minutes=moff)
+        return self.aware_datetime_to_utc(dt) - dateutil.relativedelta.relativedelta(minutes=moff)
 
     def _avoid_neverup(self, dt, date_utc, doff):
         """
@@ -221,42 +354,17 @@ class Orb:
         :return: datetime of next transit
         :rtype: datetime
         """
-        observer, orb = self.get_observer_and_orb()
-        if dt is None:
-            dt = (
-                self.shtime.utcnow()
-                - dateutil.relativedelta.relativedelta(minutes=moff)
-                + dateutil.relativedelta.relativedelta(seconds=2)
-            )
-            observer.date = dt
-            logger.debug(
-                f'ephem: noon for {self.orb} with doff={doff}, moff={moff}, dt is None, using observer.date={observer.date}'
-            )
-        else:
-            if dt.tzinfo is None:
-                # unaware datetime
-                logger.debug(
-                    f'ephem: noon for {self.orb} with doff={doff}, moff={moff}, dt={dt}, dt is unaware of timezone, assuming local time'
-                )
-                observer.date = self.unaware_datetime_to_utc(dt) - dateutil.relativedelta.relativedelta(minutes=moff)
-            else:
-                logger.debug(
-                    f'ephem: noon for {self.orb} with doff={doff}, moff={moff}, dt={dt}, dt timezone is {dt.tzinfo}'
-                )
-                observer.date = self.aware_datetime_to_utc(dt) - dateutil.relativedelta.relativedelta(minutes=moff)
-
-        # observer.date.datetime will be utc but it might be without tzinfo
-        date_utc = (observer.date.datetime()).replace(tzinfo=tzutc())
+        date_utc = self._resolve_to_utc(dt, moff)
+        logger.debug(f'noon for {self.orb} with doff={doff}, moff={moff}, dt={dt}, resolved date_utc={date_utc}')
 
         # attention: _avoid_neverup itself calls noon(), this might well get circular in some circumstances
         if not doff == 0:
             doff = self._avoid_neverup(dt, date_utc, doff)
 
-        observer.horizon = str(doff)
-        next_transit = observer.next_transit(orb).datetime()
+        next_transit = self._backend.next_transit(self.lon, self.lat, self.elev, self.orb, date_utc, doff)
         next_transit = next_transit + dateutil.relativedelta.relativedelta(minutes=moff)
         next_transit = next_transit.replace(tzinfo=tzutc())
-        logger.debug(f'ephem: noon for {self.orb} with doff={doff}, moff={moff}, dt={dt} will be {next_transit}')
+        logger.debug(f'noon for {self.orb} with doff={doff}, moff={moff}, dt={dt} will be {next_transit}')
         return next_transit
 
     def midnight(self, doff=0, moff=0, dt=None):
@@ -272,43 +380,17 @@ class Orb:
         :return: datetime of next antitransit
         :rtype: datetime
         """
-
-        observer, orb = self.get_observer_and_orb()
-        if dt is None:
-            observer.date = (
-                self.shtime.utcnow()
-                - dateutil.relativedelta.relativedelta(minutes=moff)
-                + dateutil.relativedelta.relativedelta(seconds=2)
-            )
-            logger.debug(
-                f'ephem: midnight for {self.orb} with doff={doff}, moff={moff}, dt is None, using observer.date={observer.date}'
-            )
-        else:
-            if dt.tzinfo is None:
-                # unaware datetime
-                logger.debug(
-                    f'ephem: midnight for {self.orb} with doff={doff}, moff={moff}, dt={dt}, dt is unaware of timezone, assuming local time'
-                )
-                observer.date = self.unaware_datetime_to_utc(dt) - dateutil.relativedelta.relativedelta(minutes=moff)
-            else:
-                logger.debug(
-                    f'ephem: midnight for {self.orb} with doff={doff}, moff={moff}, dt={dt}, dt timezone is {dt.tzinfo}'
-                )
-                observer.date = self.aware_datetime_to_utc(dt) - dateutil.relativedelta.relativedelta(minutes=moff)
-
-        date_utc = (observer.date.datetime()).replace(tzinfo=tzutc())
+        date_utc = self._resolve_to_utc(dt, moff)
+        logger.debug(f'midnight for {self.orb} with doff={doff}, moff={moff}, dt={dt}, resolved date_utc={date_utc}')
 
         # attention: _avoid_neverup itself calls noon(), this might well get circular in some circumstances
         if not doff == 0:
             doff = self._avoid_neverup(dt, date_utc, doff)
 
-        observer.horizon = str(doff)
-        next_antitransit = observer.next_antitransit(orb).datetime()
+        next_antitransit = self._backend.next_antitransit(self.lon, self.lat, self.elev, self.orb, date_utc, doff)
         next_antitransit = next_antitransit + dateutil.relativedelta.relativedelta(minutes=moff)
         next_antitransit = next_antitransit.replace(tzinfo=tzutc())
-        logger.debug(
-            f'ephem: midnight for {self.orb} with doff={doff}, moff={moff}, dt={dt} will be {next_antitransit}'
-        )
+        logger.debug(f'midnight for {self.orb} with doff={doff}, moff={moff}, dt={dt} will be {next_antitransit}')
         return next_antitransit
 
     def rise(self, doff=0, moff=0, center=True, dt=None):
@@ -318,56 +400,33 @@ class Orb:
         :param moff:    minutes offset from time of rise (either before or after)
         :param center:  if True then the centerpoint of either sun or moon will be considered to make the transit otherwise the upper limb will be considered
         :param dt:      start time for the search for a rise, if not given the current time will be used
-        :return: datetime of next rising in utc timezone
+        :return: datetime of next rising in utc timezone, or None if the body does not rise during this circuit
         """
-        observer, orb = self.get_observer_and_orb()
-        # workaround if rise is 0.001 seconds in the past
-        if dt is None:
-            observer.date = self.shtime.utcnow() + dateutil.relativedelta.relativedelta(seconds=2)
-            logger.debug(
-                f'ephem: rise for {self.orb} with doff={doff}, moff={moff}, dt is None, using observer.date={observer.date}'
-            )
-        else:
-            if dt.tzinfo is None:
-                # unaware datetime
-                logger.debug(
-                    f'ephem: rise for {self.orb} with doff={doff}, moff={moff}, dt={dt}, dt is unaware of timezone, assuming local time'
-                )
-                observer.date = self.unaware_datetime_to_utc(dt)
-            else:
-                logger.debug(
-                    f'ephem: rise for {self.orb} with doff={doff}, moff={moff}, dt={dt}, dt timezone is {dt.tzinfo}'
-                )
-                observer.date = self.aware_datetime_to_utc(dt)
-
-        date_utc = (observer.date.datetime()).replace(tzinfo=tzutc())
+        # _resolve_to_utc adds 2 seconds when dt is None, working around rise being 0.001s in the past
+        date_utc = self._resolve_to_utc(dt, 0)
+        logger.debug(f'rise for {self.orb} with doff={doff}, moff={moff}, dt={dt}, resolved date_utc={date_utc}')
 
         # attention: _avoid_neverup itself calls noon(), this might well get circular in some circumstances
         if not doff == 0:
             doff = self._avoid_neverup(dt, date_utc, doff)
-        observer.horizon = str(doff)
-        try:
-            if not doff == 0:
-                next_rising = observer.next_rising(orb, use_center=center).datetime()
-                observer.horizon = 0
-                next_real_rising = observer.next_rising(orb, use_center=center).datetime().replace(tzinfo=tzutc())
-            else:
-                next_rising = observer.next_rising(orb).datetime()
-                next_real_rising = next_rising.replace(tzinfo=tzutc())
-        except (ephem.AlwaysUpError, ephem.NeverUpError) as e:
-            # _avoid_neverup only clamps non-zero degree offsets; a plain (doff=0) rise
-            # genuinely does not occur during midnight sun / polar night at this location.
-            logger.notice(f'ephem: {self.orb} has no rise event for {date_utc} at this location ({e}); returning None')
+
+        next_rising = self._backend.next_rising(self.lon, self.lat, self.elev, self.orb, date_utc, doff, center)
+        if next_rising is None:
             return None
+        if not doff == 0:
+            next_real_rising = self._backend.next_rising(self.lon, self.lat, self.elev, self.orb, date_utc, 0, center)
+            if next_real_rising is None:
+                return None
+        else:
+            next_real_rising = next_rising
+
         next_rising = next_rising + dateutil.relativedelta.relativedelta(minutes=moff)
         next_rising = next_rising.replace(tzinfo=tzutc())
         if doff < 0 and next_rising > next_real_rising:
-            logger.debug(
-                f'ephem: adjusted next_rising {next_rising} to previous day as it is later than {next_real_rising}'
-            )
+            logger.debug(f'adjusted next_rising {next_rising} to previous day as it is later than {next_real_rising}')
             next_rising -= datetime.timedelta(days=1)
         logger.debug(
-            f'ephem: next_rising for {self.orb} with doff={doff}, moff={moff}, center={center}, dt={dt} will be {next_rising}'
+            f'next_rising for {self.orb} with doff={doff}, moff={moff}, center={center}, dt={dt} will be {next_rising}'
         )
         return next_rising
 
@@ -378,56 +437,35 @@ class Orb:
         :param moff:    minutes offset from time of setting (either before or after)
         :param center:  if True then the centerpoint of either sun or moon will be considered to make the transit otherwise the upper limb will be considered
         :param dt:      start time for the search for a setting, if not given the current time will be used
-        :return: datetime of next setting in utc timezone
+        :return: datetime of next setting in utc timezone, or None if the body does not set during this circuit
         """
-        observer, orb = self.get_observer_and_orb()
-        # workaround if set is 0.001 seconds in the past
-        if dt is None:
-            observer.date = self.shtime.utcnow() + dateutil.relativedelta.relativedelta(seconds=2)
-            logger.debug(
-                f'ephem: set for {self.orb} with doff={doff}, moff={moff}, dt is None, using observer.date={observer.date}'
-            )
-        else:
-            if dt.tzinfo is None:
-                # unaware datetime
-                logger.debug(
-                    f'ephem: set for {self.orb} with doff={doff}, moff={moff}, dt={dt}, dt is unaware of timezone, assuming local time'
-                )
-                observer.date = self.unaware_datetime_to_utc(dt)
-            else:
-                logger.debug(
-                    f'ephem: set for {self.orb} with doff={doff}, moff={moff}, dt={dt}, dt timezone is {dt.tzinfo}'
-                )
-                observer.date = self.aware_datetime_to_utc(dt)
-
-        date_utc = (observer.date.datetime()).replace(tzinfo=tzutc())
+        # _resolve_to_utc adds 2 seconds when dt is None, working around set being 0.001s in the past
+        date_utc = self._resolve_to_utc(dt, 0)
+        logger.debug(f'set for {self.orb} with doff={doff}, moff={moff}, dt={dt}, resolved date_utc={date_utc}')
 
         # avoid NeverUp error
         if not doff == 0:
             doff = self._avoid_neverup(dt, date_utc, doff)
-        observer.horizon = str(doff)
-        try:
-            if not doff == 0:
-                next_setting = observer.next_setting(orb, use_center=center).datetime()
-                observer.horizon = 0
-                next_real_setting = observer.next_setting(orb, use_center=center).datetime().replace(tzinfo=tzutc())
-            else:
-                next_setting = observer.next_setting(orb).datetime()
-                next_real_setting = next_setting.replace(tzinfo=tzutc())
-        except (ephem.AlwaysUpError, ephem.NeverUpError) as e:
-            # _avoid_neverup only clamps non-zero degree offsets; a plain (doff=0) setting
-            # genuinely does not occur during midnight sun / polar night at this location.
-            logger.notice(f'ephem: {self.orb} has no set event for {date_utc} at this location ({e}); returning None')
+
+        next_setting = self._backend.next_setting(self.lon, self.lat, self.elev, self.orb, date_utc, doff, center)
+        if next_setting is None:
             return None
+        if not doff == 0:
+            next_real_setting = self._backend.next_setting(self.lon, self.lat, self.elev, self.orb, date_utc, 0, center)
+            if next_real_setting is None:
+                return None
+        else:
+            next_real_setting = next_setting
+
         next_setting = next_setting + dateutil.relativedelta.relativedelta(minutes=moff)
         next_setting = next_setting.replace(tzinfo=tzutc())
         if doff < 0 and next_setting < next_real_setting:
             logger.debug(
-                f'ephem: adjusted next_setting {next_setting} to next day as it is earlier than actual sunset at {next_real_setting}'
+                f'adjusted next_setting {next_setting} to next day as it is earlier than actual sunset at {next_real_setting}'
             )
             next_setting += datetime.timedelta(days=1)
         logger.debug(
-            f'ephem: next_setting for {self.orb} with doff={doff}, moff={moff}, center={center}, dt={dt} will be {next_setting}'
+            f'next_setting for {self.orb} with doff={doff}, moff={moff}, center={center}, dt={dt} will be {next_setting}'
         )
         return next_setting
 
@@ -439,35 +477,27 @@ class Orb:
         :param dt:      time for which the position needs to be calculated
         :return:        a tuple with azimuth and elevation
         """
-        observer, orb = self.get_observer_and_orb()
         if dt is None:
             date = self.shtime.utcnow()
-            logger.debug(
-                f'ephem: pos for {self.orb} with offset={offset}, degree={degree}, dt is None, using observer.date={observer.date}'
-            )
+            logger.debug(f'pos for {self.orb} with offset={offset}, degree={degree}, dt is None, using now={date}')
+        elif dt.tzinfo is None:
+            logger.debug(f'pos for {self.orb} with offset={offset}, degree={degree}, dt={dt}, assuming local time')
+            date = self.unaware_datetime_to_utc(dt)
         else:
-            if dt.tzinfo is None:
-                # unaware datetime
-                logger.debug(
-                    f'ephem: pos for {self.orb} with offset={offset}, degree={degree}, dt={dt}, dt is unaware of timezone, assuming local time'
-                )
-                date = self.unaware_datetime_to_utc(dt)
-            else:
-                logger.debug(
-                    f'ephem: pos for {self.orb} with offset={offset}, degree={degree}, dt={dt}, dt timezone is {dt.tzinfo}'
-                )
-                date = self.aware_datetime_to_utc(dt)
+            logger.debug(
+                f'pos for {self.orb} with offset={offset}, degree={degree}, dt={dt}, dt timezone is {dt.tzinfo}'
+            )
+            date = self.aware_datetime_to_utc(dt)
 
         if offset:
             date += dateutil.relativedelta.relativedelta(minutes=offset)
 
-        observer.date = date
-        orb.compute(observer)
+        az, alt = self._backend.position(self.lon, self.lat, self.elev, self.orb, date)
 
         if degree:
-            return (math.degrees(orb.az), math.degrees(orb.alt))
+            return (math.degrees(az), math.degrees(alt))
         else:
-            return (orb.az, orb.alt)
+            return (az, alt)
 
     def _light(self, offset=None):
         """
@@ -475,14 +505,10 @@ class Orb:
         for the current time plus an offset
         :param offset: an offset given in minutes
         """
-        observer, orb = self.get_observer_and_orb()
         date = self.shtime.utcnow()
         if offset:
             date += dateutil.relativedelta.relativedelta(minutes=offset)
-        observer.date = date
-        orb.compute(observer)
-        light = int(round(orb.moon_phase * 100))
-        return light
+        return self._backend.moon_light_percent(self.lon, self.lat, self.elev, date)
 
     def _phase(self, offset=None):
         """
@@ -490,14 +516,7 @@ class Orb:
         for the current time plus an offset
         :param offset: an offset given in minutes
         """
-        observer, orb = self.get_observer_and_orb()
         date = self.shtime.utcnow()
-        cycle = 29.530588861
         if offset:
             date += dateutil.relativedelta.relativedelta(minutes=offset)
-        observer.date = date
-        orb.compute(observer)
-        last = ephem.previous_new_moon(observer.date)
-        frac = (observer.date - last) / cycle
-        phase = int(round(frac * 8))
-        return phase
+        return self._backend.moon_phase_octant(self.lon, self.lat, self.elev, date)

--- a/lib/orb.py
+++ b/lib/orb.py
@@ -21,23 +21,34 @@
 #  along with SmartHomeNG.  If not, see <http://www.gnu.org/licenses/>.
 ##########################################################################
 
+import bisect
 import logging
 import datetime
 import math
 import os
+import sys
 import dateutil.relativedelta
 
 from dateutil.tz import tzutc
-
-from lib.constants import DIR_CACHE, DIR_VAR
-from lib.shtime import Shtime
-
-logger = logging.getLogger(__name__)
 
 # shng root directory - same computation lib/smarthome.py uses for its own
 # BASE constant. Not imported from lib.smarthome directly: that module
 # constructs Orb instances itself, so importing it here would be circular.
 _BASE_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+if __name__ == '__main__':
+    # Allow running this file directly (python3 lib/orb.py ...) for the
+    # built-in backend benchmark below. Needed because the lib.* imports just
+    # below resolve relative to shng's root, which is normally already on
+    # sys.path by the time anything imports lib.orb as part of the running
+    # application (bin/smarthome.py, tests, ...) - but not when this file
+    # itself is the script being executed.
+    sys.path.insert(0, _BASE_DIR)
+
+from lib.constants import DIR_CACHE, DIR_VAR
+from lib.shtime import Shtime
+
+logger = logging.getLogger(__name__)
 
 try:
     import ephem
@@ -357,11 +368,173 @@ class _SkyfieldBackend(_OrbBackend):
         return int(round(phase_angle / 360 * 8))
 
 
+class _SkyfieldCachedBackend(_SkyfieldBackend):
+    """
+    Skyfield backend with the rise/set/transit/antitransit caching strategy
+    from the smarthome_skyfield PoC (https://github.com/CaeruleusAqua/smarthome_skyfield):
+    instead of running a fresh almanac search per call, pre-computes a batch of
+    events covering CACHE_HORIZON_DAYS and does an O(log n) bisect lookup against
+    that list for each query. Benchmarked (tools/benchmark_skyfield_caching.py) at
+    roughly 4-5 orders of magnitude cheaper per call than the uncached backend,
+    with the batch itself paying for itself after only ~3-6 calls - worthwhile for
+    shng's actual usage pattern (the same location/doff queried repeatedly, e.g.
+    daily sunrise/sunset triggers).
+
+    Caches are keyed by doff only and live on the instance (not the class): unlike
+    the location-independent ephemeris data (_planets/_ts, inherited from
+    _SkyfieldBackend), the event list itself depends on lon/lat/elev. moff is
+    applied by Orb itself after getting the raw result (the backend never sees
+    it) and center has no effect on skyfield's search at all (see Orb's
+    docstring discussion) - neither needs to be part of the cache key.
+
+    Note: doff values that get clamped by Orb._avoid_neverup() (non-zero offsets
+    near the edge of what's reachable at a given location/date) can come out as a
+    slightly different float on every call, since the clamp depends on that
+    day's min/max altitude - such calls will rarely if ever hit the cache. This
+    doesn't affect the common doff=0 case (plain sunrise/sunset), which is never
+    clamped and caches perfectly.
+    """
+
+    CACHE_HORIZON_DAYS = 365
+    MAX_CACHE_SIZE = 2000
+    # _SkyfieldBackend.next_rising()/next_setting() (the uncached base class) only
+    # ever search a 2-day window and return None if nothing real turns up in it -
+    # i.e. None means "no event in this immediate circuit", not "no event ever".
+    # The cached lookup must honour the same contract: a circumpolar location can
+    # have its next *real* rise/set months away, found anywhere in the 365-day
+    # cache - returning that distant date instead of None would silently change
+    # the meaning of the result for any caller relying on "None = circumpolar
+    # today" (e.g. Skytime.get_next()'s day-by-day search).
+    SAME_CIRCUIT_DAYS = 2
+
+    def __init__(self):
+        # doff -> (covered_start_utc, covered_end_utc, sorted list of UTC datetimes).
+        # The (start, end) interval is the exact range that has actually been
+        # searched - bisecting the list is only valid evidence of "no event here"
+        # for queries that fall inside it. A query outside [start, end] must
+        # trigger a fresh search instead of trusting whatever the list happens to
+        # contain nearby (see test_sun_rise_matches_across_several_dates in
+        # tests/test_orb.py for the bug this fixes: a query earlier than the
+        # cache's start could otherwise bisect straight to a much later entry).
+        self._rise_cache = {}
+        self._set_cache = {}
+        self._transit_cache = {}
+        self._antitransit_cache = {}
+
+    def _refill_riseset(self, lon, lat, elev, body, doff, search_fn, start):
+        observer = self._observer(lon, lat, elev)
+        orb = self._body(body)
+        end = start + datetime.timedelta(days=self.CACHE_HORIZON_DAYS)
+        t0 = self._ts.from_datetime(start)
+        t1 = self._ts.from_datetime(end)
+        times, events = search_fn(observer, orb, t0, t1, doff)
+        # only keep real horizon crossings - see the events-flag bug we found and
+        # fixed in _SkyfieldBackend.next_rising()/next_setting(); the original PoC's
+        # cached variants didn't filter on this at all.
+        entries = sorted(t.utc_datetime().replace(tzinfo=tzutc()) for t, real in zip(times, events) if real)
+        return start, end, entries
+
+    def _refill_transit(self, lon, lat, elev, body, doff, search_fn, start):
+        observer = self._observer(lon, lat, elev)
+        orb = self._body(body)
+        end = start + datetime.timedelta(days=self.CACHE_HORIZON_DAYS)
+        t0 = self._ts.from_datetime(start)
+        t1 = self._ts.from_datetime(end)
+        times = search_fn(observer, orb, t0, t1)
+        entries = sorted(t.utc_datetime().replace(tzinfo=tzutc()) for t in times)
+        return start, end, entries
+
+    def _lookup(self, cache, doff, date_utc, refill, max_proximity_days=None):
+        cached = cache.get(doff)
+        use_cached = cached is not None and len(cached[2]) <= self.MAX_CACHE_SIZE and cached[0] <= date_utc <= cached[1]
+        if use_cached:
+            _start, end, entries = cached
+            idx = bisect.bisect_right(entries, date_utc)
+            if idx < len(entries):
+                result = entries[idx]
+            elif max_proximity_days is not None and (end - date_utc) >= datetime.timedelta(days=max_proximity_days):
+                # Searched at least max_proximity_days beyond date_utc and found nothing real -
+                # confirmed "no event in this circuit", the same guarantee the uncached
+                # backend gives. Without this check, a query landing exactly at (or very
+                # near) the cached window's end would wrongly read as "confirmed no event"
+                # when really the search just didn't look far enough past that point yet.
+                return None
+            else:
+                use_cached = False
+        if not use_cached:
+            _start, end, entries = refill(date_utc)
+            cache[doff] = (_start, end, entries)
+            idx = bisect.bisect_right(entries, date_utc)
+            result = entries[idx] if idx < len(entries) else None
+        if (
+            result is not None
+            and max_proximity_days is not None
+            and (result - date_utc) > datetime.timedelta(days=max_proximity_days)
+        ):
+            return None
+        return result
+
+    def next_rising(self, lon, lat, elev, body, date_utc, doff, center):
+        self._ensure_loaded()
+        result = self._lookup(
+            self._rise_cache,
+            doff,
+            date_utc,
+            lambda start: self._refill_riseset(lon, lat, elev, body, doff, skyfield_almanac.find_risings, start),
+            max_proximity_days=self.SAME_CIRCUIT_DAYS,
+        )
+        if result is None:
+            logger.notice(
+                f'skyfield (cached): {body} has no rise event for {date_utc} at this location; returning None'
+            )
+        return result
+
+    def next_setting(self, lon, lat, elev, body, date_utc, doff, center):
+        self._ensure_loaded()
+        result = self._lookup(
+            self._set_cache,
+            doff,
+            date_utc,
+            lambda start: self._refill_riseset(lon, lat, elev, body, doff, skyfield_almanac.find_settings, start),
+            max_proximity_days=self.SAME_CIRCUIT_DAYS,
+        )
+        if result is None:
+            logger.notice(f'skyfield (cached): {body} has no set event for {date_utc} at this location; returning None')
+        return result
+
+    def next_transit(self, lon, lat, elev, body, date_utc, doff):
+        self._ensure_loaded()
+        return self._lookup(
+            self._transit_cache,
+            doff,
+            date_utc,
+            lambda start: self._refill_transit(lon, lat, elev, body, doff, skyfield_almanac.find_transits, start),
+        )
+
+    def next_antitransit(self, lon, lat, elev, body, date_utc, doff):
+        self._ensure_loaded()
+
+        def _antitransit_hour_angle(latitude, declination, altitude_radians):
+            return math.pi
+
+        def _find_antitransits(observer, orb, t0, t1):
+            times, _events = skyfield_almanac._find(observer, orb, t0, t1, 0, _antitransit_hour_angle)
+            return times
+
+        return self._lookup(
+            self._antitransit_cache,
+            doff,
+            date_utc,
+            lambda start: self._refill_transit(lon, lat, elev, body, doff, _find_antitransits, start),
+        )
+
+
 _BACKENDS = {}
 if ephem is not None:
     _BACKENDS['ephem'] = _EphemBackend
 if Loader is not None:
     _BACKENDS['skyfield'] = _SkyfieldBackend
+    _BACKENDS['skyfield-cached'] = _SkyfieldCachedBackend
 
 
 class Orb:
@@ -405,7 +578,13 @@ class Orb:
         try:
             self._backend = _BACKENDS[backend]()
         except KeyError:
-            logger.warning(f"Could not find/use ephemeris backend '{backend}'!")
+            if backend.startswith('skyfield') and Loader is None:
+                logger.warning(
+                    f"Could not find/use ephemeris backend '{backend}' - skyfield is not installed. "
+                    f"Run 'tools/fetch_skyfield_data.py' once to install it."
+                )
+            else:
+                logger.warning(f"Could not find/use ephemeris backend '{backend}'!")
             return
 
         self.shtime = Shtime.get_instance()
@@ -688,3 +867,165 @@ class Orb:
         if offset:
             date += dateutil.relativedelta.relativedelta(minutes=offset)
         return self._backend.moon_phase_octant(self.lon, self.lat, self.elev, date)
+
+
+def _benchmark_register_log_levels():
+    """Minimal standalone equivalent of lib.log.Logs.add_logging_level() for the
+    handful of custom levels Orb/_avoid_neverup use (e.g. logger.notice(...)) -
+    avoids depending on the full Logs setup (config files, handlers, ...) or on
+    test-only helpers just to run this benchmark standalone."""
+    for level, name in ((31, 'NOTICE'), (13, 'DBGHIGH'), (12, 'DBGMED'), (11, 'DBGLOW'), (9, 'DEVELOP')):
+        if hasattr(logging.getLoggerClass(), name.lower()):
+            continue
+
+        def _log_for_level(self, message, *args, _level=level, **kwargs):
+            if self.isEnabledFor(_level):
+                self._log(_level, message, args, **kwargs)
+
+        logging.addLevelName(level, name)
+        setattr(logging, name, level)
+        setattr(logging.getLoggerClass(), name.lower(), _log_for_level)
+
+
+def _benchmark_setup_shtime():
+    class _BenchmarkSh:
+        _default_language = 'de'
+
+        def get_config_file(self, basename, extension='.yaml'):
+            return os.path.join(_BASE_DIR, 'etc', basename + extension)
+
+    import lib.shtime as _shtime_mod
+
+    _shtime_mod._shtime_instance = None
+    shtime = Shtime(_BenchmarkSh())
+    shtime.set_tz('UTC')
+    return shtime
+
+
+def _benchmark_generate_queries(n, days_horizon, seed, sequential):
+    """Pre-compute n UTC query timestamps, either:
+    - sequential: one per day, advancing forward from now - matches
+      lib.triggertimes.Skytime's real day-by-day search pattern.
+    - random (default): independently random timestamps within
+      [now, now+days_horizon) - a worst-case stress test for the cached
+      backend, since queries can land anywhere relative to whatever the
+      cache happens to have covered so far.
+    """
+    base = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+    if sequential:
+        return base, [base + datetime.timedelta(days=i) for i in range(n)]
+    import random
+
+    rng = random.Random(seed)
+    return base, [base + datetime.timedelta(seconds=rng.uniform(0, days_horizon * 86400)) for _ in range(n)]
+
+
+def _benchmark_uncached(sun, queries):
+    import time
+
+    t0 = time.perf_counter()
+    for q in queries:
+        sun.rise(dt=q)
+    return time.perf_counter() - t0
+
+
+def _benchmark_cached(sun_cached, queries):
+    import time
+
+    t0 = time.perf_counter()
+    sun_cached.rise(dt=queries[0])
+    first_call_time = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    for q in queries[1:]:
+        sun_cached.rise(dt=q)
+    rest_time = time.perf_counter() - t0
+    return first_call_time, rest_time
+
+
+def _benchmark_print_uncached(label, total, n):
+    avg = total / n
+    print(f'\n--- {label}: uncached (fresh search per call) ---')
+    print(f'Total:   {total:.4f}s for {n} calls')
+    print(f'Average: {avg * 1000:.3f}ms per call')
+    return avg
+
+
+def _run_benchmark(calls, days_horizon, seed, sequential):
+    """Compares the three Orb backends ('ephem', 'skyfield', 'skyfield-cached')
+    answering "next sunrise after dt" queries, to gauge per-call cost and the
+    skyfield-cached backend's upfront batch-search cost.
+
+    sequential queries (one per day, advancing forward) match
+    lib.triggertimes.Skytime's real usage pattern; random queries (the
+    default) are a worst-case stress test for the cache, since a query
+    landing before whatever the cache currently covers forces a fresh
+    365-day batch search.
+    """
+    BERLIN_LON, BERLIN_LAT, BERLIN_ELEV = 13.4050, 52.5200, 34
+
+    _benchmark_register_log_levels()
+    _benchmark_setup_shtime()
+
+    mode = 'sequential (one per day)' if sequential else f'random within {days_horizon} days'
+    print(f'Generating {calls} query timestamps ({mode})...')
+    _base, queries = _benchmark_generate_queries(calls, days_horizon, seed, sequential)
+
+    avg_ephem = None
+    if 'ephem' in _BACKENDS:
+        sun_ephem = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='ephem')
+        total_ephem = _benchmark_uncached(sun_ephem, queries)
+        avg_ephem = _benchmark_print_uncached('ephem', total_ephem, calls)
+    else:
+        print('\nephem not installed - skipping that comparison.')
+
+    avg_a = None
+    if 'skyfield' in _BACKENDS:
+        sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='skyfield')
+        total_a = _benchmark_uncached(sun, queries)
+        avg_a = _benchmark_print_uncached('skyfield', total_a, calls)
+    else:
+        print('\nskyfield not installed - skipping that comparison and the cached backend.')
+        return
+
+    print(f'\n--- skyfield-cached: real backend (batch search covers {days_horizon} days on first use) ---')
+    sun_cached = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='skyfield-cached')
+    sun_cached._backend.CACHE_HORIZON_DAYS = days_horizon
+    first_call_time, rest_time = _benchmark_cached(sun_cached, queries)
+    avg_b = rest_time / (calls - 1) if calls > 1 else 0.0
+    print(f'First call (build + lookup): {first_call_time:.4f}s')
+    print(f'Remaining {calls - 1} calls:        {rest_time:.4f}s')
+    print(f'Average per remaining call:  {avg_b * 1000:.4f}ms')
+
+    print('\n--- Summary ---')
+    if avg_ephem is not None:
+        print(f'skyfield is ~{avg_ephem / avg_a:.1f}x the speed of ephem per uncached call (>1 = skyfield faster).')
+    if avg_b > 0:
+        print(f'skyfield-cached lookups are ~{avg_a / avg_b:.0f}x faster than uncached skyfield per call.')
+        if avg_a > avg_b:
+            breakeven = first_call_time / (avg_a - avg_b)
+            print(f'The cache build pays for itself (vs. uncached skyfield) after ~{breakeven:.1f} calls.')
+    else:
+        print('Remaining-call average rounded to 0 - too fast to measure meaningfully at this --calls value.')
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark lib.orb's Orb backends ('ephem', 'skyfield', 'skyfield-cached') "
+            'answering repeated "next sunrise" queries.'
+        )
+    )
+    parser.add_argument('--calls', '-n', type=int, default=100, help='number of repeat queries (default: 100)')
+    parser.add_argument('--days-horizon', type=int, default=365, help='cache prefill window in days (default: 365)')
+    parser.add_argument('--seed', type=int, default=42, help='random seed for query generation (default: 42)')
+    parser.add_argument(
+        '--sequential',
+        action='store_true',
+        help='use one query per day, advancing forward, instead of random timestamps '
+        "- matches lib.triggertimes.Skytime's real day-by-day search pattern",
+    )
+    args = parser.parse_args()
+    _run_benchmark(args.calls, args.days_horizon, args.seed, args.sequential)

--- a/lib/orb.py
+++ b/lib/orb.py
@@ -152,14 +152,14 @@ class Orb:
         return observer, orb
 
     def unaware_datetime_to_utc(self, naive_dt):
-        local_aware = naive_dt.astimezone()
+        local_aware = naive_dt.replace(tzinfo=self.shtime.tzinfo())
         return local_aware.astimezone(datetime.timezone.utc)
 
     def aware_datetime_to_utc(self, aware_dt):
         return aware_dt.astimezone(datetime.timezone.utc)
 
     def utc_to_local(self, utc_dt):
-        return utc_dt.astimezone()
+        return utc_dt.astimezone(self.shtime.tzinfo())
 
     def _avoid_neverup(self, dt, date_utc, doff):
         """
@@ -346,13 +346,19 @@ class Orb:
         if not doff == 0:
             doff = self._avoid_neverup(dt, date_utc, doff)
         observer.horizon = str(doff)
-        if not doff == 0:
-            next_rising = observer.next_rising(orb, use_center=center).datetime()
-            observer.horizon = 0
-            next_real_rising = observer.next_rising(orb, use_center=center).datetime().replace(tzinfo=tzutc())
-        else:
-            next_rising = observer.next_rising(orb).datetime()
-            next_real_rising = next_rising.replace(tzinfo=tzutc())
+        try:
+            if not doff == 0:
+                next_rising = observer.next_rising(orb, use_center=center).datetime()
+                observer.horizon = 0
+                next_real_rising = observer.next_rising(orb, use_center=center).datetime().replace(tzinfo=tzutc())
+            else:
+                next_rising = observer.next_rising(orb).datetime()
+                next_real_rising = next_rising.replace(tzinfo=tzutc())
+        except (ephem.AlwaysUpError, ephem.NeverUpError) as e:
+            # _avoid_neverup only clamps non-zero degree offsets; a plain (doff=0) rise
+            # genuinely does not occur during midnight sun / polar night at this location.
+            logger.notice(f'ephem: {self.orb} has no rise event for {date_utc} at this location ({e}); returning None')
+            return None
         next_rising = next_rising + dateutil.relativedelta.relativedelta(minutes=moff)
         next_rising = next_rising.replace(tzinfo=tzutc())
         if doff < 0 and next_rising > next_real_rising:
@@ -400,13 +406,19 @@ class Orb:
         if not doff == 0:
             doff = self._avoid_neverup(dt, date_utc, doff)
         observer.horizon = str(doff)
-        if not doff == 0:
-            next_setting = observer.next_setting(orb, use_center=center).datetime()
-            observer.horizon = 0
-            next_real_setting = observer.next_setting(orb, use_center=center).datetime().replace(tzinfo=tzutc())
-        else:
-            next_setting = observer.next_setting(orb).datetime()
-            next_real_setting = next_setting.replace(tzinfo=tzutc())
+        try:
+            if not doff == 0:
+                next_setting = observer.next_setting(orb, use_center=center).datetime()
+                observer.horizon = 0
+                next_real_setting = observer.next_setting(orb, use_center=center).datetime().replace(tzinfo=tzutc())
+            else:
+                next_setting = observer.next_setting(orb).datetime()
+                next_real_setting = next_setting.replace(tzinfo=tzutc())
+        except (ephem.AlwaysUpError, ephem.NeverUpError) as e:
+            # _avoid_neverup only clamps non-zero degree offsets; a plain (doff=0) setting
+            # genuinely does not occur during midnight sun / polar night at this location.
+            logger.notice(f'ephem: {self.orb} has no set event for {date_utc} at this location ({e}); returning None')
+            return None
         next_setting = next_setting + dateutil.relativedelta.relativedelta(minutes=moff)
         next_setting = next_setting.replace(tzinfo=tzutc())
         if doff < 0 and next_setting < next_real_setting:

--- a/lib/orb.py
+++ b/lib/orb.py
@@ -24,6 +24,7 @@
 import logging
 import datetime
 import math
+import os
 import dateutil.relativedelta
 
 from dateutil.tz import tzutc
@@ -36,6 +37,14 @@ try:
     import ephem
 except ImportError:
     ephem = None  # noqa
+
+try:
+    from skyfield.api import Loader, wgs84
+    from skyfield import almanac as skyfield_almanac
+except ImportError:
+    Loader = None  # noqa
+    wgs84 = None  # noqa
+    skyfield_almanac = None  # noqa
 
 
 """
@@ -191,9 +200,146 @@ class _EphemBackend(_OrbBackend):
         return int(round(frac * 8))
 
 
+class _SkyfieldBackend(_OrbBackend):
+    """
+    Skyfield-based implementation of _OrbBackend.
+
+    Skyfield's almanac search functions (find_risings/find_settings/find_transits)
+    sample the search window and bisect, unlike pyephem's Newton-iteration-based
+    next_rising()/next_setting()/next_transit() - this is structurally more robust
+    near turning points (e.g. close to a solstice, where the rate of change of
+    sunset time approaches zero) where the iterative approach has been observed to
+    occasionally overshoot. See orb_eph.py vs. orb_sky.py prototype comparison at
+    https://github.com/CaeruleusAqua/smarthome_skyfield for the origin of this
+    implementation's approach.
+
+    Ephemeris data (de421.bsp, ~17MB) is downloaded on first use and cached on disk;
+    requires network access the first time a Skyfield-backed Orb is created.
+    """
+
+    # Loaded lazily, shared across all instances/Orb objects in this process -
+    # loading the ephemeris file and timescale data is expensive and the data
+    # itself is stateless/reusable.
+    _load = None
+    _planets = None
+    _ts = None
+
+    @classmethod
+    def _ensure_loaded(cls):
+        if cls._planets is not None:
+            return
+        data_dir = cls._data_dir()
+        cls._load = Loader(data_dir)
+        cls._planets = cls._load('de421.bsp')
+        cls._ts = cls._load.timescale()
+        logger.info(f'skyfield: loaded de421.bsp ephemeris data from {data_dir}')
+
+    @staticmethod
+    def _data_dir():
+        sh = getattr(Shtime.get_instance(), '_sh', None)
+        var_dir = getattr(sh, '_var_dir', None)
+        if var_dir:
+            return os.path.join(var_dir, 'skyfield-data')
+        return '~/.skyfield-data'
+
+    def _body(self, body):
+        self._ensure_loaded()
+        return self._planets[body]
+
+    def _observer(self, lon, lat, elev):
+        self._ensure_loaded()
+        topos = wgs84.latlon(latitude_degrees=lat, longitude_degrees=lon, elevation_m=elev or 0)
+        return self._planets['earth'] + topos
+
+    def get_observer_and_orb(self, lon, lat, elev, body):
+        return self._observer(lon, lat, elev), self._body(body)
+
+    def next_transit(self, lon, lat, elev, body, date_utc, doff):
+        # doff (degree offset for the horizon) only affects rise/set, not transit
+        # (the meridian crossing happens regardless of horizon) - kept as a
+        # parameter purely to match the shared _OrbBackend interface.
+        observer = self._observer(lon, lat, elev)
+        orb = self._body(body)
+        t0 = self._ts.from_datetime(date_utc)
+        t1 = self._ts.from_datetime(date_utc + datetime.timedelta(days=2))
+        times = skyfield_almanac.find_transits(observer, orb, t0, t1)
+        if len(times) == 0:
+            return None
+        return times[0].utc_datetime().replace(tzinfo=tzutc())
+
+    def next_antitransit(self, lon, lat, elev, body, date_utc, doff):
+        # skyfield has no public antitransit finder; almanac.find_transits() looks
+        # for hour angle 0 (upper meridian crossing). almanac._find() is the
+        # private generic search helper find_transits() itself uses - reuse it
+        # directly with a target hour angle of pi (180°, lower meridian crossing).
+        observer = self._observer(lon, lat, elev)
+        orb = self._body(body)
+        t0 = self._ts.from_datetime(date_utc)
+        t1 = self._ts.from_datetime(date_utc + datetime.timedelta(days=2))
+
+        def _antitransit_hour_angle(latitude, declination, altitude_radians):
+            return math.pi
+
+        times, _events = skyfield_almanac._find(observer, orb, t0, t1, 0, _antitransit_hour_angle)
+        if len(times) == 0:
+            return None
+        return times[0].utc_datetime().replace(tzinfo=tzutc())
+
+    def next_rising(self, lon, lat, elev, body, date_utc, doff, center):
+        # center (use_center in the ephem backend) has no equivalent in skyfield's
+        # find_risings()/find_settings(): skyfield always computes against the
+        # body's actual apparent disc, there is no "upper limb" mode to opt out of.
+        observer = self._observer(lon, lat, elev)
+        orb = self._body(body)
+        t0 = self._ts.from_datetime(date_utc)
+        t1 = self._ts.from_datetime(date_utc + datetime.timedelta(days=2))
+        times, events = skyfield_almanac.find_risings(observer, orb, t0, t1, doff)
+        for time, event in zip(times, events):
+            if event:
+                return time.utc_datetime().replace(tzinfo=tzutc())
+        # every candidate in the window was a "merely transits, doesn't touch
+        # the horizon" entry - midnight sun / polar night for this horizon.
+        logger.notice(f'skyfield: {body} has no rise event for {date_utc} at this location; returning None')
+        return None
+
+    def next_setting(self, lon, lat, elev, body, date_utc, doff, center):
+        observer = self._observer(lon, lat, elev)
+        orb = self._body(body)
+        t0 = self._ts.from_datetime(date_utc)
+        t1 = self._ts.from_datetime(date_utc + datetime.timedelta(days=2))
+        times, events = skyfield_almanac.find_settings(observer, orb, t0, t1, doff)
+        for time, event in zip(times, events):
+            if event:
+                return time.utc_datetime().replace(tzinfo=tzutc())
+        logger.notice(f'skyfield: {body} has no set event for {date_utc} at this location; returning None')
+        return None
+
+    def position(self, lon, lat, elev, body, date_utc):
+        observer = self._observer(lon, lat, elev)
+        orb = self._body(body)
+        t = self._ts.from_datetime(date_utc)
+        alt, az, _distance = observer.at(t).observe(orb).apparent().altaz()
+        return (az.radians, alt.radians)
+
+    def moon_light_percent(self, lon, lat, elev, date_utc):
+        self._ensure_loaded()
+        t = self._ts.from_datetime(date_utc)
+        phase_angle = skyfield_almanac.moon_phase(self._planets, t).radians
+        light = (1 - math.cos(phase_angle)) / 2 * 100
+        return int(round(light))
+
+    def moon_phase_octant(self, lon, lat, elev, date_utc):
+        self._ensure_loaded()
+        t = self._ts.from_datetime(date_utc)
+        phase_angle = skyfield_almanac.moon_phase(self._planets, t).degrees
+        return int(round(phase_angle / 360 * 8))
+
+
 _BACKENDS = {}
 if ephem is not None:
     _BACKENDS['ephem'] = _EphemBackend
+if Loader is not None:
+    _BACKENDS['skyfield'] = _SkyfieldBackend
 
 
 class Orb:

--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -1,5 +1,6 @@
 # lib.orb:
 ephem>=4.2,<5.0.0
+skyfield>=1.49,<2.0.0
 pytz
 babel
 

--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -1,6 +1,14 @@
 # lib.orb:
+# skyfield is an alternative, opt-in ephemeris backend (orb_backend: skyfield in
+# smarthome.yaml) and deliberately NOT listed here: it's not auto-installed by
+# shpypi's core-requirements check, which runs before smarthome.yaml is even
+# parsed (so it can't know which backend is configured) and would otherwise
+# install skyfield's dependencies (numpy, sgp4, jplephem) for every
+# installation regardless of whether it's ever used. Run
+# tools/fetch_skyfield_data.py once to install skyfield and its ephemeris data
+# before switching to that backend. See lib/orb.py and
+# doc/user/source/referenz/smarthomeng/methoden_sonne_mond.rst.
 ephem>=4.2,<5.0.0
-skyfield>=1.49,<2.0.0
 pytz
 babel
 

--- a/lib/shtime.py
+++ b/lib/shtime.py
@@ -181,6 +181,10 @@ class Shtime:
 
     def ts(self, dt, tz=None):
         """Return dt as posix timestamp, possibly with different local tz"""
+        if dt.tzinfo is not None and tz is None:
+            # already aware and no explicit override: timestamp() is tz-correct as-is,
+            # replacing tzinfo would silently shift the represented instant
+            return dt.timestamp()
         if tz is None:
             tz = self._tzinfo
         return dt.replace(tzinfo=tz).timestamp()
@@ -218,34 +222,34 @@ class Shtime:
 
     def tzname(self):
         """
-        Returns the name about the actual local timezone (e.g. CEST)
+        Returns the name about the actual configured timezone (e.g. CEST)
 
         :return: timezone string (like: 'CEST' or 'CET')
         :rtype: str
         """
 
-        return datetime.datetime.now(tz.tzlocal()).tzname()
+        return self.now().tzname()
 
     def tznameST(self):
         """
-        Returns the name for Standard Time in the local timezone (e.g. CET)
+        Returns the name for Standard Time in the configured timezone (e.g. CET)
 
         :return: Timezone info (like: 'CET')
         :rtype: str
         """
 
-        jan = datetime.datetime.fromtimestamp(datetime.datetime.timestamp(datetime.datetime(2020, 1, 1)), tz.tzlocal())
+        jan = datetime.datetime(2020, 1, 1, tzinfo=self._tzinfo)
         return jan.strftime('%Z')
 
     def tznameDST(self):
         """
-        Returns the name for Daylight Saving Time (DST) in the local timezone (e.g. CEST)
+        Returns the name for Daylight Saving Time (DST) in the configured timezone (e.g. CEST)
 
         :return: Timezone info (like: 'CEST')
         :rtype: str
         """
 
-        jul = datetime.datetime.fromtimestamp(datetime.datetime.timestamp(datetime.datetime(2020, 7, 1)), tz.tzlocal())
+        jul = datetime.datetime(2020, 7, 1, tzinfo=self._tzinfo)
         return jul.strftime('%Z')
 
     def utcnow(self):
@@ -581,8 +585,9 @@ class Shtime:
         else:
             raise TypeError(self.translate("Cannot convert type '{key}' to datetime").format(key=type(key)))
         if isinstance(key, datetime.datetime) and key.tzinfo is None:
-            # key = self._timezone.localize(key)   # uses a pytz method
-            key = key.astimezone(self._timezone)
+            # naive datetime: label it as being in shng's configured timezone, don't shift it.
+            # .astimezone() would instead treat it as OS-local time and convert (shift) it.
+            key = key.replace(tzinfo=self._timezone)
         return key
 
     def date_transform(self, key):
@@ -699,7 +704,7 @@ class Shtime:
         :return: date of today
         :rtype: datetime.date
         """
-        return (datetime.datetime.now() + datetime.timedelta(days=offset)).date()
+        return (self.now() + datetime.timedelta(days=offset)).date()
 
     def tomorrow(self):
         """

--- a/lib/smarthome.py
+++ b/lib/smarthome.py
@@ -569,7 +569,13 @@ class SmartHome:
         # orb_backend: which ephemeris library lib.orb.Orb uses ('ephem' or 'skyfield').
         # Default set in initialize_vars(), overridden by smarthome.yaml if present.
         if self._orb_backend not in lib.orb._BACKENDS:
-            self._logger.warning(f"Could not find/use ephemeris backend '{self._orb_backend}'!")
+            if self._orb_backend.startswith('skyfield') and lib.orb.Loader is None:
+                self._logger.warning(
+                    f"Could not find/use ephemeris backend '{self._orb_backend}' - skyfield is not installed. "
+                    f"Run 'tools/fetch_skyfield_data.py' once to install it."
+                )
+            else:
+                self._logger.warning(f"Could not find/use ephemeris backend '{self._orb_backend}'!")
         elif not (hasattr(self, '_lon') and hasattr(self, '_lat')):
             self._logger.warning('No latitude/longitude specified => you could not use the sun and moon object.')
         else:

--- a/lib/smarthome.py
+++ b/lib/smarthome.py
@@ -163,6 +163,7 @@ class SmartHome:
 
         self._config_etc = False
         self._legacy_instances = True
+        self._orb_backend = 'ephem'
 
     def initialize_dir_vars(self):
         self._base_dir = BASE
@@ -565,13 +566,17 @@ class SmartHome:
         else:
             self._sun_neverup_delta = 0.00001
 
-        if lib.orb.ephem is None:
-            self._logger.warning('Could not find/use ephem!')
+        # orb_backend: which ephemeris library lib.orb.Orb uses ('ephem' or 'skyfield').
+        # Default set in initialize_vars(), overridden by smarthome.yaml if present.
+        if self._orb_backend not in lib.orb._BACKENDS:
+            self._logger.warning(f"Could not find/use ephemeris backend '{self._orb_backend}'!")
         elif not (hasattr(self, '_lon') and hasattr(self, '_lat')):
             self._logger.warning('No latitude/longitude specified => you could not use the sun and moon object.')
         else:
-            self.sun = lib.orb.Orb('sun', self._lon, self._lat, self._elev, self._sun_neverup_delta)
-            self.moon = lib.orb.Orb('moon', self._lon, self._lat, self._elev)
+            self.sun = lib.orb.Orb(
+                'sun', self._lon, self._lat, self._elev, self._sun_neverup_delta, backend=self._orb_backend
+            )
+            self.moon = lib.orb.Orb('moon', self._lon, self._lat, self._elev, backend=self._orb_backend)
 
     @property
     def lat(self) -> float:

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,8 @@
+import contextlib
 import logging
 import os
 import sys
+import time
 import pathlib
 
 # with Linux standard installation of SmartHomeNG
@@ -34,3 +36,26 @@ def register_shng_log_levels():
             logging.addLevelName(level, name)
             setattr(logging, name, level)
             setattr(logging.getLoggerClass(), name.lower(), _make_method(level))
+
+
+@contextlib.contextmanager
+def force_os_tz(tz_name):
+    """Force the process's OS-level timezone to tz_name for the duration of the block.
+
+    Shtime.set_tz() writes os.environ['TZ'], which on some platforms makes naive
+    .astimezone()/.now() calls silently track the *configured* shng timezone too -
+    masking bugs where code should use shng's configured tz but instead falls back
+    to "whatever the OS thinks". This forces a genuine OS/configured mismatch via
+    time.tzset() (POSIX only) so such bugs are actually exercised by tests.
+    """
+    orig_tz = os.environ.get('TZ')
+    os.environ['TZ'] = tz_name
+    time.tzset()
+    try:
+        yield
+    finally:
+        if orig_tz is None:
+            os.environ.pop('TZ', None)
+        else:
+            os.environ['TZ'] = orig_tz
+        time.tzset()

--- a/tests/mock/core.py
+++ b/tests/mock/core.py
@@ -35,7 +35,19 @@ class MockScheduler:
 
         lib.scheduler._scheduler_instance = self
 
-    def add(self, name, obj, prio=3, cron=None, cycle=None, value=None, offset=None, next=None):
+    def add(
+        self,
+        name,
+        obj,
+        prio=3,
+        cron=None,
+        cycle=None,
+        value=None,
+        offset=None,
+        next=None,
+        from_smartplugin=False,
+        items=None,
+    ):
         logger.warning(
             'MockScheduler (add): {}, cron={}, cycle={}, value={}, offset={}'.format(
                 name, str(cron), str(cycle), str(value), str(offset)
@@ -47,8 +59,13 @@ class MockScheduler:
         except AttributeError:
             pass
 
-    def remove(self, name):
+    def remove(self, name, from_smartplugin=False):
         logger.warning('MockScheduler (remove): {}'.format(name))
+
+    def trigger(
+        self, name, obj=None, by='Logic', source=None, value=None, dest=None, prio=3, dt=None, from_smartplugin=False
+    ):
+        logger.warning('MockScheduler (trigger): {}, by={}, value={}'.format(name, by, value))
 
 
 class MockSmartHome:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -27,6 +27,12 @@ beautifulsoup4>=4.1.0
 # testing with pytest
 pytest>=3.6.0
 
+# lib.orb's opt-in skyfield backend (orb_backend: skyfield) is deliberately not
+# in lib/requirements.txt (not auto-installed for every user - see the comment
+# there), but the test suite parametrizes lib.orb's characterization tests
+# against both backends, so it's needed here to get full coverage in CI/dev.
+skyfield>=1.49,<2.0.0
+
 # used by tests/mock/core.py:
 #python-dateutil
 

--- a/tests/test_orb.py
+++ b/tests/test_orb.py
@@ -206,6 +206,13 @@ class TestSunRiseSetSkyfield(TestSunRiseSet):
     BACKEND = 'skyfield'
 
 
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestSunRiseSetSkyfieldCached(TestSunRiseSet):
+    """Same characterization suite again, against the cached skyfield backend."""
+
+    BACKEND = 'skyfield-cached'
+
+
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
 class TestSolarNoon(unittest.TestCase):
     BACKEND = 'ephem'
@@ -239,6 +246,11 @@ class TestSolarNoon(unittest.TestCase):
 @unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
 class TestSolarNoonSkyfield(TestSolarNoon):
     BACKEND = 'skyfield'
+
+
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestSolarNoonSkyfieldCached(TestSolarNoon):
+    BACKEND = 'skyfield-cached'
 
 
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
@@ -289,6 +301,11 @@ class TestSolarPositionSkyfield(TestSolarPosition):
     BACKEND = 'skyfield'
 
 
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestSolarPositionSkyfieldCached(TestSolarPosition):
+    BACKEND = 'skyfield-cached'
+
+
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
 class TestMoon(unittest.TestCase):
     BACKEND = 'ephem'
@@ -327,6 +344,11 @@ class TestMoon(unittest.TestCase):
 @unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
 class TestMoonSkyfield(TestMoon):
     BACKEND = 'skyfield'
+
+
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestMoonSkyfieldCached(TestMoon):
+    BACKEND = 'skyfield-cached'
 
 
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
@@ -422,6 +444,11 @@ class TestEquinoxSkyfield(TestEquinox):
     BACKEND = 'skyfield'
 
 
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestEquinoxSkyfieldCached(TestEquinox):
+    BACKEND = 'skyfield-cached'
+
+
 # ===========================================================================
 # Moon rise/set sanity (only phase/light were characterized before)
 # ===========================================================================
@@ -463,6 +490,11 @@ class TestMoonRiseSet(unittest.TestCase):
 @unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
 class TestMoonRiseSetSkyfield(TestMoonRiseSet):
     BACKEND = 'skyfield'
+
+
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestMoonRiseSetSkyfieldCached(TestMoonRiseSet):
+    BACKEND = 'skyfield-cached'
 
 
 # ===========================================================================
@@ -529,6 +561,89 @@ class TestHighLatitudeNeverUp(unittest.TestCase):
 @unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
 class TestHighLatitudeNeverUpSkyfield(TestHighLatitudeNeverUp):
     BACKEND = 'skyfield'
+
+
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestHighLatitudeNeverUpSkyfieldCached(TestHighLatitudeNeverUp):
+    BACKEND = 'skyfield-cached'
+
+
+# ===========================================================================
+# Correctness: the cached backend must agree with the uncached one exactly.
+# The cache batches a whole year of events and bisects into it instead of
+# running a fresh search per call - these tests catch the bug we found while
+# building it (a circumpolar query returning the next *real* event months
+# away instead of None - see _SkyfieldCachedBackend.SAME_CIRCUIT_DAYS).
+# ===========================================================================
+
+
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestSkyfieldCachedMatchesUncached(unittest.TestCase):
+    def setUp(self):
+        self.shtime = _make_shtime()
+        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='skyfield')
+        self.sun_cached = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='skyfield-cached')
+        self.moon = Orb('moon', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='skyfield')
+        self.moon_cached = Orb('moon', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='skyfield-cached')
+        self.tromso_sun = Orb('sun', TROMSO_LON, TROMSO_LAT, TROMSO_ELEV, backend='skyfield')
+        self.tromso_sun_cached = Orb('sun', TROMSO_LON, TROMSO_LAT, TROMSO_ELEV, backend='skyfield-cached')
+
+    def test_sun_rise_matches_across_several_dates(self):
+        for dt in (_SUMMER_SOLSTICE, _WINTER_SOLSTICE, _SPRING_EQUINOX):
+            with self.subTest(dt=dt):
+                self.assertEqual(self.sun.rise(dt=dt), self.sun_cached.rise(dt=dt))
+
+    def test_sun_set_matches_across_several_dates(self):
+        for dt in (_SUMMER_SOLSTICE, _WINTER_SOLSTICE, _SPRING_EQUINOX):
+            with self.subTest(dt=dt):
+                self.assertEqual(self.sun.set(dt=dt), self.sun_cached.set(dt=dt))
+
+    def test_sun_rise_matches_repeated_calls_across_consecutive_days(self):
+        # exercises the cache hit path (second+ call for the same doff)
+        dt = _SUMMER_SOLSTICE
+        for _ in range(5):
+            with self.subTest(dt=dt):
+                self.assertEqual(self.sun.rise(dt=dt), self.sun_cached.rise(dt=dt))
+            dt = self.sun.rise(dt=dt) + datetime.timedelta(seconds=1)
+
+    def test_noon_midnight_match(self):
+        self.assertEqual(self.sun.noon(dt=_SUMMER_SOLSTICE), self.sun_cached.noon(dt=_SUMMER_SOLSTICE))
+        self.assertEqual(self.sun.midnight(dt=_WINTER_SOLSTICE), self.sun_cached.midnight(dt=_WINTER_SOLSTICE))
+
+    def test_moon_rise_set_match(self):
+        self.assertEqual(self.moon.rise(dt=_SPRING_EQUINOX), self.moon_cached.rise(dt=_SPRING_EQUINOX))
+        self.assertEqual(self.moon.set(dt=_SPRING_EQUINOX), self.moon_cached.set(dt=_SPRING_EQUINOX))
+
+    def test_circumpolar_none_matches(self):
+        # the actual bug this test suite exists to catch: the cached backend
+        # must return None here too, not the next real event months away.
+        self.assertIsNone(self.tromso_sun.rise(dt=_SUMMER_SOLSTICE))
+        self.assertIsNone(self.tromso_sun_cached.rise(dt=_SUMMER_SOLSTICE))
+        self.assertIsNone(self.tromso_sun.set(dt=_SUMMER_SOLSTICE))
+        self.assertIsNone(self.tromso_sun_cached.set(dt=_SUMMER_SOLSTICE))
+        self.assertIsNone(self.tromso_sun.rise(dt=_WINTER_SOLSTICE))
+        self.assertIsNone(self.tromso_sun_cached.rise(dt=_WINTER_SOLSTICE))
+
+    def test_circumpolar_equinox_still_matches(self):
+        # away from the solstices, Tromsø has normal events again - the cache
+        # must resolve these via the proximity check too, not just return None.
+        self.assertEqual(self.tromso_sun.rise(dt=_SPRING_EQUINOX), self.tromso_sun_cached.rise(dt=_SPRING_EQUINOX))
+        self.assertEqual(self.tromso_sun.set(dt=_SPRING_EQUINOX), self.tromso_sun_cached.set(dt=_SPRING_EQUINOX))
+
+    def test_query_at_cache_window_boundary_is_not_a_false_none(self):
+        # Regression test: a query landing exactly at the cached window's end
+        # must not be mistaken for "confirmed no event" - that's just where the
+        # search stopped, not proof nothing exists just beyond it (found via
+        # 1000 sequential daily queries at Berlin - never circumpolar - wrongly
+        # returning None right at each yearly cache-refill boundary). Use a
+        # short CACHE_HORIZON_DAYS to hit the boundary deterministically
+        # without iterating a full year.
+        self.sun_cached._backend.CACHE_HORIZON_DAYS = 3
+        self.sun_cached.rise(dt=_SUMMER_SOLSTICE)  # populates the cache, covered_end = +3 days
+        boundary = _SUMMER_SOLSTICE + datetime.timedelta(days=3)
+        result = self.sun_cached.rise(dt=boundary)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, self.sun.rise(dt=boundary))
 
 
 if __name__ == '__main__':

--- a/tests/test_orb.py
+++ b/tests/test_orb.py
@@ -56,9 +56,18 @@ _SUMMER_SOLSTICE = datetime.datetime(2024, 6, 21, 0, 0, 0, tzinfo=datetime.timez
 _WINTER_SOLSTICE = datetime.datetime(2024, 12, 21, 0, 0, 0, tzinfo=datetime.timezone.utc)
 # Noon on summer solstice (for position tests)
 _SUMMER_NOON = datetime.datetime(2024, 6, 21, 11, 31, 0, tzinfo=datetime.timezone.utc)
+# Spring equinox 2024 (Berlin) — day/night roughly equal length
+_SPRING_EQUINOX = datetime.datetime(2024, 3, 20, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+# Tromsø, Norway (69.65°N) — well inside the Arctic Circle, exercises
+# midnight sun (summer) / polar night (winter), where the sun's plain
+# (doff=0) rise/set genuinely does not occur on the given calendar day.
+TROMSO_LON = 18.9553
+TROMSO_LAT = 69.6492
+TROMSO_ELEV = 10
 
 
-def _make_shtime():
+def _make_shtime(tz='UTC'):
     import lib.shtime as _m
 
     _m._shtime_instance = None
@@ -71,7 +80,7 @@ def _make_shtime():
             return os.path.join(base, basename + extension)
 
     st = Shtime(_Sh())
-    st.set_tz('UTC')
+    st.set_tz(tz)
     return st
 
 
@@ -287,6 +296,159 @@ class TestCoordinateConversions(unittest.TestCase):
         utc = datetime.datetime(2024, 6, 21, 12, 0, 0, tzinfo=datetime.timezone.utc)
         result = self.sun.utc_to_local(utc)
         self.assertIsInstance(result, datetime.datetime)
+
+
+@unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
+class TestCoordinateConversionsUseConfiguredTz(unittest.TestCase):
+    """Regression tests: unaware_datetime_to_utc/utc_to_local must use shng's
+    configured timezone (self.shtime.tzinfo()), not whatever the OS-level
+    timezone happens to be. force_os_tz creates a genuine mismatch so these
+    actually exercise the bug rather than relying on OS/configured tz happening
+    to agree in the test environment."""
+
+    def setUp(self):
+        self.shtime = _make_shtime('Pacific/Honolulu')
+        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+
+    def test_unaware_to_utc_uses_configured_tz(self):
+        with common.force_os_tz('Europe/Berlin'):
+            naive = datetime.datetime(2024, 6, 15, 12, 0, 0)
+            result = self.sun.unaware_datetime_to_utc(naive)
+            # 12:00 Honolulu (UTC-10) -> 22:00 UTC same day
+            self.assertEqual(result, datetime.datetime(2024, 6, 15, 22, 0, 0, tzinfo=datetime.timezone.utc))
+
+    def test_utc_to_local_uses_configured_tz(self):
+        with common.force_os_tz('Europe/Berlin'):
+            utc_dt = datetime.datetime(2024, 6, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+            result = self.sun.utc_to_local(utc_dt)
+            # 12:00 UTC -> 02:00 Honolulu (UTC-10) same day
+            self.assertEqual(result.hour, 2)
+            self.assertEqual(result.utcoffset(), datetime.timedelta(hours=-10))
+
+
+# ===========================================================================
+# Equinox sanity (second reference point beyond the solstice tests, prep
+# for ephem-to-skyfield comparison)
+# ===========================================================================
+
+
+@unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
+class TestEquinox(unittest.TestCase):
+    def setUp(self):
+        self.shtime = _make_shtime()
+        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+
+    def test_equinox_day_length_close_to_twelve_hours(self):
+        # True day/night equality ("equilux") happens a few days after the
+        # astronomical equinox due to atmospheric refraction and the sun's
+        # angular size; 30 min tolerance covers that gap.
+        rise = self.sun.rise(dt=_SPRING_EQUINOX)
+        sset = self.sun.set(dt=_SPRING_EQUINOX)
+        day_length = sset - rise
+        self.assertLess(abs(day_length.total_seconds() - 12 * 3600), 30 * 60)
+
+    def test_equinox_rise_approx(self):
+        expected = datetime.datetime(2024, 3, 20, 5, 8, 0, tzinfo=datetime.timezone.utc)
+        result = self.sun.rise(dt=_SPRING_EQUINOX)
+        diff = abs(result.replace(tzinfo=datetime.timezone.utc) - expected)
+        self.assertLessEqual(diff, datetime.timedelta(minutes=15))
+
+    def test_equinox_set_approx(self):
+        expected = datetime.datetime(2024, 3, 20, 17, 21, 0, tzinfo=datetime.timezone.utc)
+        result = self.sun.set(dt=_SPRING_EQUINOX)
+        diff = abs(result.replace(tzinfo=datetime.timezone.utc) - expected)
+        self.assertLessEqual(diff, datetime.timedelta(minutes=15))
+
+
+# ===========================================================================
+# Moon rise/set sanity (only phase/light were characterized before)
+# ===========================================================================
+
+
+@unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
+class TestMoonRiseSet(unittest.TestCase):
+    def setUp(self):
+        self.shtime = _make_shtime()
+        self.moon = Orb('moon', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+
+    def test_moon_rise_is_utc_aware(self):
+        result = self.moon.rise(dt=_SPRING_EQUINOX)
+        self.assertIsNotNone(result.tzinfo)
+
+    def test_moon_set_is_utc_aware(self):
+        result = self.moon.set(dt=_SPRING_EQUINOX)
+        self.assertIsNotNone(result.tzinfo)
+
+    def test_moon_rise_within_24h_of_search_start(self):
+        # Moon rise/set always occurs roughly once per ~24h50m (lunar day);
+        # a "next" search should never jump multiple days.
+        result = self.moon.rise(dt=_SPRING_EQUINOX)
+        self.assertLess((result - _SPRING_EQUINOX).total_seconds() / 3600, 26)
+
+    def test_moon_set_within_24h_of_search_start(self):
+        result = self.moon.set(dt=_SPRING_EQUINOX)
+        self.assertLess((result - _SPRING_EQUINOX).total_seconds() / 3600, 26)
+
+    def test_moon_minute_offset_shifts_time(self):
+        rise_plain = self.moon.rise(dt=_SPRING_EQUINOX)
+        rise_plus30 = self.moon.rise(moff=30, dt=_SPRING_EQUINOX)
+        diff = rise_plus30 - rise_plain
+        self.assertAlmostEqual(diff.total_seconds() / 60, 30, delta=1)
+
+
+# ===========================================================================
+# High-latitude (midnight sun / polar night) regression tests
+#
+# Orb.rise()/set() with doff=0 (the default) used to crash with an uncaught
+# ephem.AlwaysUpError/NeverUpError at any location where the sun's plain
+# horizon crossing genuinely does not occur on the given day. _avoid_neverup
+# only clamps non-zero degree offsets, so this path had no protection.
+# ===========================================================================
+
+
+@unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
+class TestHighLatitudeNeverUp(unittest.TestCase):
+    def setUp(self):
+        self.shtime = _make_shtime()
+        self.sun = Orb('sun', TROMSO_LON, TROMSO_LAT, TROMSO_ELEV)
+
+    def test_midnight_sun_rise_returns_none_not_raises(self):
+        # Tromsø, summer solstice: sun never sets, so it never "rises" either
+        # (it's already up). Must not raise AlwaysUpError.
+        result = self.sun.rise(dt=_SUMMER_SOLSTICE)
+        self.assertIsNone(result)
+
+    def test_midnight_sun_set_returns_none_not_raises(self):
+        result = self.sun.set(dt=_SUMMER_SOLSTICE)
+        self.assertIsNone(result)
+
+    def test_polar_night_rise_returns_none_not_raises(self):
+        # Tromsø, winter solstice: sun never rises above the horizon.
+        result = self.sun.rise(dt=_WINTER_SOLSTICE)
+        self.assertIsNone(result)
+
+    def test_polar_night_set_returns_none_not_raises(self):
+        result = self.sun.set(dt=_WINTER_SOLSTICE)
+        self.assertIsNone(result)
+
+    def test_noon_unaffected_by_midnight_sun(self):
+        # Transit (solar noon) always exists regardless of whether the sun
+        # crosses the horizon that day.
+        result = self.sun.noon(dt=_SUMMER_SOLSTICE)
+        self.assertIsInstance(result, datetime.datetime)
+
+    def test_midnight_unaffected_by_polar_night(self):
+        result = self.sun.midnight(dt=_WINTER_SOLSTICE)
+        self.assertIsInstance(result, datetime.datetime)
+
+    def test_equinox_rise_set_work_normally_at_high_latitude(self):
+        # Sanity check: away from the solstices, Tromsø still has normal
+        # rise/set events (this should never have been broken).
+        rise = self.sun.rise(dt=_SPRING_EQUINOX)
+        sset = self.sun.set(dt=_SPRING_EQUINOX)
+        self.assertIsInstance(rise, datetime.datetime)
+        self.assertIsInstance(sset, datetime.datetime)
+        self.assertLess(rise, sset)
 
 
 if __name__ == '__main__':

--- a/tests/test_orb.py
+++ b/tests/test_orb.py
@@ -38,6 +38,13 @@ try:
 except ImportError:
     HAS_EPHEM = False
 
+try:
+    from skyfield.api import Loader as _skyfield_loader_check
+
+    HAS_SKYFIELD = True
+except ImportError:
+    HAS_SKYFIELD = False
+
 from lib.orb import Orb
 from lib.shtime import Shtime
 
@@ -100,10 +107,17 @@ class TestOrbInit(unittest.TestCase):
         self.assertIsInstance(orb._backend, _EphemBackend)
 
     def test_unknown_backend_warns_and_leaves_orb_unconfigured(self):
-        orb = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='skyfield')
-        # skyfield isn't registered yet (tracer bullet for the planned migration) -
-        # Orb.__init__ returns early, same as the historical "ephem not installed" case.
+        orb = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='nonexistent')
+        # Orb.__init__ returns early for an unregistered backend name, same as
+        # the historical "ephem not installed" case.
         self.assertFalse(hasattr(orb, 'orb'))
+
+    @unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+    def test_skyfield_backend_selectable(self):
+        orb = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='skyfield')
+        from lib.orb import _SkyfieldBackend
+
+        self.assertIsInstance(orb._backend, _SkyfieldBackend)
 
     def test_moon_object_created(self):
         orb = Orb('moon', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
@@ -128,10 +142,11 @@ class TestSunRiseSet(unittest.TestCase):
     """Sunrise and sunset times against published USNO values (±10 min)."""
 
     TOLERANCE = datetime.timedelta(minutes=10)
+    BACKEND = 'ephem'
 
     def setUp(self):
         self.shtime = _make_shtime()
-        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend=self.BACKEND)
 
     def test_summer_solstice_sunrise_approx(self):
         # pyephem computes Berlin sunrise on 2024-06-21 ≈ 02:43 UTC.
@@ -184,11 +199,20 @@ class TestSunRiseSet(unittest.TestCase):
         self.assertAlmostEqual(diff.total_seconds() / 60, 30, delta=1)
 
 
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestSunRiseSetSkyfield(TestSunRiseSet):
+    """Same characterization suite as TestSunRiseSet, against the skyfield backend."""
+
+    BACKEND = 'skyfield'
+
+
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
 class TestSolarNoon(unittest.TestCase):
+    BACKEND = 'ephem'
+
     def setUp(self):
         self.shtime = _make_shtime()
-        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend=self.BACKEND)
 
     def test_noon_approx_time(self):
         # pyephem computes Berlin solar noon on 2024-06-21 ≈ 11:08 UTC.
@@ -212,11 +236,18 @@ class TestSolarNoon(unittest.TestCase):
         self.assertIsNotNone(result.tzinfo)
 
 
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestSolarNoonSkyfield(TestSolarNoon):
+    BACKEND = 'skyfield'
+
+
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
 class TestSolarPosition(unittest.TestCase):
+    BACKEND = 'ephem'
+
     def setUp(self):
         self.shtime = _make_shtime()
-        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend=self.BACKEND)
 
     def test_pos_returns_two_values(self):
         result = self.sun.pos(dt=_SUMMER_SOLSTICE)
@@ -253,11 +284,18 @@ class TestSolarPosition(unittest.TestCase):
         self.assertLessEqual(el_deg, 90)
 
 
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestSolarPositionSkyfield(TestSolarPosition):
+    BACKEND = 'skyfield'
+
+
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
 class TestMoon(unittest.TestCase):
+    BACKEND = 'ephem'
+
     def setUp(self):
         self.shtime = _make_shtime()
-        self.moon = Orb('moon', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+        self.moon = Orb('moon', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend=self.BACKEND)
 
     def test_moon_rise_returns_datetime(self):
         result = self.moon.rise(dt=_SUMMER_SOLSTICE)
@@ -284,6 +322,11 @@ class TestMoon(unittest.TestCase):
         self.assertIsInstance(result, int)
         self.assertGreaterEqual(result, 0)
         self.assertLessEqual(result, 100)
+
+
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestMoonSkyfield(TestMoon):
+    BACKEND = 'skyfield'
 
 
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
@@ -346,9 +389,11 @@ class TestCoordinateConversionsUseConfiguredTz(unittest.TestCase):
 
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
 class TestEquinox(unittest.TestCase):
+    BACKEND = 'ephem'
+
     def setUp(self):
         self.shtime = _make_shtime()
-        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+        self.sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend=self.BACKEND)
 
     def test_equinox_day_length_close_to_twelve_hours(self):
         # True day/night equality ("equilux") happens a few days after the
@@ -372,6 +417,11 @@ class TestEquinox(unittest.TestCase):
         self.assertLessEqual(diff, datetime.timedelta(minutes=15))
 
 
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestEquinoxSkyfield(TestEquinox):
+    BACKEND = 'skyfield'
+
+
 # ===========================================================================
 # Moon rise/set sanity (only phase/light were characterized before)
 # ===========================================================================
@@ -379,9 +429,11 @@ class TestEquinox(unittest.TestCase):
 
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
 class TestMoonRiseSet(unittest.TestCase):
+    BACKEND = 'ephem'
+
     def setUp(self):
         self.shtime = _make_shtime()
-        self.moon = Orb('moon', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+        self.moon = Orb('moon', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend=self.BACKEND)
 
     def test_moon_rise_is_utc_aware(self):
         result = self.moon.rise(dt=_SPRING_EQUINOX)
@@ -408,6 +460,11 @@ class TestMoonRiseSet(unittest.TestCase):
         self.assertAlmostEqual(diff.total_seconds() / 60, 30, delta=1)
 
 
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestMoonRiseSetSkyfield(TestMoonRiseSet):
+    BACKEND = 'skyfield'
+
+
 # ===========================================================================
 # High-latitude (midnight sun / polar night) regression tests
 #
@@ -415,14 +472,20 @@ class TestMoonRiseSet(unittest.TestCase):
 # ephem.AlwaysUpError/NeverUpError at any location where the sun's plain
 # horizon crossing genuinely does not occur on the given day. _avoid_neverup
 # only clamps non-zero degree offsets, so this path had no protection.
+#
+# The skyfield variant exercises the *different* mechanism that backend uses
+# to signal "no event": checking the find_risings()/find_settings() events
+# flag rather than catching an ephem-specific exception.
 # ===========================================================================
 
 
 @unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
 class TestHighLatitudeNeverUp(unittest.TestCase):
+    BACKEND = 'ephem'
+
     def setUp(self):
         self.shtime = _make_shtime()
-        self.sun = Orb('sun', TROMSO_LON, TROMSO_LAT, TROMSO_ELEV)
+        self.sun = Orb('sun', TROMSO_LON, TROMSO_LAT, TROMSO_ELEV, backend=self.BACKEND)
 
     def test_midnight_sun_rise_returns_none_not_raises(self):
         # Tromsø, summer solstice: sun never sets, so it never "rises" either
@@ -461,6 +524,11 @@ class TestHighLatitudeNeverUp(unittest.TestCase):
         self.assertIsInstance(rise, datetime.datetime)
         self.assertIsInstance(sset, datetime.datetime)
         self.assertLess(rise, sset)
+
+
+@unittest.skipUnless(HAS_SKYFIELD, 'skyfield not installed')
+class TestHighLatitudeNeverUpSkyfield(TestHighLatitudeNeverUp):
+    BACKEND = 'skyfield'
 
 
 if __name__ == '__main__':

--- a/tests/test_orb.py
+++ b/tests/test_orb.py
@@ -93,6 +93,18 @@ class TestOrbInit(unittest.TestCase):
         orb = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
         self.assertEqual(orb.orb, 'sun')
 
+    def test_ephem_backend_used_by_default(self):
+        orb = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+        from lib.orb import _EphemBackend
+
+        self.assertIsInstance(orb._backend, _EphemBackend)
+
+    def test_unknown_backend_warns_and_leaves_orb_unconfigured(self):
+        orb = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV, backend='skyfield')
+        # skyfield isn't registered yet (tracer bullet for the planned migration) -
+        # Orb.__init__ returns early, same as the historical "ephem not installed" case.
+        self.assertFalse(hasattr(orb, 'orb'))
+
     def test_moon_object_created(self):
         orb = Orb('moon', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
         self.assertEqual(orb.orb, 'moon')

--- a/tests/test_shtime.py
+++ b/tests/test_shtime.py
@@ -30,6 +30,8 @@ import unittest
 # Make shng root importable
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
+import tests.common as common
+
 
 # ---------------------------------------------------------------------------
 # Register shng's custom log levels before importing shtime.
@@ -244,6 +246,17 @@ class TestDatetimeTransform(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.st.datetime_transform([2024, 1, 1])
 
+    def test_naive_datetime_is_labeled_not_shifted(self):
+        # Regression test: a naive datetime must be interpreted as wall-clock
+        # time *in the configured timezone*, not as OS-local time that gets
+        # converted. force_os_tz creates a genuine OS/configured mismatch.
+        st = _make_shtime('Pacific/Honolulu')
+        with common.force_os_tz('Europe/Berlin'):
+            dt = datetime.datetime(2024, 6, 15, 12, 0, 0)
+            result = st.datetime_transform(dt)
+            self.assertEqual(result.hour, 12)
+            self.assertEqual(result.utcoffset(), datetime.timedelta(hours=-10))
+
 
 class TestDateTransform(unittest.TestCase):
     def setUp(self):
@@ -437,6 +450,100 @@ class TestBeginningOf(unittest.TestCase):
     def test_beginning_of_year_with_positive_offset(self):
         result = self.st.beginning_of_year(year=2024, offset=1)
         self.assertEqual(result, datetime.date(2025, 1, 1))
+
+
+# ===========================================================================
+# today / tomorrow / yesterday
+#
+# NOTE: real OS-tz/configured-tz mismatch can't be exercised deterministically
+# here because the bug only manifests near midnight relative to the offset
+# difference, and "now" is real wall-clock time at test run. These verify the
+# contract instead: today() must derive from the configured tz via now().
+# ===========================================================================
+
+
+class TestTodayTomorrowYesterday(unittest.TestCase):
+    def setUp(self):
+        self.st = _make_shtime('Pacific/Honolulu')
+
+    def test_today_matches_now_date_in_configured_tz(self):
+        self.assertEqual(self.st.today(), self.st.now().date())
+
+    def test_tomorrow_is_today_plus_one(self):
+        self.assertEqual(self.st.tomorrow(), self.st.today() + datetime.timedelta(days=1))
+
+    def test_yesterday_is_today_minus_one(self):
+        self.assertEqual(self.st.yesterday(), self.st.today() - datetime.timedelta(days=1))
+
+    def test_today_offset(self):
+        self.assertEqual(self.st.today(offset=2), self.st.today() + datetime.timedelta(days=2))
+
+
+# ===========================================================================
+# tzname / tznameST / tznameDST
+#
+# Regression tests: these must report the *configured* timezone's name, not
+# whatever the OS-level timezone happens to be (dateutil's tz.tzlocal() reads
+# OS state dynamically, so force_os_tz can genuinely discriminate here).
+# ===========================================================================
+
+
+class TestTzNames(unittest.TestCase):
+    def setUp(self):
+        self.st = _make_shtime('Pacific/Honolulu')
+
+    def test_tzname_reports_configured_tz(self):
+        with common.force_os_tz('Europe/Berlin'):
+            self.assertEqual(self.st.tzname(), 'HST')
+
+    def test_tznameST_reports_configured_tz(self):
+        with common.force_os_tz('Europe/Berlin'):
+            self.assertEqual(self.st.tznameST(), 'HST')
+
+    def test_tznameDST_reports_configured_tz(self):
+        with common.force_os_tz('Europe/Berlin'):
+            self.assertEqual(self.st.tznameDST(), 'HST')
+
+    def test_tzname_distinguishes_st_and_dst_for_dst_observing_zone(self):
+        # Pacific/Honolulu has no DST (always HST); Europe/Berlin does
+        # (CET in winter, CEST in summer) - use it to confirm ST != DST name.
+        st = _make_shtime('Europe/Berlin')
+        self.assertEqual(st.tznameST(), 'CET')
+        self.assertEqual(st.tznameDST(), 'CEST')
+
+
+# ===========================================================================
+# ts()
+#
+# Regression test: ts() must not overwrite tzinfo on an already-aware
+# datetime (no OS-tz involvement needed - this is purely an
+# overwrite-vs-preserve bug).
+# ===========================================================================
+
+
+class TestTs(unittest.TestCase):
+    def setUp(self):
+        self.st = _make_shtime('Europe/Berlin')
+
+    def test_aware_datetime_timestamp_unaffected_by_configured_tz(self):
+        # 12:00 UTC must yield the same posix timestamp regardless of shng's
+        # configured timezone - ts() must not relabel it to Europe/Berlin.
+        utc_dt = datetime.datetime(2024, 6, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        expected = utc_dt.timestamp()
+        self.assertEqual(self.st.ts(utc_dt), expected)
+
+    def test_naive_datetime_uses_configured_tz(self):
+        naive_dt = datetime.datetime(2024, 6, 15, 12, 0, 0)
+        result = self.st.ts(naive_dt)
+        expected = naive_dt.replace(tzinfo=self.st.tzinfo()).timestamp()
+        self.assertEqual(result, expected)
+
+    def test_explicit_tz_override_still_works(self):
+        naive_dt = datetime.datetime(2024, 6, 15, 12, 0, 0)
+        honolulu = _make_shtime('Pacific/Honolulu').tzinfo()
+        result = self.st.ts(naive_dt, tz=honolulu)
+        expected = naive_dt.replace(tzinfo=honolulu).timestamp()
+        self.assertEqual(result, expected)
 
 
 # ===========================================================================

--- a/tests/test_triggertimes.py
+++ b/tests/test_triggertimes.py
@@ -25,12 +25,57 @@ from . import common
 import unittest
 import logging
 import datetime
+import os
 
 from tests.mock.core import MockSmartHome
 
-from lib.triggertimes import Crontab
+from lib.triggertimes import Crontab, Skytime
+
+try:
+    import ephem as _ephem_check
+
+    HAS_EPHEM = True
+except ImportError:
+    HAS_EPHEM = False
+
+from lib.shtime import Shtime
+from lib.orb import Orb
+
+common.register_shng_log_levels()
 
 logger = logging.getLogger(__name__)
+
+BERLIN_LON = 13.4050
+BERLIN_LAT = 52.5200
+BERLIN_ELEV = 34
+
+
+def _make_sky_env(tz='Europe/Berlin'):
+    """Set up a minimal Shtime + Orb('sun') environment and register it with
+    Skytime, mirroring how bin/smarthome.py wires sh.shtime/sh.sun/sh.moon."""
+    import lib.shtime as _m
+
+    _m._shtime_instance = None
+
+    class _Sh:
+        _default_language = 'de'
+
+        def get_config_file(self, basename, extension='.yaml'):
+            base = os.path.join(os.path.dirname(__file__), 'resources', 'etc')
+            return os.path.join(base, basename + extension)
+
+    shtime = Shtime(_Sh())
+    shtime.set_tz(tz)
+    sun = Orb('sun', BERLIN_LON, BERLIN_LAT, BERLIN_ELEV)
+
+    class _SkySh:
+        def __init__(self, shtime, sun):
+            self.shtime = shtime
+            self.sun = sun
+            self.moon = sun  # unused by these tests, just needs to exist
+
+    Skytime.set_smarthome_reference(_SkySh(shtime, sun))
+    return shtime, sun
 
 
 class TestCrontab(unittest.TestCase):
@@ -200,6 +245,38 @@ class TestCrontab(unittest.TestCase):
 
         logger.warning('\nfurthermore fancy dates')
         self.assertEqual(Crontab('59 59 23 31 10 *').get_next(now), datetime.datetime(year, 10, 31, 23, 59, 59))
+
+
+@unittest.skipUnless(HAS_EPHEM, 'pyephem not installed')
+class TestSkytimeSolsticeGuard(unittest.TestCase):
+    """Regression guard for a forum-reported bug: a sun-bound trigger like
+    'sunset+35m', re-triggered day after day across the summer solstice, was
+    reported to occasionally skip forward by several weeks instead of firing
+    the next evening (smarthome v1.9.5). This was NOT reproducible against
+    current develop with real pyephem (verified empirically: every gap across
+    2024-06-01..2024-07-30 at Berlin coordinates came out to a clean ~24h).
+    This test locks in that correct behaviour so a future change (e.g. the
+    planned ephem->skyfield port) can't silently reintroduce the jump."""
+
+    MAX_PLAUSIBLE_GAP = datetime.timedelta(hours=30)
+
+    def setUp(self):
+        self.shtime, self.sun = _make_sky_env()
+
+    def test_sunset_plus_offset_advances_by_about_one_day_across_solstice(self):
+        sky = Skytime('sunset+35m')
+        starttime = datetime.datetime(2024, 6, 1, 12, 0, 0, tzinfo=self.shtime.tzinfo())
+        end = datetime.datetime(2024, 7, 30, tzinfo=self.shtime.tzinfo())
+        prev = None
+        while starttime < end:
+            nxt = sky.get_next(starttime)
+            if prev is not None:
+                gap = nxt - prev
+                self.assertLessEqual(
+                    gap, self.MAX_PLAUSIBLE_GAP, f'gap from {prev} to {nxt} is {gap}, expected roughly 24h'
+                )
+            prev = nxt
+            starttime = nxt + datetime.timedelta(microseconds=1)
 
 
 if __name__ == '__main__':

--- a/tools/fetch_skyfield_data.py
+++ b/tools/fetch_skyfield_data.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
+#########################################################################
+#  This file is part of SmartHomeNG
+#
+#  SmartHomeNG is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SmartHomeNG is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SmartHomeNG  If not, see <http://www.gnu.org/licenses/>.
+#########################################################################
+
+"""
+Ensures the skyfield ephemeris file (de421.bsp, ~17MB) used by the optional
+skyfield backend of lib.orb is present on disk, downloading it once if
+missing.
+
+This is the only network access the skyfield backend ever requires: de421.bsp
+covers 1899-07-28 through 2053-10-08 and never needs re-fetching within that
+range. Run this once before switching lib.orb to the skyfield backend (set
+``orb_backend: skyfield`` in etc/smarthome.yaml) so SmartHomeNG's normal
+runtime never needs network access for it - matches the existing
+skyfield.api.Loader behaviour of skipping the download entirely if the file
+already exists at the target path, so re-running this script is always safe
+and a no-op once the file is in place.
+
+Not run automatically at startup/install time: doing so unconditionally would
+download 17MB for every installation regardless of which backend is actually
+configured (orb_backend defaults to 'ephem'), reintroducing exactly the kind
+of required network access this is meant to avoid for everyone who hasn't
+opted into skyfield.
+
+Usage:
+    tools/fetch_skyfield_data.py
+"""
+
+import os
+import sys
+
+sh_basedir = os.sep.join(os.path.realpath(__file__).split(os.sep)[:-2])
+sys.path.insert(0, sh_basedir)
+
+try:
+    from lib.orb import _BACKENDS, _SkyfieldBackend
+except ImportError as e:
+    print("Could not import lib.orb - is SmartHomeNG's venv active? ({})".format(e))
+    sys.exit(1)
+
+if 'skyfield' not in _BACKENDS:
+    print("lib.orb's skyfield backend is not available (skyfield not installed).")
+    print("Run 'pip install -r requirements/base.txt' first, then re-run this script.")
+    sys.exit(1)
+
+data_dir = _SkyfieldBackend._data_dir()
+target = os.path.join(data_dir, 'de421.bsp')
+
+if os.path.exists(target):
+    print(f'Skyfield ephemeris data already present at {target} - nothing to do.')
+    sys.exit(0)
+
+print(f'Fetching skyfield ephemeris data (de421.bsp, ~17MB) to {data_dir} ...', flush=True)
+print('This is a one-time download - the file is valid through 2053 and will not be re-fetched.', flush=True)
+
+try:
+    _SkyfieldBackend._ensure_loaded()
+except Exception as e:
+    print(f'ERROR: could not download skyfield ephemeris data: {e}')
+    sys.exit(1)
+
+print(f'Done. Skyfield ephemeris data is now cached at {target}.')

--- a/tools/fetch_skyfield_data.py
+++ b/tools/fetch_skyfield_data.py
@@ -18,34 +18,49 @@
 #########################################################################
 
 """
-Ensures the skyfield ephemeris file (de421.bsp, ~17MB) used by the optional
-skyfield backend of lib.orb is present on disk, downloading it once if
-missing.
+Single entry point for opting into lib.orb's skyfield backend:
+  1) installs the skyfield package itself (pip), if not already present
+  2) downloads the skyfield ephemeris file (de421.bsp, ~17MB) it needs, if
+     not already present
 
-This is the only network access the skyfield backend ever requires: de421.bsp
-covers 1899-07-28 through 2053-10-08 and never needs re-fetching within that
-range. Run this once before switching lib.orb to the skyfield backend (set
-``orb_backend: skyfield`` in etc/smarthome.yaml) so SmartHomeNG's normal
-runtime never needs network access for it - matches the existing
-skyfield.api.Loader behaviour of skipping the download entirely if the file
-already exists at the target path, so re-running this script is always safe
-and a no-op once the file is in place.
+skyfield is deliberately NOT in lib/requirements.txt - shpypi's core-requirements
+check (run by bin/smarthome.py on every startup) runs before smarthome.yaml is
+even parsed, so it can't know whether orb_backend is actually set to
+'skyfield', and would otherwise install skyfield's dependencies (numpy, sgp4,
+jplephem) for every installation regardless of whether it's ever used. Run
+this script once instead, then set ``orb_backend: skyfield`` in
+etc/smarthome.yaml.
 
-Not run automatically at startup/install time: doing so unconditionally would
-download 17MB for every installation regardless of which backend is actually
-configured (orb_backend defaults to 'ephem'), reintroducing exactly the kind
-of required network access this is meant to avoid for everyone who hasn't
-opted into skyfield.
+The ephemeris file is the only network access the skyfield backend ever
+requires: de421.bsp covers 1899-07-28 through 2053-10-08 and never needs
+re-fetching within that range. Re-running this script is always safe and a
+no-op once both the package and the file are in place (skyfield.api.Loader
+skips its own download if the file already exists at the target path).
 
 Usage:
     tools/fetch_skyfield_data.py
 """
 
 import os
+import subprocess
 import sys
 
 sh_basedir = os.sep.join(os.path.realpath(__file__).split(os.sep)[:-2])
 sys.path.insert(0, sh_basedir)
+
+# Keep this in sync with tests/requirements.txt's skyfield line.
+SKYFIELD_REQUIREMENT = 'skyfield>=1.49,<2.0.0'
+
+try:
+    import skyfield  # noqa: F401
+except ImportError:
+    print(f"skyfield is not installed. Installing it now ('pip install {SKYFIELD_REQUIREMENT}')...", flush=True)
+    try:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', SKYFIELD_REQUIREMENT])
+    except subprocess.CalledProcessError as e:
+        print(f'ERROR: pip install failed: {e}')
+        print(f"Install it manually, then re-run this script: pip install '{SKYFIELD_REQUIREMENT}'")
+        sys.exit(1)
 
 try:
     from lib.orb import _BACKENDS, _SkyfieldBackend
@@ -54,8 +69,7 @@ except ImportError as e:
     sys.exit(1)
 
 if 'skyfield' not in _BACKENDS:
-    print("lib.orb's skyfield backend is not available (skyfield not installed).")
-    print("Run 'pip install -r requirements/base.txt' first, then re-run this script.")
+    print("lib.orb's skyfield backend is still not available after installing skyfield - see the error above.")
     sys.exit(1)
 
 data_dir = _SkyfieldBackend._data_dir()
@@ -75,3 +89,4 @@ except Exception as e:
     sys.exit(1)
 
 print(f'Done. Skyfield ephemeris data is now cached at {target}.')
+print("You can now set 'orb_backend: skyfield' in etc/smarthome.yaml.")

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -125,10 +125,12 @@ if [ -z "\$STAGED" ]; then
     exit 0
 fi
 
-echo "\$STAGED" | xargs "\$RUFF" format --quiet
+# --force-exclude: ruff's [tool.ruff] exclude only applies during directory
+# discovery, not to explicit file paths (which is what xargs passes here).
+echo "\$STAGED" | xargs "\$RUFF" format --force-exclude --quiet && echo 'Formatted.'
 echo "\$STAGED" | xargs git add
 
-if ! echo "\$STAGED" | xargs "\$RUFF" check; then
+if ! echo "\$STAGED" | xargs "\$RUFF" check --force-exclude; then
     echo ""
     echo "==> COMMIT REJECTED: ruff found lint errors in staged files."
     echo ""


### PR DESCRIPTION
lib.org uses pyephem as calculation backend. pyephem consists of a C core which can be challenging to install on some platforms. In addition, pyephem works by mathematically approximating the times, which can be instable and incorrect for a time window of ca. +- 15 minutes.

For this reason, this PR builds on top of CaeruleusAqua/smarthome_skyfield and extends the idea of using skyfield instead of ephem. Actually, the package to use can be choosen.

lib.orb gets the relevant methods refactored to a backend class. The available backend classes are:

- ephem
- skyfield
- skyfield-cached

ephem and skyfield calculate values on every call. The cached version of skyfield retrieves all relevant values for the requested date plus a window of 365 days (this also builds on top of CaeruleusAqua's ideas). As long as subsequent requests fall into the cached window, no new calculations are necessary. For regular and repeated requests this is a massive speedup.

Using vanilla skyfield is not recommended due to the relatively high overhead for each single call.

This PR includes the fixes from #801 as necessary prerequisites.

To use skyfield and to avoid installing it by default, the `tools/fetch_skyfield_data.py` must be run once after installation. It installs the skyfield package and retrieves the 17MB data package needed for calculations.